### PR TITLE
US952: Update build to use gulp & webpack instead of npm & webpack

### DIFF
--- a/crossroads.net/README.md
+++ b/crossroads.net/README.md
@@ -3,7 +3,17 @@
 The client facing website for crossroads church. 
 
 ###Getting Started 
-The only thing you'll need to get started is NodeJS. Head over to [http://nodejs.org/](http://nodejs.org) and install based on your operating system. We use npm scripts to run webpack so there are no node modules to install globally. Once you pull down the code, just run `npm i` to install all dependencies locally. 
+The first thing you'll need to get started is NodeJS. Head over to [http://nodejs.org/](http://nodejs.org) and install based on your operating system. Once you pull down the code, just run `npm i` to install all dependencies locally.
+
+We use gulp scripts to build and run webpack so you will also need to install gulp globally.  This is not required, but makes command-line tasks easier later on.  To install gulp globally, use one of the following commands.  Both will install gulp into the NodeJS path, which is presumably already on your OS's execution PATH.
+
+For Windows users (replace the prefix value below with the path to your NodeJS install):
+``` npm set prefix "C:\Program Files\nodejs" ```
+``` npm install -g gulp ```
+
+Mac and Linux (replace the prefix value below with the path to your NodeJS install):
+``` npm set prefix /usr/local/nodejs ```
+``` npm install -g gulp ```
 
 ###Configuration
 By default webpack inserts `http://localhost:49380` everywhere it finds `__API_ENDPOINT__` in the javascript. This can be changed by creating and setting an environment variable called **CRDS_API_ENDPOINT**. 
@@ -14,13 +24,13 @@ For windows users:
 Mac and Linux:
 ``` export CRDS_API_ENDPOINT = http://path-to-api-host/ ```
 
->Keep in mind that this way of setting environment variables will not be persistent, windows users will have to add this variable in system settings and linux/mac users will have to set it in thier .bashrc/.zshrc files for persistence. 
+>Keep in mind that this way of setting environment variables will not be persistent, windows users will have to add this variable in system settings and linux/mac users will have to set it in their .bashrc/.zshrc files for persistence. 
 
 ###Build
-To just build the project, run `npm run build`
+To just build the project, run `gulp build-dev` for a dev build, or `gulp build` for production.
 
 ###Run
-To run the project, run `npm start` and point your browser to `http://localhost:8080`. If you want live reload, use `http://localhost:8080/webpack-dev-server` but keep in mind that the anglar inspector will not work correctly and routes will not show up correctly with live reload. 
+To run the project, run `gulp start` and point your browser to `http://localhost:8080`. If you want live reload, use `http://localhost:8080/webpack-dev-server` but keep in mind that the angular inspector will not work correctly and routes will not show up correctly with live reload. 
 
 ##Mac OS with Gateway code running under VirtualBox Windows Guest
 Follow these instructions in order to setup the application to call Gateway services that are hosted on IIS Express on a Windows VM running under VirtualBox on a Mac.

--- a/crossroads.net/gulpfile.js
+++ b/crossroads.net/gulpfile.js
@@ -1,0 +1,94 @@
+var gulp = require("gulp");
+var watch = require("gulp-watch");
+var gutil = require("gulp-util");
+var webpack = require("webpack");
+var gulpWebpack = require("gulp-webpack");
+var WebpackDevServer = require("webpack-dev-server");
+var webpackConfig = require("./webpack.config.js");
+
+// Start the development server
+gulp.task("default", ["webpack-dev-server"]);
+
+// Build and watch cycle (another option for development)
+// Advantage: No server required, can run app from filesystem
+// Disadvantage: Requests are not blocked until bundle is available,
+//               can serve an old app on refresh
+gulp.task("build-dev", ["webpack:build-dev"], function() {
+	gulp.watch(["app/**/*"], ["webpack:build-dev"]);
+});
+
+// Production build
+gulp.task("build", ["webpack:build"]);
+
+// For convenience, an "alias" to webpack-dev-server
+gulp.task("start", ["webpack-dev-server"]);
+
+// Run the development server
+gulp.task("webpack-dev-server", function(callback) {
+	// modify some webpack config options
+	var myConfig = Object.create(webpackConfig);
+	myConfig.devtool = "eval";
+	myConfig.debug = true;
+	myConfig.output.path = "/";
+
+	// Build app to assets - watch for changes
+	gulp.src("app/**/**")
+		.pipe(watch("app/**/**"))
+		.pipe(gulpWebpack(myConfig))
+		.pipe(gulp.dest("./assets"));
+
+	new WebpackDevServer(webpack(myConfig), {
+			publicPath: "/assets/",
+			quiet: false,
+			watchDelay: 300,
+			stats: {
+				colors: true
+			}
+			}).listen(8080, "localhost", function(err) {
+				if(err) throw new gutil.PluginError("webpack-dev-server", err);
+				gutil.log("[start]", "http://localhost:8080/webpack-dev-server/index.html");
+			});
+			
+	gutil.log("[start]", "Access crossroads.net at http://localhost:8080/#");
+	gutil.log("[start]", "Access crossroads.net Live Reload at http://localhost:8080/webpack-dev-server/#");
+});
+
+gulp.task("webpack:build", function(callback) {
+	// modify some webpack config options
+	var myConfig = Object.create(webpackConfig);
+	myConfig.plugins = myConfig.plugins.concat(
+		new webpack.DefinePlugin({
+			"process.env": {
+				// This has effect on the react lib size
+				"NODE_ENV": JSON.stringify("production")
+			}
+		}),
+		new webpack.optimize.DedupePlugin(),
+		new webpack.optimize.UglifyJsPlugin()
+	);
+
+	// run webpack
+	webpack(myConfig, function(err, stats) {
+		if(err) throw new gutil.PluginError("webpack:build", err);
+		gutil.log("[webpack:build]", stats.toString({
+			colors: true
+		}));
+		callback();
+	});
+});
+
+gulp.task("webpack:build-dev", function(callback) {
+	// modify some webpack config options
+	var myDevConfig = Object.create(webpackConfig);
+	myDevConfig.devtool = "sourcemap";
+	myDevConfig.debug = true;
+
+	// run webpack
+	webpack(myDevConfig).run(function(err, stats) {
+		if(err) throw new gutil.PluginError("webpack:build-dev", err);
+		gutil.log("[webpack:build-dev]", stats.toString({
+			colors: true
+		}));
+		callback();
+	});
+});

--- a/crossroads.net/package.json
+++ b/crossroads.net/package.json
@@ -4,8 +4,8 @@
   "description": "Crossroads Church Web Presence",
   "main": "app.js",
   "scripts": {
-    "build": "webpack --progress --colors",
-    "start": "webpack -d --progress --colors --watch | webpack-dev-server --progress --colors",
+    "build": "echo \"Deprecated: please use 'gulp build' or 'gulp build-dev'.\" && exit 1",
+    "start": "echo \"Deprecated: please use 'gulp start'.\" && exit 1",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -24,12 +24,16 @@
     "css-loader": "^0.9.1",
     "extract-text-webpack-plugin": "^0.3.8",
     "file-loader": "^0.8.1",
+    "gulp": "^3.8.11",
+    "gulp-util": "^3.0.4",
+    "gulp-watch": "^4.1.1",
+    "gulp-webpack": "^1.2.0",
     "image-webpack-loader": "^1.2.0",
     "imagemin": "^3.1.0",
     "sass-loader": "^0.4.0-beta.1",
     "style-loader": "^0.8.3",
     "url-loader": "^0.5.5",
-    "webpack": "^1.5.3",
+    "webpack": "^1.6.0",
     "webpack-dev-server": "^1.7.0"
   },
   "dependencies": {


### PR DESCRIPTION
* Add new script file for gulp, providing build and dev server tasks
* Update package.json with new dependencies, and deprecate old scripts
* Update README with new instructions for running with gulp