### PR TITLE
US1073: Set quickAdd to true when adding group & event participant sub-page records

### DIFF
--- a/Gateway/MinistryPlatform.Translation.Test/Services/EventServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/EventServiceTest.cs
@@ -43,7 +43,7 @@ namespace MinistryPlatform.Translation.Test.Services
             int eventParticipantId = fixture.registerParticipantForEvent(123, 456);
 
             ministryPlatformService.Verify(mocked => mocked.CreateSubRecord(
-                EventParticipantPageId, 456, expectedValues, It.IsAny<string>(), false));
+                EventParticipantPageId, 456, expectedValues, It.IsAny<string>(), true));
 
             Assert.AreEqual(987, eventParticipantId);
         }

--- a/Gateway/MinistryPlatform.Translation.Test/Services/GroupServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/GroupServiceTest.cs
@@ -45,7 +45,7 @@ namespace MinistryPlatform.Translation.Test.Services
 
             ministryPlatformService.Setup(mocked => mocked.CreateSubRecord(
                 It.IsAny<int>(), It.IsAny<int>(), It.IsAny<Dictionary<string, object>>(),
-                It.IsAny<string>(), It.IsAny<Boolean>())).Returns(987);
+                It.IsAny<string>(), true)).Returns(987);
 
             DateTime startDate = DateTime.Now;
             DateTime endDate = startDate.AddDays(1);
@@ -62,7 +62,7 @@ namespace MinistryPlatform.Translation.Test.Services
             int groupParticipantId = fixture.addParticipantToGroup(123, 456, 789, startDate, endDate, true);
 
             ministryPlatformService.Verify(mocked => mocked.CreateSubRecord(
-                GroupsParticipantsPageId, 456, expectedValues, It.IsAny<string>(), false));
+                GroupsParticipantsPageId, 456, expectedValues, It.IsAny<string>(), true));
 
             Assert.AreEqual(987, groupParticipantId);
 
@@ -95,7 +95,7 @@ namespace MinistryPlatform.Translation.Test.Services
             }
             catch (GroupFullException e)
             {
-                ministryPlatformService.Verify(mocked => mocked.CreateSubRecord(1, 1, It.IsAny<Dictionary<string, object>>(), It.IsAny<string>(), false), Times.Never);
+                ministryPlatformService.Verify(mocked => mocked.CreateSubRecord(1, 1, It.IsAny<Dictionary<string, object>>(), It.IsAny<string>(), true), Times.Never);
                 Assert.NotNull(e.GroupDetails);
                 Assert.AreEqual(456, e.GroupDetails.RecordId);
                 Assert.AreEqual(1, e.GroupDetails.TargetSize);

--- a/Gateway/MinistryPlatform.Translation/Services/EventService.cs
+++ b/Gateway/MinistryPlatform.Translation/Services/EventService.cs
@@ -27,7 +27,7 @@ namespace MinistryPlatform.Translation.Services
 
             int eventParticipantId = WithApiLogin<int>(apiToken =>
             {
-                return (ministryPlatformService.CreateSubRecord(EventParticipantPageId, eventId, values, apiToken));
+                return (ministryPlatformService.CreateSubRecord(EventParticipantPageId, eventId, values, apiToken, true));
             });
 
             logger.Debug("Added participant " + participantId + " to event " + eventId + ": record id: " + eventParticipantId);

--- a/Gateway/MinistryPlatform.Translation/Services/GroupService.cs
+++ b/Gateway/MinistryPlatform.Translation/Services/GroupService.cs
@@ -47,7 +47,7 @@ namespace MinistryPlatform.Translation.Services
 
             int groupParticipantId = WithApiLogin<int>(apiToken =>
             {
-                return (ministryPlatformService.CreateSubRecord(GroupsParticipantsPageId, groupId, values, apiToken));
+                return (ministryPlatformService.CreateSubRecord(GroupsParticipantsPageId, groupId, values, apiToken, true));
             });
 
             // TODO Should we set Group_Is_Full flag here, or will that be done by a trigger?  Pending SPIKE: US1080
@@ -62,7 +62,7 @@ namespace MinistryPlatform.Translation.Services
             return (WithApiLogin<Group>(apiToken =>
             {
                 logger.Debug("Getting group details for group " + groupId);
-                var groupDetails = ministryPlatformService.GetRecordDict(GroupsPageId, groupId, apiToken);
+                var groupDetails = ministryPlatformService.GetRecordDict(GroupsPageId, groupId, apiToken, false);
                 if (groupDetails == null)
                 {
                     logger.Debug("No group found for group id " + groupId);
@@ -140,7 +140,7 @@ namespace MinistryPlatform.Translation.Services
                 object recordId = null;
                 if (e.TryGetValue("dp_RecordID", out recordId))
                 {
-                    var eventGroup = ministryPlatformService.GetRecordDict(EventsGroupsPageId, (int)recordId, apiToken);
+                    var eventGroup = ministryPlatformService.GetRecordDict(EventsGroupsPageId, (int)recordId, apiToken, false);
                     if (eventGroup == null)
                     {
                         continue;


### PR DESCRIPTION
This kicks off any process associated to the group and event, in this case, sending email to group participant after signing up