### PR TITLE
DE118 - Filter not applying if family is checked

### DIFF
--- a/crossroads.net/app/my_serve/refine/refineList.directive.js
+++ b/crossroads.net/app/my_serve/refine/refineList.directive.js
@@ -47,6 +47,7 @@
           getUniqueTimes();
           initCheckBoxes();
           scope.original = angular.copy(data);
+          applyFamilyFilter();
         }); 
       }
 


### PR DESCRIPTION
Had to call `applyFamilyFilter()` in the activate function