### PR TITLE
DE123: Update Contact Service to return nulls for optional nullable fields

### DIFF
--- a/Gateway/MinistryPlatform.Translation.Test/Services/ContactServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/ContactServiceTest.cs
@@ -66,5 +66,55 @@ namespace MinistryPlatform.Translation.Test.Services
             Assert.AreEqual(3, myProfile.Contact_ID);
             Assert.AreEqual(100, myProfile.Address_ID);
         }
+
+        [Test]
+        public void GetMyProfileWithOptionalNullableFields()
+        {
+            var dictionaryList = new List<Dictionary<string, object>>
+            {
+                new Dictionary<string, object>
+                {
+                    {"Address_ID", null},
+                    {"Address_Line_1", "address-line-1"},
+                    {"Address_Line_2", "address-line-2"},
+                    {"Congregation_ID", null},
+                    {"Household_ID", 4},
+                    {"City", "Cincinnati"},
+                    {"State", "OH"},
+                    {"Postal_Code", "45208"},
+                    {"Anniversary_Date", new DateTime(2013, 8, 5)},
+                    {"Contact_ID", 3},
+                    {"Date_of_Birth", new DateTime(2007, 5, 29)},
+                    {"Email_Address", "email-address@email.com"},
+                    {"Employer_Name", "Crossroads"},
+                    {"First_Name", "first-name"},
+                    {"Foreign_Country", "USA"},
+                    {"Gender_ID", null},
+                    {"Home_Phone", "513-555-1234"},
+                    {"Last_Name", "last-name"},
+                    {"Maiden_Name", "maiden-name"},
+                    {"Marital_Status_ID", null},
+                    {"Middle_Name", "middle-name"},
+                    {"Mobile_Carrier_ID", null},
+                    {"Mobile_Phone", "513-555-9876"},
+                    {"Nickname", "nickname"}
+                }
+            };
+
+            _ministryPlatformService.Setup(m => m.GetRecordsDict("MyProfile", It.IsAny<string>(), "", ""))
+                .Returns(dictionaryList);
+
+            var myProfile = _fixture.GetMyProfile(It.IsAny<string>());
+
+            _ministryPlatformService.VerifyAll();
+
+            Assert.IsNotNull(myProfile);
+            Assert.IsNull(myProfile.Address_ID);
+            Assert.IsNull(myProfile.Congregation_ID);
+            Assert.IsNull(myProfile.Gender_ID);
+            Assert.IsNull(myProfile.Marital_Status_ID);
+            Assert.IsNull(myProfile.Mobile_Carrier);
+        }
+
     }
 }

--- a/Gateway/MinistryPlatform.Translation/Services/ContactService.cs
+++ b/Gateway/MinistryPlatform.Translation/Services/ContactService.cs
@@ -43,11 +43,11 @@ namespace MinistryPlatform.Translation.Services
             contact.Employer_Name = myContact.ToString("Employer_Name");
             contact.First_Name = myContact.ToString("First_Name");
             contact.Foreign_Country = myContact.ToString("Foreign_Country");
-            contact.Gender_ID = myContact.ToInt("Gender_ID");
+            contact.Gender_ID = myContact.ToNullableInt("Gender_ID");
             contact.Home_Phone = myContact.ToString("Home_Phone");
             contact.Last_Name = myContact.ToString("Last_Name");
             contact.Maiden_Name = myContact.ToString("Maiden_Name");
-            contact.Marital_Status_ID = myContact.ToInt("Marital_Status_ID");
+            contact.Marital_Status_ID = myContact.ToNullableInt("Marital_Status_ID");
             contact.Middle_Name = myContact.ToString("Middle_Name");
             contact.Mobile_Carrier = myContact.ToNullableInt("Mobile_Carrier_ID");
             contact.Mobile_Phone = myContact.ToString("Mobile_Phone");


### PR DESCRIPTION
Gender_ID and Marital_Status_ID are optional integer profile fields, but they were being returned as 0 instead of null when they were not set in the db.  This was causing issues when saving the profile, if those fields were not changed on the frontend.