### PR TITLE
US1313: Implement an optionally authorized wrapper for gateway controllers to use

### DIFF
--- a/Gateway/crds-angular.test/Security/MPAuthTest.cs
+++ b/Gateway/crds-angular.test/Security/MPAuthTest.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Moq;
+using crds_angular.Security;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Web.Http.Controllers;
+using System.Web.Http;
+using System.Web.Http.Results;
+
+
+namespace crds_angular.test.Security
+{
+    class MPAuthTest
+    {
+        private MPAuthTester fixture;
+
+        private Mock<Func<string, IHttpActionResult>> actionWhenAuthorized;
+        private Mock<Func<IHttpActionResult>> actionWhenNotAuthorized;
+        private OkResult okResult;
+
+        private string authType;
+        private string authToken;
+
+        [SetUp]
+        public void SetUp()
+        {
+            fixture = new MPAuthTester();
+
+            actionWhenAuthorized = new Mock<Func<string, IHttpActionResult>>(MockBehavior.Strict);
+            actionWhenNotAuthorized = new Mock<Func<IHttpActionResult>>(MockBehavior.Strict);
+            okResult = new OkResult(fixture);
+
+            authType = "auth_type";
+            authToken = "auth_token";
+            fixture.Request = new HttpRequestMessage();
+            fixture.Request.Headers.Authorization = new AuthenticationHeaderValue(authType, authToken);
+            fixture.RequestContext = new HttpRequestContext();
+        }
+
+        [Test]
+        public void testAuthorizedNotAuthorized()
+        {
+            fixture.Request = new HttpRequestMessage();
+            fixture.Request.Headers.Authorization = null;
+
+            var result = fixture.AuthTest(actionWhenAuthorized.Object);
+            actionWhenAuthorized.VerifyAll();
+
+            Assert.NotNull(result);
+            Assert.IsInstanceOf(typeof(UnauthorizedResult), result);
+        }
+
+        [Test]
+        public void testAuthorizedWhenAuthorized()
+        {
+            actionWhenAuthorized.Setup(mocked => mocked(authType + " " + authToken)).Returns(okResult);
+            var result = fixture.AuthTest(actionWhenAuthorized.Object);
+            actionWhenAuthorized.VerifyAll();
+
+            Assert.NotNull(result);
+            Assert.IsInstanceOf(typeof(OkResult), result);
+            Assert.AreSame(okResult, result);
+        }
+
+        [Test]
+        public void testOptionalAuthorizedNotAuthorized()
+        {
+            fixture.Request = new HttpRequestMessage();
+            fixture.Request.Headers.Authorization = null;
+
+            actionWhenNotAuthorized.Setup(mocked => mocked()).Returns(okResult);
+
+            var result = fixture.AuthTest(actionWhenAuthorized.Object, actionWhenNotAuthorized.Object);
+            actionWhenNotAuthorized.VerifyAll();
+            actionWhenAuthorized.VerifyAll();
+
+            Assert.NotNull(result);
+            Assert.IsInstanceOf(typeof(OkResult), result);
+            Assert.AreSame(okResult, result);
+        }
+
+        [Test]
+        public void testOptionalAuthorizedWhenAuthorized()
+        {
+            actionWhenAuthorized.Setup(mocked => mocked(authType + " " + authToken)).Returns(okResult);
+            var result = fixture.AuthTest(actionWhenAuthorized.Object, actionWhenNotAuthorized.Object);
+            actionWhenAuthorized.VerifyAll();
+            actionWhenNotAuthorized.VerifyAll();
+
+            Assert.NotNull(result);
+            Assert.IsInstanceOf(typeof(OkResult), result);
+            Assert.AreSame(okResult, result);
+        }
+
+        private class MPAuthTester : MPAuth
+        {
+            public IHttpActionResult AuthTest(Func<string, IHttpActionResult> doIt)
+            {
+                return(base.Authorized(doIt));
+            }
+
+            public IHttpActionResult AuthTest(Func<string, IHttpActionResult> actionWhenAuthorized, Func<IHttpActionResult> actionWhenNotAuthorized)
+            {
+                return (base.Authorized(actionWhenAuthorized, actionWhenNotAuthorized));
+            }
+        }
+    }
+}

--- a/Gateway/crds-angular.test/crds-angular.test.csproj
+++ b/Gateway/crds-angular.test/crds-angular.test.csproj
@@ -154,6 +154,7 @@
     <Compile Include="controllers\ProgramControllerTest.cs" />
     <Compile Include="Models\Person.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Security\MPAuthTest.cs" />
     <Compile Include="Services\AccountServiceTest.cs" />
     <Compile Include="Services\PersonServiceTest.cs" />
     <Compile Include="Services\ServeServiceTest.cs" />

--- a/Gateway/crds-angular/Security/MPAuth.cs
+++ b/Gateway/crds-angular/Security/MPAuth.cs
@@ -19,6 +19,13 @@ namespace crds_angular.Security
     {
         protected readonly log4net.ILog logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
+        /// <summary>
+        /// Ensure that a user is authenticated before executing the given labmda expression.  The expression will
+        /// have a reference to the user's authentication token (the value of the "Authorization" cookie).  If
+        /// the user is not authenticated, an UnauthorizedResult will be returned.
+        /// </summary>
+        /// <param name="doIt">A labmda expression to execute if the user is authenticated</param>
+        /// <returns>An IHttpActionResult from the "doIt" expression, or UnauthorizedResult if the user is not authenticated.</returns>
         protected IHttpActionResult Authorized(Func<string,IHttpActionResult> doIt )
         {
             try
@@ -37,6 +44,33 @@ namespace crds_angular.Security
             }
         }
 
+        /// <summary>
+        /// Execute the labmda expression "actionWhenAuthorized" if the user is authenticated, or execute the expression
+        /// "actionWhenNotAuthorized" if the user is not authenticated.  If authenticated, the "actionWhenAuthorized"
+        /// expression will have a reference to the user's authentication token (the value of the "Authorization" cookie).
+        /// </summary>
+        /// <param name="actionWhenAuthorized">A labmda expression to execute if the user is authenticated</param>
+        /// <param name="actionWhenNotAuthorized">A labmda expression to execute if the user is NOT authenticated</param>
+        /// <returns>An IHttpActionResult from the labmda expression that was executed.</returns>
+        protected IHttpActionResult Authorized(Func<string, IHttpActionResult> actionWhenAuthorized, Func<IHttpActionResult> actionWhenNotAuthorized)
+        {
+            try
+            {
+                var authorized = Request.Headers.GetValues("Authorization").FirstOrDefault();
+                if (authorized != null && (authorized != "null" || authorized != ""))
+                {
+                    return actionWhenAuthorized(authorized);
+                }
+                else
+                {
+                    return actionWhenNotAuthorized();
+                }
+            }
+            catch (System.InvalidOperationException)
+            {
+                return actionWhenNotAuthorized();
+            }
+        }
 
         //protected IHttpActionResult AuthorizedWithCookie(Func<CookieInfo, IHttpActionResult> doIt)
         //{

--- a/Gateway/crds-angular/Security/MPAuth.cs
+++ b/Gateway/crds-angular/Security/MPAuth.cs
@@ -20,38 +20,25 @@ namespace crds_angular.Security
         protected readonly log4net.ILog logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
         /// <summary>
-        /// Ensure that a user is authenticated before executing the given labmda expression.  The expression will
+        /// Ensure that a user is authenticated before executing the given lambda expression.  The expression will
         /// have a reference to the user's authentication token (the value of the "Authorization" cookie).  If
         /// the user is not authenticated, an UnauthorizedResult will be returned.
         /// </summary>
-        /// <param name="doIt">A labmda expression to execute if the user is authenticated</param>
+        /// <param name="doIt">A lambda expression to execute if the user is authenticated</param>
         /// <returns>An IHttpActionResult from the "doIt" expression, or UnauthorizedResult if the user is not authenticated.</returns>
         protected IHttpActionResult Authorized(Func<string,IHttpActionResult> doIt )
         {
-            try
-            {
-                var authorized = Request.Headers.GetValues("Authorization").FirstOrDefault();
-                //CookieHeaderValue cookie = Request.Headers.GetCookies("sessionId").FirstOrDefault();
-                if (authorized != null && (authorized != "null" || authorized != ""))
-                {
-                    return doIt(authorized);
-                }
-                return Unauthorized();
-            }
-            catch (System.InvalidOperationException)
-            {
-                return Unauthorized();
-            }
+            return (Authorized(doIt, () => { return (Unauthorized()); }));
         }
 
         /// <summary>
-        /// Execute the labmda expression "actionWhenAuthorized" if the user is authenticated, or execute the expression
+        /// Execute the lambda expression "actionWhenAuthorized" if the user is authenticated, or execute the expression
         /// "actionWhenNotAuthorized" if the user is not authenticated.  If authenticated, the "actionWhenAuthorized"
         /// expression will have a reference to the user's authentication token (the value of the "Authorization" cookie).
         /// </summary>
-        /// <param name="actionWhenAuthorized">A labmda expression to execute if the user is authenticated</param>
-        /// <param name="actionWhenNotAuthorized">A labmda expression to execute if the user is NOT authenticated</param>
-        /// <returns>An IHttpActionResult from the labmda expression that was executed.</returns>
+        /// <param name="actionWhenAuthorized">A lambda expression to execute if the user is authenticated</param>
+        /// <param name="actionWhenNotAuthorized">A lambda expression to execute if the user is NOT authenticated</param>
+        /// <returns>An IHttpActionResult from the lambda expression that was executed.</returns>
         protected IHttpActionResult Authorized(Func<string, IHttpActionResult> actionWhenAuthorized, Func<IHttpActionResult> actionWhenNotAuthorized)
         {
             try


### PR DESCRIPTION
Added a new Authorized wrapper that takes two lambda expressions - one to execute when the user is authenticated, one to execute when not authenticated.