### PR TITLE
DE180 submit filter dates on enter key

### DIFF
--- a/crossroads.net/app/my_serve/refine/refineList.html
+++ b/crossroads.net/app/my_serve/refine/refineList.html
@@ -14,7 +14,7 @@
   </div>
 
   <div collapse="isCollapsed">
-    <form name='filterdates'>
+    <form name='filterdates' ng-submit="readyFilterByDate()">
       <div class="push-half-bottom filter-group">
 
         <!-- From -->  
@@ -87,6 +87,7 @@
           </span> 
         </div>
         <!--/form-group-->
+        <input type="submit" style="display:none"> </input>
        </div>
        <!--/push-bottom-->
       </form>


### PR DESCRIPTION
Since the form does not have a submit button, I had to add a hidden
input type. The problem is that if you add an input of type 'submit',
you can't also create it hidden. To remedy this, I added the
`display:none` style to the input tag. I think the best solution in the
long run is to actually add a submit button for the user to press.