### PR TITLE
DE196 Fix 'TO' field not defaulting to last opp date

### DIFF
--- a/crossroads.net/app/my_serve/serveTeam.directive.js
+++ b/crossroads.net/app/my_serve/serveTeam.directive.js
@@ -265,8 +265,9 @@
             default:
               // every  or everyother
               scope.formErrors.frequency = false;
+              var roleId =  (scope.currentMember.serveRsvp.roleId === 0) ? scope.currentMember.roles[0].roleId : scope.currentMember.serveRsvp.roleId;
               ServeOpportunities.LastOpportunityDate.get({
-                id: scope.currentMember.serveRsvp.roleId
+                id: roleId
               }, function(ret) {
                 var dateNum = Number(ret.date * 1000);
                 var toDate = new Date(dateNum);


### PR DESCRIPTION
When a volunteer chooses 'NO' there roleId is set to 0, so we need to
send a valid roleId to the server when populating dates. If the roleId
is 0, get the first valid roleId in the list of roles