### PR TITLE
correcting validation on credit card and cvc

### DIFF
--- a/crossroads.net/app/give/directives/creditCardInfo.directive.js
+++ b/crossroads.net/app/give/directives/creditCardInfo.directive.js
@@ -115,7 +115,7 @@ require('../creditCardInfo.html');
               return(false);
             }
 
-            return (scope.bankinfoSubmitted && scope.creditCardForm.ccNumber.$pristine && ccValid || //cannot be blank on submit
+            return (scope.bankinfoSubmitted && scope.creditCardForm.ccNumber.$pristine && !ccValid || //cannot be blank on submit
                    !ccValid && scope.creditCardForm.ccNumber.$dirty);  //show error when not valid
          };
 
@@ -131,7 +131,7 @@ require('../creditCardInfo.html');
               return(false);
             }
 
-            return (scope.bankinfoSubmitted && scope.creditCardForm.cvc.$pristine || //cannot be blank on submit
+            return (scope.bankinfoSubmitted && scope.creditCardForm.cvc.$pristine && !ccValid || //cannot be blank on submit
                     !cvcValid && scope.bankinfoSubmitted ||
                     !cvcValid && scope.creditCardForm.cvc.$dirty);  //show error when not valid
         };


### PR DESCRIPTION
Altering validation for credit card and cvc.  Error state was being triggered after the change link was clicked when the credit card and cvc were valid.