### PR TITLE
resetting the amountsubmitted indicator when processing a change

### DIFF
--- a/crossroads.net/app/give/give_controller.js
+++ b/crossroads.net/app/give/give_controller.js
@@ -240,6 +240,7 @@
             vm.dto.donor.default_source.cvc = "";
           };
           vm.processingChange = true;
+          vm.amountSubmitted = false;
           $state.go("give.amount");
         };
 


### PR DESCRIPTION
Resetting the amountSubmitted indicator when processing a change. This alleviates the error state when the initiative field is clicked,