### PR TITLE
when a template error is received, log a message but do not throw the …

### DIFF
--- a/Gateway/MinistryPlatform.Translation/Services/DonorService.cs
+++ b/Gateway/MinistryPlatform.Translation/Services/DonorService.cs
@@ -126,8 +126,7 @@ namespace MinistryPlatform.Translation.Services
             }
             catch (Exception e)
             {
-                throw new ApplicationException(
-                    string.Format("Sending of Confirmation Email failed for Donation Id: {0}", donationId), e);
+                logger.Debug(string.Format("Failed when processing the template for Donation Id: {0}", donationId));
             }
 
             return donationDistributionId;

--- a/Gateway/MinistryPlatform.Translation/Services/DonorService.cs
+++ b/Gateway/MinistryPlatform.Translation/Services/DonorService.cs
@@ -126,7 +126,7 @@ namespace MinistryPlatform.Translation.Services
             }
             catch (Exception e)
             {
-                logger.Debug(string.Format("Failed when processing the template for Donation Id: {0}", donationId));
+                logger.Error(string.Format("Failed when processing the template for Donation Id: {0}", donationId));
             }
 
             return donationDistributionId;


### PR DESCRIPTION
…exception.  This allows for the proper user experience. 
If the exception is thrown, it appears to the user that the giving process failed.