### PR TITLE
DE356: Correcting issue where login gets removed in Chrome and Safari…

### DIFF
--- a/crossroads.net/app/routes.js
+++ b/crossroads.net/app/routes.js
@@ -496,6 +496,9 @@
             // Force browser to do a full reload to load corkboard's index.html
             $window.location.href = $location.path();
           }
+        },
+        data: {
+          preventRouteAuthentication: true
         }
       })
       .state('tools', {

--- a/crossroads.net/core/core.run.js
+++ b/crossroads.net/core/core.run.js
@@ -35,7 +35,11 @@
                     Session.addRedirectRoute('home', '');
                 }
                 return;
-            }
+           }
+	    
+           if (toState.data !== undefined && toState.data.preventRouteAuthentication) {
+             return;
+           }
            if (Session.isActive()) {
               $http({
                 method: 'GET',


### PR DESCRIPTION
… because the browser cancels the request to api/authenticated which causes clearAndRedirect to delete the cookies. This all happens because the corkboard route in crds-angular has to force the browser to load the page from the server.