### PR TITLE
DE447: Set view properly after retrieving donor

### DIFF
--- a/crossroads.net/app/common/giving/services/donation.service.js
+++ b/crossroads.net/app/common/giving/services/donation.service.js
@@ -242,9 +242,11 @@
           if (GiveTransferService.donor.default_source.credit_card.last4 != null){
             GiveTransferService.last4 = donor.default_source.credit_card.last4;
             GiveTransferService.brand = CC_BRAND_CODES[donor.default_source.credit_card.brand];
+            GiveTransferService.view = 'cc';
           } else {
             GiveTransferService.last4 = donor.default_source.bank_account.last4;
             GiveTransferService.brand = '#library';
+            GiveTransferService.view = 'bank';
           }
           $state.go(GiveFlow.confirm);
         },function(error){

--- a/crossroads.net/spec/give/give.controller.spec.js
+++ b/crossroads.net/spec/give/give.controller.spec.js
@@ -700,10 +700,44 @@ describe('GiveController', function() {
        controller.donationService.transitionForLoggedInUserBasedOnExistingDonor(mockEvent, mockToState);
        expect(controller.dto.last4).toBe('6699');
        expect(controller.dto.brand).toBe('#library');
+       expect(controller.dto.view).toBe('bank');
      });
-   });
 
-  describe('function goToChange', function() {
+  it('should set brand and last 4 correctly when payment type is cc', function(){
+    mockGetResponse = {
+      Processor_ID: "123456",
+      default_source :  {
+        credit_card : {
+          brand : 'Visa',
+          last4 : '4242'
+        },
+        bank_account: {
+          routing: null,
+          last4: null
+        }
+      }
+    };
+
+    var mockEvent = {
+      preventDefault : function(){}
+    };
+
+    var mockToState = {
+      name : 'give.account'
+    };
+    controller.dto.email= 'test@test.com';
+
+    mockSession.isActive.and.callFake(function(){
+      return true;
+    });
+    controller.donationService.transitionForLoggedInUserBasedOnExistingDonor(mockEvent, mockToState);
+    expect(controller.dto.last4).toBe('4242');
+    expect(controller.dto.brand).toBe('#cc_visa');
+    expect(controller.dto.view).toBe('cc');
+  });
+});
+
+describe('function goToChange', function() {
       
     beforeEach(function(){
       mockSession.isActive.and.callFake(function(){


### PR DESCRIPTION
In transitionForLoggedInUserBasedOnExistingDonor, when a donor is retrieved, set the GiveTransferService.view properly based on the default source on the donor.