### PR TITLE
DE465: Set donation_view_ready to true when no profile or donations are located

### DIFF
--- a/crossroads.net/app/giving_history/giving_history.controller.js
+++ b/crossroads.net/app/giving_history/giving_history.controller.js
@@ -55,6 +55,7 @@
 
         function(/*error*/) {
           vm.overall_view_ready = true;
+          vm.donation_view_ready = true;
           vm.donation_history = false;
           vm.soft_credit_donation_history = false;
         });
@@ -62,6 +63,7 @@
 
       function(/*error*/) {
         vm.overall_view_ready = true;
+        vm.donation_view_ready = true;
         vm.donation_history = false;
         vm.soft_credit_donation_history = false;
       });

--- a/crossroads.net/spec/giving_history/giving_history.controller.spec.js
+++ b/crossroads.net/spec/giving_history/giving_history.controller.spec.js
@@ -180,7 +180,7 @@ describe('GivingHistoryController', function() {
       expect(sut.beginning_donation_date).not.toBeDefined();
       expect(sut.ending_donation_date).not.toBeDefined();
       expect(sut.donation_history).toBeFalsy();
-      expect(sut.donation_view_ready).toBeFalsy();
+      expect(sut.donation_view_ready).toBeTruthy();
       expect(sut.soft_credit_donation_history).toBeFalsy();
       expect(sut.soft_credit_donation_view_ready).toBeFalsy();
       expect(sut.overall_view_ready).toBeTruthy();
@@ -201,7 +201,7 @@ describe('GivingHistoryController', function() {
       expect(sut.beginning_donation_date).not.toBeDefined();
       expect(sut.ending_donation_date).not.toBeDefined();
       expect(sut.donation_history).toBeFalsy();
-      expect(sut.donation_view_ready).toBeFalsy();
+      expect(sut.donation_view_ready).toBeTruthy();
       expect(sut.soft_credit_donation_history).toBeFalsy();
       expect(sut.soft_credit_donation_view_ready).toBeFalsy();
       expect(sut.overall_view_ready).toBeTruthy();


### PR DESCRIPTION
This flag drives the display of the "no giving history" section, as well as actual donations, so needs to be true even when there are no donations.  A separate flag (donation_history and soft_credit_donation_history) drives display of actual donations.