### PR TITLE
US2657-donation status added to view, notes removed

### DIFF
--- a/CI/US2657-DonationStatusNotNotes.sql
+++ b/CI/US2657-DonationStatusNotNotes.sql
@@ -1,0 +1,24 @@
+
+USE [MinistryPlatform]
+GO
+
+UPDATE [dbo].[dp_Pages]
+   SET [Default_Field_List] =
+    'Donations.Donation_Date
+	,Donor_ID_Table_Contact_ID_Table.Display_Name
+	,Donor_ID_Table_Contact_ID_Table.Nickname
+	,Donor_ID_Table_Contact_ID_Table.First_Name
+	,Donations.Donation_Amount
+	,Payment_Type_ID_Table.Payment_Type
+	,Item_Number
+	,Transaction_Code
+	,Subscription_Code
+	,Batch_ID_Table.Batch_ID
+	,Batch_ID_Table.Setup_Date
+	,Donations.Registered_Donor
+	,Processor_Fee_Amount
+	,Donor_ID_Table.Donor_ID
+	,Donation_Status_ID_Table.Donation_Status'
+
+ WHERE page_id = 297
+ GO


### PR DESCRIPTION
Note that all the page view listed in the AC use the default field list.  therefore, changing the default fields on the page successfully changes the fields for all those views.