### PR TITLE
Defect/de609 donation emails no workie

### DIFF
--- a/Gateway/MinistryPlatform.Translation.Test/Services/CommunicationServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/CommunicationServiceTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Crossroads.Utilities.Interfaces;
+using MinistryPlatform.Translation.Exceptions;
 using MinistryPlatform.Translation.Services;
 using MinistryPlatform.Translation.Services.Interfaces;
 using Moq;
@@ -69,13 +70,26 @@ namespace MinistryPlatform.Translation.Test.Services
             {
                 {"DavidsGame", "Global Thermonuclear War"},
                 {"WoprsGame", "Chess"},
-                {"WhenToPlayChess", null}
+                {"WhenToPlayChess", string.Empty}
             };
 
             var parsed = _fixture.ParseTemplateBody("David: Would you like to play a game of [DavidsGame]? / WOPR: Not right now, wouldn't you like to play a game of [WoprsGame] instead? / David: No, maybe some other time, [WhenToPlayChess]",
                                        mergeData);
 
             Assert.AreEqual("David: Would you like to play a game of Global Thermonuclear War? / WOPR: Not right now, wouldn't you like to play a game of Chess instead? / David: No, maybe some other time, ", parsed);
+        }
+
+        [Test]
+        [ExpectedException(typeof(TemplateParseException))]
+        public void TestParseTemplateBodyWithNullValueInMergeData()
+        {
+            var mergeData = new Dictionary<string, object>
+            {
+                {"Key1", "Value1"},
+                {"Key2", null}
+            };
+
+            _fixture.ParseTemplateBody("This is [Key1] and [Key2]", mergeData);
         }
     }
 }

--- a/Gateway/MinistryPlatform.Translation.Test/Services/CommunicationServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/CommunicationServiceTest.cs
@@ -61,5 +61,21 @@ namespace MinistryPlatform.Translation.Test.Services
             Assert.AreEqual(toContactId, communication.ToContactId);
             Assert.AreEqual(toEmailAddress, communication.ToEmailAddress);
         }
+
+        [Test]
+        public void TestParseTemplateBody()
+        {
+            var mergeData = new Dictionary<string, object>
+            {
+                {"DavidsGame", "Global Thermonuclear War"},
+                {"WoprsGame", "Chess"},
+                {"WhenToPlayChess", null}
+            };
+
+            var parsed = _fixture.ParseTemplateBody("David: Would you like to play a game of [DavidsGame]? / WOPR: Not right now, wouldn't you like to play a game of [WoprsGame] instead? / David: No, maybe some other time, [WhenToPlayChess]",
+                                       mergeData);
+
+            Assert.AreEqual("David: Would you like to play a game of Global Thermonuclear War? / WOPR: Not right now, wouldn't you like to play a game of Chess instead? / David: No, maybe some other time, ", parsed);
+        }
     }
 }

--- a/Gateway/MinistryPlatform.Translation.Test/Services/DonorServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/DonorServiceTest.cs
@@ -685,7 +685,6 @@ namespace MinistryPlatform.Translation.Test.Services
                     })},
                     {"Payment_Method", paymentType},
                     {"Decline_Reason", emailReason},
-                    {"Frequency", string.Empty}
                 }
             };
 
@@ -702,7 +701,7 @@ namespace MinistryPlatform.Translation.Test.Services
                                 c.MergeData["Donation_Date"].Equals(expectedCommunication.MergeData["Donation_Date"]) &&
                                 c.MergeData["Payment_Method"].Equals(expectedCommunication.MergeData["Payment_Method"]) &&
                                 c.MergeData["Decline_Reason"].Equals(expectedCommunication.MergeData["Decline_Reason"]) &&
-                                c.MergeData["Frequency"].Equals(expectedCommunication.MergeData["Frequency"])
+                                !c.MergeData.ContainsKey("Frequency")
                             )));
 
             _fixture.SendEmail(declineEmailTemplate, donorId, donationAmt, paymentType, donationDate, program,

--- a/Gateway/MinistryPlatform.Translation.Test/Services/DonorServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/DonorServiceTest.cs
@@ -627,6 +627,93 @@ namespace MinistryPlatform.Translation.Test.Services
         }
 
         [Test]
+        public void TestSendEmailNoFrequency()
+        {
+            const string program = "Crossroads";
+            const int declineEmailTemplate = 11940;
+            var donationDate = DateTime.Now;
+            const string emailReason = "rejected: lack of funds";
+            const int donorId = 9876;
+            const int donationAmt = 4343;
+            const string paymentType = "Bank";
+
+            var getTemplateResponse = new MessageTemplate()
+            {
+                Body = "Your payment was rejected.  Darn.",
+                Subject = "Test Decline Email"
+            };
+
+            const string emailAddress = "me@here.com";
+            const int contactId = 3;
+            var contactList = new List<Dictionary<string, object>>
+            {
+                new Dictionary<string, object>
+                {
+                    {"Donor_ID", 1},
+                    {"Processor_ID", 2},
+                    {"Contact_ID", contactId},
+                    {"Email", emailAddress},
+                    {"Statement_Type", "Family"},
+                    {"Statement_Type_ID", 2},
+                    {"Statement_Frequency", "Quarterly"},
+                    {"Statement_Method", "Online"},
+                    {"Household_ID", 4},
+                }
+            };
+
+            _ministryPlatformService.Setup(mocked => mocked.GetPageViewRecords("DonorByContactId", It.IsAny<string>(), It.IsAny<string>(), string.Empty, 0)).Returns(contactList);
+            var expectedCommunication = new Communication
+            {
+                AuthorUserId = 5,
+                DomainId = 1,
+                EmailBody = getTemplateResponse.Body,
+                EmailSubject = getTemplateResponse.Subject,
+                FromContactId = 5,
+                FromEmailAddress = "giving@crossroads.net",
+                ReplyContactId = 5,
+                ReplyToEmailAddress = "giving@crossroads.net",
+                ToContactId = contactId,
+                ToEmailAddress = emailAddress,
+                MergeData = new Dictionary<string, object>
+                {
+                    {"Program_Name", program},
+                    {"Donation_Amount", donationAmt.ToString("N2")},
+                    {"Donation_Date", donationDate.ToString("MM/dd/yyyy h:mmtt", new DateTimeFormatInfo
+                    {
+                        AMDesignator = "am",
+                        PMDesignator = "pm"
+                    })},
+                    {"Payment_Method", paymentType},
+                    {"Decline_Reason", emailReason},
+                    {"Frequency", string.Empty}
+                }
+            };
+
+            _communicationService.Setup(mocked => mocked.GetTemplate(declineEmailTemplate)).Returns(getTemplateResponse);
+            _communicationService.Setup(
+                mocked =>
+                    mocked.SendMessage(
+                        It.Is<Communication>(
+                            c =>
+                                c.EmailBody.Equals(expectedCommunication.EmailBody) && c.EmailSubject.Equals(expectedCommunication.EmailSubject) &&
+                                c.ToContactId == expectedCommunication.ToContactId && c.ToEmailAddress.Equals(expectedCommunication.ToEmailAddress) &&
+                                c.MergeData["Program_Name"].Equals(expectedCommunication.MergeData["Program_Name"]) &&
+                                c.MergeData["Donation_Amount"].Equals(expectedCommunication.MergeData["Donation_Amount"]) &&
+                                c.MergeData["Donation_Date"].Equals(expectedCommunication.MergeData["Donation_Date"]) &&
+                                c.MergeData["Payment_Method"].Equals(expectedCommunication.MergeData["Payment_Method"]) &&
+                                c.MergeData["Decline_Reason"].Equals(expectedCommunication.MergeData["Decline_Reason"]) &&
+                                c.MergeData["Frequency"].Equals(expectedCommunication.MergeData["Frequency"])
+                            )));
+
+            _fixture.SendEmail(declineEmailTemplate, donorId, donationAmt, paymentType, donationDate, program,
+                emailReason, null);
+
+            _ministryPlatformService.VerifyAll();
+            _communicationService.VerifyAll();
+
+        }
+
+        [Test]
         public void TestGetContactDonorForDonorAccount()
         {
             const int donorId = 1234567;

--- a/Gateway/MinistryPlatform.Translation/Services/CommunicationService.cs
+++ b/Gateway/MinistryPlatform.Translation/Services/CommunicationService.cs
@@ -167,11 +167,11 @@ namespace MinistryPlatform.Translation.Services
                     return templateBody;
                 }
                 return record.Aggregate(templateBody,
-                    (current, field) => current.Replace("[" + field.Key + "]", field.Value == null ? string.Empty : field.Value.ToString()));
+                    (current, field) => current.Replace("[" + field.Key + "]", field.Value.ToString()));
             }
             catch (Exception ex)
             {
-                _logger.Debug(string.Format("Failed to parse the template"));
+                _logger.Warn("Failed to parse the template", ex);
                 throw new TemplateParseException("Failed to parse the template", ex);
             }
         }

--- a/Gateway/MinistryPlatform.Translation/Services/CommunicationService.cs
+++ b/Gateway/MinistryPlatform.Translation/Services/CommunicationService.cs
@@ -167,7 +167,7 @@ namespace MinistryPlatform.Translation.Services
                     return templateBody;
                 }
                 return record.Aggregate(templateBody,
-                    (current, field) => current.Replace("[" + field.Key + "]", field.Value.ToString()));
+                    (current, field) => current.Replace("[" + field.Key + "]", field.Value == null ? string.Empty : field.Value.ToString()));
             }
             catch (Exception ex)
             {

--- a/Gateway/MinistryPlatform.Translation/Services/DonorService.cs
+++ b/Gateway/MinistryPlatform.Translation/Services/DonorService.cs
@@ -609,7 +609,7 @@ namespace MinistryPlatform.Translation.Services
                     {"Donation_Date", setupDate.ToString("MM/dd/yyyy h:mmtt", _dateTimeFormat)},
                     {"Payment_Method", paymentType},
                     {"Decline_Reason", emailReason},
-                    {"Frequency", frequency}
+                    {"Frequency", frequency ?? string.Empty}
                 }
             };
 

--- a/Gateway/MinistryPlatform.Translation/Services/DonorService.cs
+++ b/Gateway/MinistryPlatform.Translation/Services/DonorService.cs
@@ -608,11 +608,14 @@ namespace MinistryPlatform.Translation.Services
                     {"Donation_Amount", donationAmount.ToString("N2")},
                     {"Donation_Date", setupDate.ToString("MM/dd/yyyy h:mmtt", _dateTimeFormat)},
                     {"Payment_Method", paymentType},
-                    {"Decline_Reason", emailReason},
-                    {"Frequency", frequency ?? string.Empty}
+                    {"Decline_Reason", emailReason}
                 }
             };
 
+            if (!string.IsNullOrWhiteSpace(frequency))
+            {
+                comm.MergeData["Frequency"] = frequency;
+            }
 
             _communicationService.SendMessage(comm);
         }


### PR DESCRIPTION
* [DE609](https://rally1.rallydev.com/#/27593764268d/detail/defect/46127132491)
* We broke this a couple sprints ago when we did the Recurring Gift emails
* Don't send null value from DonorService to CommunicationService in merge data
* Put safeguard in CommunicationService to check for nulls before using merge data value