### PR TITLE
DE613: Make sure we don't exceed the MP limit for check number

### DIFF
--- a/Gateway/Crossroads.Utilities/Crossroads.Utilities.csproj
+++ b/Gateway/Crossroads.Utilities/Crossroads.Utilities.csproj
@@ -71,6 +71,7 @@
   <ItemGroup>
     <Compile Include="CrossroadsConstants.cs" />
     <Compile Include="Extensions\DateTimeExtensions.cs" />
+    <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Extensions\TimeSpanExtensions.cs" />
     <Compile Include="Interfaces\IConfigurationWrapper.cs" />
     <Compile Include="Interfaces\IContentBlockService.cs" />

--- a/Gateway/Crossroads.Utilities/Extensions/StringExtensions.cs
+++ b/Gateway/Crossroads.Utilities/Extensions/StringExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Crossroads.Utilities.Extensions
+{
+    public static class StringExtensions
+    {
+        public static string Left(this string str, int length)
+        {
+            str = str ?? string.Empty;
+            return str.Substring(0, Math.Min(length, str.Length));
+        }
+
+        public static string Right(this string str, int length)
+        {
+            str = str ?? string.Empty;
+            return str.Length >= length ? str.Substring(str.Length - length, length) : str;
+        }
+    }
+}

--- a/Gateway/crds-angular.test/Services/EzScanCheckScannerServiceTest.cs
+++ b/Gateway/crds-angular.test/Services/EzScanCheckScannerServiceTest.cs
@@ -7,7 +7,6 @@ using crds_angular.Services;
 using crds_angular.Services.Interfaces;
 using MinistryPlatform.Models;
 using Moq;
-using MvcContrib.TestHelper;
 using NUnit.Framework;
 using MPServices=MinistryPlatform.Translation.Services.Interfaces;
 
@@ -107,7 +106,7 @@ namespace crds_angular.test.Services
                     },
                     Amount = 1111,
                     CheckDate = DateTime.Now.AddHours(1),
-                    CheckNumber = "11111",
+                    CheckNumber = " 0 0 00000222111111111111111",
                     Name1 = "1 name 1",
                     Name2 = "1 name 2",
                     RoutingNumber = "1010",
@@ -192,7 +191,7 @@ namespace crds_angular.test.Services
                                                                  d.RegisteredDonor &&
                                                                  d.DonorAcctId == donorAcctId &&
                                                                  d.CheckScannerBatchName.Equals("batch123") &&
-                                                                 d.CheckNumber.Equals("11111"))))
+                                                                 d.CheckNumber.Equals("111111111111111"))))
                 .Returns(321);
 
             var contactDonorNew = new ContactDonor

--- a/Gateway/crds-angular/Services/EzScanCheckScannerService.cs
+++ b/Gateway/crds-angular/Services/EzScanCheckScannerService.cs
@@ -7,6 +7,7 @@ using crds_angular.Services.Interfaces;
 using log4net;
 using MinistryPlatform.Models;
 using MPServices = MinistryPlatform.Translation.Services.Interfaces;
+using Crossroads.Utilities.Extensions;
 
 namespace crds_angular.Services
 {
@@ -17,6 +18,8 @@ namespace crds_angular.Services
         private readonly ILog _logger = LogManager.GetLogger(typeof (EzScanCheckScannerService));
         private readonly MPServices.IDonorService _mpDonorService;
         private readonly IPaymentService _paymentService;
+
+        private const int MinistryPlatformCheckNumberMaxLength = 15;
       
         public EzScanCheckScannerService(ICheckScannerDao checkScannerDao, IDonorService donorService, IPaymentService paymentService, MPServices.IDonorService mpDonorService)
         {
@@ -97,7 +100,7 @@ namespace crds_angular.Services
                         RegisteredDonor = contactDonor.RegisteredUser,
                         DonorAcctId = donorAccountId,
                         CheckScannerBatchName = batchDetails.Name,
-                        CheckNumber = check.CheckNumber,
+                        CheckNumber = check.CheckNumber.TrimStart(' ', '0').Right(MinistryPlatformCheckNumberMaxLength)
                     };
 
                     var donationId = _mpDonorService.CreateDonationAndDistributionRecord(donationAndDistribution);
@@ -111,6 +114,8 @@ namespace crds_angular.Services
                 catch (Exception e)
                 {
                     check.Error = e.ToString();
+                    check.AccountNumber = _mpDonorService.DecryptCheckValue(check.AccountNumber);
+                    check.RoutingNumber = _mpDonorService.DecryptCheckValue(check.RoutingNumber);
                     batchDetails.ErrorChecks.Add(check);
                     _checkScannerDao.UpdateCheckStatus(check.Id, check.Exported, check.Error);
                 }

--- a/Gateway/crds-angular/Services/EzScanCheckScannerService.cs
+++ b/Gateway/crds-angular/Services/EzScanCheckScannerService.cs
@@ -100,7 +100,7 @@ namespace crds_angular.Services
                         RegisteredDonor = contactDonor.RegisteredUser,
                         DonorAcctId = donorAccountId,
                         CheckScannerBatchName = batchDetails.Name,
-                        CheckNumber = check.CheckNumber.TrimStart(' ', '0').Right(MinistryPlatformCheckNumberMaxLength)
+                        CheckNumber = (check.CheckNumber ?? string.Empty).TrimStart(' ', '0').Right(MinistryPlatformCheckNumberMaxLength)
                     };
 
                     var donationId = _mpDonorService.CreateDonationAndDistributionRecord(donationAndDistribution);


### PR DESCRIPTION
* [DE613](https://rally1.rallydev.com/#/27593764268d/detail/defect/46154900660)
* Changed check scanner service to strip off leading zeroes and spaces from check number, and then take the rightmost 15 digits of the check number if it still exceeds 15 (which would be a check number in the 999 trillion range...)