### PR TITLE
Defect/de434 check giving decimal fix

### DIFF
--- a/Gateway/MinistryPlatform.Models/DonationAndDistributionRecord.cs
+++ b/Gateway/MinistryPlatform.Models/DonationAndDistributionRecord.cs
@@ -4,7 +4,7 @@ namespace MinistryPlatform.Models
 {
     public class DonationAndDistributionRecord
     {
-        public int DonationAmt { get; set; }
+        public decimal DonationAmt { get; set; }
 
         public int? FeeAmt { get; set; }
 

--- a/Gateway/MinistryPlatform.Translation.Test/Services/DonorServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/DonorServiceTest.cs
@@ -151,7 +151,7 @@ namespace MinistryPlatform.Translation.Test.Services
         [Test]
         public void CreateDonationAndDistributionRecord()
         {
-            var donationAmt = 676767;
+            const decimal donationAmt = 676767;
             var feeAmt = 5656;
             var donorId = 1234567;
             var programId = "3";
@@ -278,7 +278,7 @@ namespace MinistryPlatform.Translation.Test.Services
         [Test]
         public void CreateDonationAndDistributionRecordWithPledge()
         {
-            var donationAmt = 676767;
+            const decimal donationAmt = 676767;
             var feeAmt = 5656;
             var donorId = 1234567;
             var programId = "3";

--- a/Gateway/MinistryPlatform.Translation/Services/DonorService.cs
+++ b/Gateway/MinistryPlatform.Translation/Services/DonorService.cs
@@ -540,7 +540,7 @@ namespace MinistryPlatform.Translation.Services
             }
         }
 
-        public void SetupConfirmationEmail(int programId, int donorId, int donationAmount, DateTime setupDate, string pymtType)
+        public void SetupConfirmationEmail(int programId, int donorId, decimal donationAmount, DateTime setupDate, string pymtType)
         {
             var program = _programService.GetProgramById(programId);
             //If the communcations admin does not link a message to the program, the default template will be used.

--- a/Gateway/MinistryPlatform.Translation/Services/Interfaces/IDonorService.cs
+++ b/Gateway/MinistryPlatform.Translation/Services/Interfaces/IDonorService.cs
@@ -19,7 +19,7 @@ namespace MinistryPlatform.Translation.Services.Interfaces
         ContactDonor GetPossibleGuestContactDonor(string email);
         ContactDonor GetContactDonorForDonorAccount(string accountNumber, string routingNumber);
         int UpdatePaymentProcessorCustomerId(int donorId, string paymentProcessorCustomerId);
-        void SetupConfirmationEmail(int programId, int donorId, int donationAmount, DateTime setupDate, string pymtType);
+        void SetupConfirmationEmail(int programId, int donorId, decimal donationAmount, DateTime setupDate, string pymtType);
         ContactDonor GetEmailViaDonorId(int donorId);
         void SendEmail(int emailTemplate, int donorId, decimal donationAmount, string donationType, DateTime donationDate, string programName, string emailReason, string frequency = null);
         ContactDonor GetContactDonorForCheckAccount(string encryptedKey);

--- a/Gateway/crds-angular.test/Services/EzScanCheckScannerServiceTest.cs
+++ b/Gateway/crds-angular.test/Services/EzScanCheckScannerServiceTest.cs
@@ -5,6 +5,7 @@ using crds_angular.DataAccess.Interfaces;
 using crds_angular.Models.Crossroads.Stewardship;
 using crds_angular.Services;
 using crds_angular.Services.Interfaces;
+using Crossroads.Utilities;
 using MinistryPlatform.Models;
 using Moq;
 using NUnit.Framework;
@@ -104,7 +105,7 @@ namespace crds_angular.test.Services
                         State = "1 state",
                         PostalCode = "1 postal"
                     },
-                    Amount = 1111,
+                    Amount = 111100,
                     CheckDate = DateTime.Now.AddHours(1),
                     CheckNumber = " 0 0 00000222111111111111111",
                     Name1 = "1 name 1",
@@ -124,7 +125,7 @@ namespace crds_angular.test.Services
                         State = "2 state",
                         PostalCode = "2 postal"
                     },
-                    Amount = 2222,
+                    Amount = 222200,
                     CheckDate = DateTime.Now.AddHours(3),
                     CheckNumber = "22222",
                     Name1 = "2 name 1",
@@ -156,7 +157,7 @@ namespace crds_angular.test.Services
             
             _donorService.Setup(mocked => mocked.GetContactDonorForDonorAccount(checks[0].AccountNumber, checks[0].RoutingNumber)).Returns(contactDonorExisting);
            
-            _paymentService.Setup(mocked => mocked.ChargeCustomer(contactDonorExisting.ProcessorId, contactDonorExisting.Account.ProcessorAccountId, (int) checks[0].Amount, contactDonorExisting.DonorId)).Returns(new StripeCharge
+            _paymentService.Setup(mocked => mocked.ChargeCustomer(contactDonorExisting.ProcessorId, contactDonorExisting.Account.ProcessorAccountId, (int) (checks[0].Amount *Constants.StripeDecimalConversionValue), contactDonorExisting.DonorId)).Returns(new StripeCharge
             {
                 Id = "1020304",
                 Source = new StripeSource()
@@ -180,7 +181,7 @@ namespace crds_angular.test.Services
                 mocked =>
                     mocked.CreateDonationAndDistributionRecord(
                         It.Is<DonationAndDistributionRecord>(d =>
-                                                                 d.DonationAmt == (int) checks[0].Amount &&
+                                                                 d.DonationAmt == checks[0].Amount &&
                                                                  d.FeeAmt == 123 &&
                                                                  d.DonorId == contactDonorExisting.DonorId &&
                                                                  d.ProgramId.Equals("9090") &&
@@ -231,7 +232,7 @@ namespace crds_angular.test.Services
                         "tok123",
                         It.IsAny<DateTime>()))
                 .Returns(contactDonorNew);
-            _paymentService.Setup(mocked => mocked.ChargeCustomer(contactDonorNew.ProcessorId, contactDonorNew.Account.ProcessorAccountId, (int)checks[1].Amount, contactDonorNew.DonorId)).Returns(mockCharge);
+            _paymentService.Setup(mocked => mocked.ChargeCustomer(contactDonorNew.ProcessorId, contactDonorNew.Account.ProcessorAccountId, (int)(checks[1].Amount * Constants.StripeDecimalConversionValue), contactDonorNew.DonorId)).Returns(mockCharge);
 
             _mpDonorService.Setup(mocked => mocked.CreateHashedAccountAndRoutingNumber(decrypAcct, decryptRout)).Returns(encryptedKey);
             _mpDonorService.Setup(mocked => mocked.UpdateDonorAccount(encryptedKey, mockCharge.Source.id, contactDonorNew.ProcessorId)).Returns(donorAcctId);
@@ -240,7 +241,7 @@ namespace crds_angular.test.Services
                 mocked =>
                     mocked.CreateDonationAndDistributionRecord(
                         It.Is<DonationAndDistributionRecord>(d =>
-                                                                 d.DonationAmt == (int) checks[1].Amount &&
+                                                                 d.DonationAmt == checks[1].Amount &&
                                                                  d.FeeAmt == null &&
                                                                  d.DonorId == contactDonorNew.DonorId &&
                                                                  d.ProgramId.Equals("9090") &&

--- a/Gateway/crds-angular.test/Services/StripeServiceTest.cs
+++ b/Gateway/crds-angular.test/Services/StripeServiceTest.cs
@@ -341,7 +341,7 @@ namespace crds_angular.test.Services
                 It.Is<IRestRequest>(o =>
                     o.Method == Method.POST
                     && o.Resource.Equals("charges")
-                    && o.Parameters.Matches("amount", 9090 * Constants.StripeDecimalConversionValue)
+                    && o.Parameters.Matches("amount", 9090)
                     && o.Parameters.Matches("currency", "usd")
                     && o.Parameters.Matches("customer", "cust_token")
                     && o.Parameters.Matches("description", "Donor ID #98765")

--- a/Gateway/crds-angular/Services/EzScanCheckScannerService.cs
+++ b/Gateway/crds-angular/Services/EzScanCheckScannerService.cs
@@ -66,14 +66,7 @@ namespace crds_angular.Services
                     //Always use the customer ID and source ID from the Donor Account, if it exists
                     StripeCharge charge;
                     var decimalAmt = check.Amount * Constants.StripeDecimalConversionValue;
-                    if (contactDonor.HasAccount)
-                    {
-                        charge = _paymentService.ChargeCustomer(contactDonor.ProcessorId, contactDonor.Account.ProcessorAccountId, (int)decimalAmt, contactDonor.DonorId);
-                    }
-                    else
-                    {
-                        charge = _paymentService.ChargeCustomer(contactDonor.ProcessorId, (int) decimalAmt, contactDonor.DonorId);   
-                    }
+                    charge = contactDonor.HasAccount ? _paymentService.ChargeCustomer(contactDonor.ProcessorId, contactDonor.Account.ProcessorAccountId, (int)decimalAmt, contactDonor.DonorId) : _paymentService.ChargeCustomer(contactDonor.ProcessorId, (int) decimalAmt, contactDonor.DonorId);
                    
                     var fee = charge.BalanceTransaction != null ? charge.BalanceTransaction.Fee : null;
 
@@ -85,7 +78,7 @@ namespace crds_angular.Services
                     var routing = _mpDonorService.DecryptCheckValue(check.RoutingNumber);
                     var encryptedKey = _mpDonorService.CreateHashedAccountAndRoutingNumber(account, routing);
                                      
-                   var donorAccountId =_mpDonorService.UpdateDonorAccount(encryptedKey, charge.Source.id, contactDonor.ProcessorId);
+                    var donorAccountId =_mpDonorService.UpdateDonorAccount(encryptedKey, charge.Source.id, contactDonor.ProcessorId);
                  
                     var programId = batchDetails.ProgramId == null ? null : batchDetails.ProgramId + "";
 

--- a/Gateway/crds-angular/Services/StripeService.cs
+++ b/Gateway/crds-angular/Services/StripeService.cs
@@ -268,7 +268,7 @@ namespace crds_angular.Services
         public StripeCharge ChargeCustomer(string customerToken, int amount, int donorId)
         {
             var request = new RestRequest("charges", Method.POST);
-            request.AddParameter("amount", amount * Constants.StripeDecimalConversionValue);
+            request.AddParameter("amount", amount);
             request.AddParameter("currency", "usd");
             request.AddParameter("customer", customerToken);
             request.AddParameter("description", "Donor ID #" + donorId);

--- a/crossroads.net/app/give/one_time/templates/one_time_thank_you.html
+++ b/crossroads.net/app/give/one_time/templates/one_time_thank_you.html
@@ -1,11 +1,11 @@
 <div class="form-group">
   <div class="push-top push-bottom">
       <h4>Thank You</h4>
-      <p>Thank you for your <strong>{{give.dto.amount | currency}}</strong> gift to <strong>{{give.dto.program['Name']}}!</strong>
+      <p>Thank you for your <strong>{{give.dto.amount | currency}}</strong> gift to <strong>{{give.dto.program['Name']}}</strong>
         <span ng-if="give.dto.mockPledge">
             <!-- TEMPORARY - if this is towards a specific commitment, we want to put the commitment owner's full name here to make it clear who it's going to -->
             towards <strong>First Last's</strong> commitment
-        </span>
+        </span>!
           A receipt has been sent to <strong>{{give.dto.email}}</strong>.
       </p>
       <br />

--- a/crossroads.net/app/give/one_time/templates/one_time_thank_you.html
+++ b/crossroads.net/app/give/one_time/templates/one_time_thank_you.html
@@ -1,11 +1,11 @@
 <div class="form-group">
   <div class="push-top push-bottom">
       <h4>Thank You</h4>
-      <p>Thank you for your <strong>{{give.dto.amount | currency}}</strong> gift to <strong>{{give.dto.program['Name']}}</strong>
+      <p>Thank you for your <strong>{{give.dto.amount | currency}}</strong> gift to <strong>{{give.dto.program['Name']}}!</strong>
         <span ng-if="give.dto.mockPledge">
             <!-- TEMPORARY - if this is towards a specific commitment, we want to put the commitment owner's full name here to make it clear who it's going to -->
             towards <strong>First Last's</strong> commitment
-        </span>!
+        </span>
           A receipt has been sent to <strong>{{give.dto.email}}</strong>.
       </p>
       <br />


### PR DESCRIPTION
Allow for checks to process with dollars and cents
Make sure all emails generate with the correctly formatted amount
Remove the space between the exclamation point and the fund.