### PR TITLE
DE770: Carry trial period over when moving subscription to new plan

### DIFF
--- a/Gateway/crds-angular.test/Services/DonorServiceTest.cs
+++ b/Gateway/crds-angular.test/Services/DonorServiceTest.cs
@@ -865,13 +865,15 @@ namespace crds_angular.test.Services
 
             const int newDonorAccountId = 987;
 
+            DateTime? trialEndDate = DateTime.Now.AddDays(3);
             var oldSubscription = new StripeSubscription
             {
                 Id = "sub_123",
                 Plan = new StripePlan
                 {
                     Id = "plan_123"
-                }
+                },
+                TrialEnd = trialEndDate
             };
 
             var newPlan = new StripePlan
@@ -910,7 +912,7 @@ namespace crds_angular.test.Services
             _paymentService.Setup(mocked => mocked.UpdateCustomerSource(existingGift.StripeCustomerId, editGift.StripeTokenId)).Returns(stripeSource);
             _mpDonorService.Setup(mocked => mocked.CreateDonorAccount(stripeSource.brand, "0", stripeSource.last4, null, existingGift.DonorId, stripeSource.id, existingGift.StripeCustomerId)).Returns(newDonorAccountId);
             _paymentService.Setup(mocked => mocked.GetSubscription(existingGift.StripeCustomerId, existingGift.SubscriptionId)).Returns(oldSubscription);
-            _paymentService.Setup(mocked => mocked.UpdateSubscriptionPlan(existingGift.StripeCustomerId, existingGift.SubscriptionId, newPlan.Id)).Returns(oldSubscription);
+            _paymentService.Setup(mocked => mocked.UpdateSubscriptionPlan(existingGift.StripeCustomerId, existingGift.SubscriptionId, newPlan.Id, trialEndDate)).Returns(oldSubscription);
             _paymentService.Setup(mocked => mocked.CancelPlan(oldSubscription.Plan.Id)).Returns(oldSubscription.Plan);
             _paymentService.Setup(mocked => mocked.CreatePlan(editGift, donor)).Returns(newPlan);
             _mpDonorService.Setup(mocked => mocked.CancelRecurringGift(authUserToken, existingGift.RecurringGiftId.Value));

--- a/Gateway/crds-angular.test/Services/StripeServiceTest.cs
+++ b/Gateway/crds-angular.test/Services/StripeServiceTest.cs
@@ -699,7 +699,7 @@ namespace crds_angular.test.Services
             const string customer = "cus_123";
             const string plan = "plan_123";
 
-            var response = _fixture.UpdateSubscriptionPlan(customer, sub, plan, null);
+            var response = _fixture.UpdateSubscriptionPlan(customer, sub, plan);
             _restClient.Verify(
                 mocked =>
                     mocked.Execute<StripeSubscription>(

--- a/Gateway/crds-angular.test/Services/StripeServiceTest.cs
+++ b/Gateway/crds-angular.test/Services/StripeServiceTest.cs
@@ -668,13 +668,45 @@ namespace crds_angular.test.Services
             const string sub = "sub_123";
             const string customer = "cus_123";
             const string plan = "plan_123";
+            var trialDateTime = DateTime.Now.AddDays(2);
+            var expectedTrialEndDate = trialDateTime.Date.ConvertDateTimeToEpoch();
 
-            var response = _fixture.UpdateSubscriptionPlan(customer, sub, plan);
+            var response = _fixture.UpdateSubscriptionPlan(customer, sub, plan, trialDateTime);
             _restClient.Verify(
                 mocked =>
                     mocked.Execute<StripeSubscription>(
                         It.Is<IRestRequest>(
-                            o => o.Method == Method.POST && o.Resource.Equals("customers/" + customer + "/subscriptions/" + sub) && o.Parameters.Matches("plan", plan) && o.Parameters.Matches("prorate", false))));
+                            o =>
+                                o.Method == Method.POST && o.Resource.Equals("customers/" + customer + "/subscriptions/" + sub) && o.Parameters.Matches("plan", plan) &&
+                                o.Parameters.Matches("prorate", false) && o.Parameters.Matches("trial_end", expectedTrialEndDate))));
+
+            Assert.AreSame(stripeSubscription, response);
+        }
+
+        [Test]
+        public void TestUpdateSubscriptionPlanWithNoTrial()
+        {
+            var stripeSubscription = new StripeSubscription();
+
+            var stripeResponse = new Mock<IRestResponse<StripeSubscription>>(MockBehavior.Strict);
+            stripeResponse.SetupGet(mocked => mocked.ResponseStatus).Returns(ResponseStatus.Completed).Verifiable();
+            stripeResponse.SetupGet(mocked => mocked.StatusCode).Returns(HttpStatusCode.OK).Verifiable();
+            stripeResponse.SetupGet(mocked => mocked.Data).Returns(stripeSubscription).Verifiable();
+
+            _restClient.Setup(mocked => mocked.Execute<StripeSubscription>(It.IsAny<IRestRequest>())).Returns(stripeResponse.Object);
+
+            const string sub = "sub_123";
+            const string customer = "cus_123";
+            const string plan = "plan_123";
+
+            var response = _fixture.UpdateSubscriptionPlan(customer, sub, plan, null);
+            _restClient.Verify(
+                mocked =>
+                    mocked.Execute<StripeSubscription>(
+                        It.Is<IRestRequest>(
+                            o =>
+                                o.Method == Method.POST && o.Resource.Equals("customers/" + customer + "/subscriptions/" + sub) && o.Parameters.Matches("plan", plan) &&
+                                o.Parameters.Matches("prorate", false) && !o.Parameters.Contains("trial_end"))));
 
             Assert.AreSame(stripeSubscription, response);
         }

--- a/Gateway/crds-angular/Models/Crossroads/Stewardship/StripeSubscription.cs
+++ b/Gateway/crds-angular/Models/Crossroads/Stewardship/StripeSubscription.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using crds_angular.Models.Json;
+using Newtonsoft.Json;
 
 namespace crds_angular.Models.Crossroads.Stewardship
 {
@@ -28,5 +30,8 @@ namespace crds_angular.Models.Crossroads.Stewardship
         [JsonProperty("ended_at")]
         public string EndedAt { get; set; }
 
+        [JsonProperty("trial_end")]
+        [JsonConverter(typeof(StripeDateTimeConverter))]
+        public DateTime? TrialEnd { get; set; }
     }
 }

--- a/Gateway/crds-angular/Services/DonorService.cs
+++ b/Gateway/crds-angular/Services/DonorService.cs
@@ -420,9 +420,7 @@ namespace crds_angular.Services
                         stripeSubscription = _paymentService.UpdateSubscriptionPlan(existingGift.StripeCustomerId,
                                                                                     stripeSubscription.Id,
                                                                                     plan.Id,
-                                                                                    oldSubscription.TrialEnd != null && oldSubscription.TrialEnd > DateTime.Now
-                                                                                        ? oldSubscription.TrialEnd
-                                                                                        : null);
+                                                                                    oldSubscription.TrialEnd);
                     }
                     else
                     {

--- a/Gateway/crds-angular/Services/DonorService.cs
+++ b/Gateway/crds-angular/Services/DonorService.cs
@@ -417,7 +417,12 @@ namespace crds_angular.Services
                     {
                         // If we just changed the amount, we just need to update the Subscription to point to the new plan
                         oldSubscription = _paymentService.GetSubscription(existingGift.StripeCustomerId, stripeSubscription.Id);
-                        stripeSubscription = _paymentService.UpdateSubscriptionPlan(existingGift.StripeCustomerId, stripeSubscription.Id, plan.Id);
+                        stripeSubscription = _paymentService.UpdateSubscriptionPlan(existingGift.StripeCustomerId,
+                                                                                    stripeSubscription.Id,
+                                                                                    plan.Id,
+                                                                                    oldSubscription.TrialEnd != null && oldSubscription.TrialEnd > DateTime.Now
+                                                                                        ? oldSubscription.TrialEnd
+                                                                                        : null);
                     }
                     else
                     {

--- a/Gateway/crds-angular/Services/Interfaces/IPaymentService.cs
+++ b/Gateway/crds-angular/Services/Interfaces/IPaymentService.cs
@@ -24,7 +24,7 @@ namespace crds_angular.Services.Interfaces
         StripeCharge GetCharge(string chargeId);
         StripePlan CreatePlan(RecurringGiftDto recurringGiftDto, ContactDonor contactDonor);
         StripeSubscription CreateSubscription(string planName, string customer, DateTime trialEndDate);
-        StripeSubscription UpdateSubscriptionPlan(string customerId, string subscriptionId, string planId, DateTime? trialEndDate);
+        StripeSubscription UpdateSubscriptionPlan(string customerId, string subscriptionId, string planId, DateTime? trialEndDate = null);
         StripeSubscription GetSubscription(string customerId, string subscriptionId);
         StripeCustomer AddSourceToCustomer(string customerToken, string cardToken);
         StripeSubscription CancelSubscription(string customerId, string subscriptionId);

--- a/Gateway/crds-angular/Services/Interfaces/IPaymentService.cs
+++ b/Gateway/crds-angular/Services/Interfaces/IPaymentService.cs
@@ -24,7 +24,7 @@ namespace crds_angular.Services.Interfaces
         StripeCharge GetCharge(string chargeId);
         StripePlan CreatePlan(RecurringGiftDto recurringGiftDto, ContactDonor contactDonor);
         StripeSubscription CreateSubscription(string planName, string customer, DateTime trialEndDate);
-        StripeSubscription UpdateSubscriptionPlan(string customerId, string subscriptionId, string planId);
+        StripeSubscription UpdateSubscriptionPlan(string customerId, string subscriptionId, string planId, DateTime? trialEndDate);
         StripeSubscription GetSubscription(string customerId, string subscriptionId);
         StripeCustomer AddSourceToCustomer(string customerToken, string cardToken);
         StripeSubscription CancelSubscription(string customerId, string subscriptionId);

--- a/Gateway/crds-angular/Services/StripeService.cs
+++ b/Gateway/crds-angular/Services/StripeService.cs
@@ -406,12 +406,12 @@ namespace crds_angular.Services
             return response.Data;
         }
 
-        public StripeSubscription UpdateSubscriptionPlan(string customerId, string subscriptionId, string planId, DateTime? trialEndDate)
+        public StripeSubscription UpdateSubscriptionPlan(string customerId, string subscriptionId, string planId, DateTime? trialEndDate = null)
         {
             var request = new RestRequest(string.Format("customers/{0}/subscriptions/{1}", customerId, subscriptionId), Method.POST);
             request.AddParameter("prorate", false);
             request.AddParameter("plan", planId);
-            if (trialEndDate != null)
+            if (trialEndDate != null && trialEndDate.Value.Date > DateTime.Today.Date)
             {
                 request.AddParameter("trial_end", trialEndDate.Value.Date.ConvertDateTimeToEpoch());
             }

--- a/Gateway/crds-angular/Services/StripeService.cs
+++ b/Gateway/crds-angular/Services/StripeService.cs
@@ -406,11 +406,15 @@ namespace crds_angular.Services
             return response.Data;
         }
 
-        public StripeSubscription UpdateSubscriptionPlan(string customerId, string subscriptionId, string planId)
+        public StripeSubscription UpdateSubscriptionPlan(string customerId, string subscriptionId, string planId, DateTime? trialEndDate)
         {
             var request = new RestRequest(string.Format("customers/{0}/subscriptions/{1}", customerId, subscriptionId), Method.POST);
             request.AddParameter("prorate", false);
             request.AddParameter("plan", planId);
+            if (trialEndDate != null)
+            {
+                request.AddParameter("trial_end", trialEndDate.Value.Date.ConvertDateTimeToEpoch());
+            }
 
             var response = _stripeRestClient.Execute<StripeSubscription>(request);
             CheckStripeResponse("Invalid subscription update request", response);


### PR DESCRIPTION
* [DE770](https://rally1.rallydev.com/#/27593764268d/detail/defect/48687773683)
* When we edit a gift that is currently in trial at Stripe, we will carry the trial period to the new plan.