### PR TITLE
DE822: Check for null or 0 to indicate no email template

### DIFF
--- a/Gateway/MinistryPlatform.Translation.Test/Services/DonorServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/DonorServiceTest.cs
@@ -731,6 +731,100 @@ namespace MinistryPlatform.Translation.Test.Services
         }
 
         [Test]
+        public void TestSetupConfirmationEmailWithTemplate()
+        {
+            const int programId = 123;
+            const int donorId = 456;
+            const decimal amount = 789.10M;
+            var setupDate = DateTime.Now.AddDays(2);
+            const string accountType = "bank";
+
+
+            var program = new Program
+            {
+                CommunicationTemplateId = 9000,
+                Name = "program name"
+            };
+
+            // TODO Mocking the test fixture in order to mock SendEmail.  Probably ought to refactor SendEmail to a separate class - shouldn't have to mock the class we're testing...
+            var donorService = new Mock<DonorService>(_ministryPlatformService.Object, _programService.Object, _communicationService.Object, _authService.Object, _contactService.Object, _configuration.Object, _crypto.Object)
+            {
+                CallBase = true
+            };
+            donorService.Setup(mocked => mocked.SendEmail(program.CommunicationTemplateId.Value, donorId, amount, accountType, setupDate, program.Name, "None", null));
+
+            _programService.Setup(mocked => mocked.GetProgramById(programId)).Returns(program);
+
+            donorService.Object.SetupConfirmationEmail(programId, donorId, amount, setupDate, accountType);
+            _programService.VerifyAll();
+            donorService.VerifyAll();
+        }
+
+        [Test]
+        public void TestSetupConfirmationEmailWithNullTemplate()
+        {
+            const int programId = 123;
+            const int donorId = 456;
+            const decimal amount = 789.10M;
+            var setupDate = DateTime.Now.AddDays(2);
+            const string accountType = "bank";
+
+            const int templateId = 987;
+            _configuration.Setup(mocked => mocked.GetConfigIntValue("DefaultGiveConfirmationEmailTemplate")).Returns(templateId);
+
+            var program = new Program
+            {
+                CommunicationTemplateId = null,
+                Name = "program name"
+            };
+
+            // TODO Mocking the test fixture in order to mock SendEmail.  Probably ought to refactor SendEmail to a separate class - shouldn't have to mock the class we're testing...
+            var donorService = new Mock<DonorService>(_ministryPlatformService.Object, _programService.Object, _communicationService.Object, _authService.Object, _contactService.Object, _configuration.Object, _crypto.Object)
+            {
+                CallBase = true
+            };
+            donorService.Setup(mocked => mocked.SendEmail(templateId, donorId, amount, accountType, setupDate, program.Name, "None", null));
+
+            _programService.Setup(mocked => mocked.GetProgramById(programId)).Returns(program);
+
+            donorService.Object.SetupConfirmationEmail(programId, donorId, amount, setupDate, accountType);
+            _programService.VerifyAll();
+            donorService.VerifyAll();
+        }
+
+        [Test]
+        public void TestSetupConfirmationEmailWithZeroTemplate()
+        {
+            const int programId = 123;
+            const int donorId = 456;
+            const decimal amount = 789.10M;
+            var setupDate = DateTime.Now.AddDays(2);
+            const string accountType = "bank";
+
+            const int templateId = 987;
+            _configuration.Setup(mocked => mocked.GetConfigIntValue("DefaultGiveConfirmationEmailTemplate")).Returns(templateId);
+
+            var program = new Program
+            {
+                CommunicationTemplateId = 0,
+                Name = "program name"
+            };
+
+            // TODO Mocking the test fixture in order to mock SendEmail.  Probably ought to refactor SendEmail to a separate class - shouldn't have to mock the class we're testing...
+            var donorService = new Mock<DonorService>(_ministryPlatformService.Object, _programService.Object, _communicationService.Object, _authService.Object, _contactService.Object, _configuration.Object, _crypto.Object)
+            {
+                CallBase = true
+            };
+            donorService.Setup(mocked => mocked.SendEmail(templateId, donorId, amount, accountType, setupDate, program.Name, "None", null));
+
+            _programService.Setup(mocked => mocked.GetProgramById(programId)).Returns(program);
+
+            donorService.Object.SetupConfirmationEmail(programId, donorId, amount, setupDate, accountType);
+            _programService.VerifyAll();
+            donorService.VerifyAll();
+        }
+
+        [Test]
         public void TestGetContactDonorForDonorAccount()
         {
             const int donorId = 1234567;

--- a/Gateway/MinistryPlatform.Translation/Services/DonorService.cs
+++ b/Gateway/MinistryPlatform.Translation/Services/DonorService.cs
@@ -544,7 +544,9 @@ namespace MinistryPlatform.Translation.Services
         {
             var program = _programService.GetProgramById(programId);
             //If the communcations admin does not link a message to the program, the default template will be used.
-            var communicationTemplateId = program.CommunicationTemplateId != 0 ? Convert.ToInt32(program.CommunicationTemplateId) : AppSetting("DefaultGiveConfirmationEmailTemplate");
+            var communicationTemplateId = program.CommunicationTemplateId != null && program.CommunicationTemplateId != 0
+                ? program.CommunicationTemplateId.Value
+                : _configurationWrapper.GetConfigIntValue("DefaultGiveConfirmationEmailTemplate");
 
             SendEmail(communicationTemplateId, donorId, donationAmount, pymtType, setupDate, program.Name, EmailReason);
         }
@@ -587,7 +589,8 @@ namespace MinistryPlatform.Translation.Services
             return donor;
         }
 
-        public void SendEmail(int communicationTemplateId, int donorId, decimal donationAmount, string paymentType, DateTime setupDate, string program, string emailReason, string frequency = null)
+        // TODO Made this virtual so could mock in a unit test.  Probably ought to refactor to a separate class - shouldn't have to mock the class we're testing...
+        public virtual void SendEmail(int communicationTemplateId, int donorId, decimal donationAmount, string paymentType, DateTime setupDate, string program, string emailReason, string frequency = null)
         {
             var template = _communicationService.GetTemplate(communicationTemplateId);
             var defaultContact = _contactService.GetContactById(AppSetting("DefaultGivingContactEmailId"));


### PR DESCRIPTION
* [DE822](https://rally1.rallydev.com/#/27593764268d/detail/defect/48815512405)
* Now checking for null or 0 in communication template, then fall back to default template