### PR TITLE
DE953: Add missing dependencies to ang.js

### DIFF
--- a/crossroads.net/app/ang.js
+++ b/crossroads.net/app/ang.js
@@ -16,6 +16,8 @@
   require('angular-payments');
   require('angular-bootstrap-npm');
   require('angular-ui-router');
+  require('angular-ui-event');
+  require('angular-ui-mask');
   require('angular-addthis');
   require('angular-aside');
   require('angular-match-media');
@@ -23,4 +25,7 @@
   require('angular-image-crop');
   require('angulartics');
   require('angulartics-gtm');
+
+  require('../node_modules/angular-toggle-switch/angular-toggle-switch-bootstrap.css');
+  require('../node_modules/angular-toggle-switch/angular-toggle-switch.css');
 })();


### PR DESCRIPTION
* [DE953](https://rally1.rallydev.com/#/27593764268d/detail/defect/49935576668)
* Reference dependencies properly