### PR TITLE
Defect/de968 dont allow duplicate email register

### DIFF
--- a/Gateway/Crossroads.AsyncJobs/Unity.config
+++ b/Gateway/Crossroads.AsyncJobs/Unity.config
@@ -293,7 +293,8 @@
     <register type="MinistryPlatform.Translation.Services.Interfaces.ICongregationService" mapTo="MinistryPlatform.Translation.Services.CongregationService" />
     <register type="MinistryPlatform.Translation.Services.Interfaces.IRoomService" mapTo="MinistryPlatform.Translation.Services.RoomService" />
     <register type="MinistryPlatform.Translation.Services.Interfaces.IEquipmentService" mapTo="MinistryPlatform.Translation.Services.EquipmentService" />
-    
+    <register type="MinistryPlatform.Translation.Services.Interfaces.ILookupService" mapTo="MinistryPlatform.Translation.Services.LookupService" />
+
     <!-- Configuration Wrapper -->
     <register type="Crossroads.Utilities.Interfaces.IConfigurationWrapper" mapTo="Crossroads.Utilities.Services.ConfigurationWrapper" />
 

--- a/Gateway/CrossroadsStripeOnboarding/Unity.config
+++ b/Gateway/CrossroadsStripeOnboarding/Unity.config
@@ -45,6 +45,7 @@
     <register type="MinistryPlatform.Translation.Services.Interfaces.IPledgeService" mapTo="MinistryPlatform.Translation.Services.PledgeService" />
     <register type="MinistryPlatform.Translation.Services.Interfaces.IProgramService" mapTo="MinistryPlatform.Translation.Services.ProgramService" />
     <register type="MinistryPlatform.Translation.Services.Interfaces.IPrivateInviteService" mapTo="MinistryPlatform.Translation.Services.PrivateInviteService"/>
+    <register type="MinistryPlatform.Translation.Services.Interfaces.ILookupService" mapTo="MinistryPlatform.Translation.Services.LookupService" />
 
     <!-- Configuration Wrapper -->
     <register type="Crossroads.Utilities.Interfaces.IConfigurationWrapper" mapTo="Crossroads.Utilities.Services.ConfigurationWrapper" />

--- a/Gateway/MinistryPlatform.Translation/MinistryPlatform.Translation.csproj
+++ b/Gateway/MinistryPlatform.Translation/MinistryPlatform.Translation.csproj
@@ -154,6 +154,7 @@
     <Compile Include="Services\Interfaces\IFormSubmissionService.cs" />
     <Compile Include="Services\Interfaces\IGroupParticipantService.cs" />
     <Compile Include="Services\Interfaces\IGroupService.cs" />
+    <Compile Include="Services\Interfaces\ILookupService.cs" />
     <Compile Include="Services\Interfaces\IMinistryPlatformService.cs" />
     <Compile Include="Services\Interfaces\IOpportunityService.cs" />
     <Compile Include="Services\Interfaces\IParticipantService.cs" />

--- a/Gateway/MinistryPlatform.Translation/Services/Interfaces/ILookupService.cs
+++ b/Gateway/MinistryPlatform.Translation/Services/Interfaces/ILookupService.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+
+namespace MinistryPlatform.Translation.Services.Interfaces
+{
+    public interface ILookupService
+    {
+        Dictionary<string, object> EmailSearch(string email, string token);
+
+        List<Dictionary<string, object>> EventTypes(string token);
+
+        List<Dictionary<string, object>> Genders(string token);
+
+        List<Dictionary<string, object>> MaritalStatus(string token);
+
+        List<Dictionary<string, object>> ServiceProviders(string token);
+
+        List<Dictionary<string, object>> States(string token);
+
+        List<Dictionary<string, object>> Countries(string token);
+
+        List<Dictionary<string, object>> CrossroadsLocations(string token);
+
+        List<Dictionary<string, object>> ReminderDays(string token);
+
+        List<Dictionary<string, object>> WorkTeams(string token);
+    }
+}

--- a/Gateway/MinistryPlatform.Translation/Services/LookupService.cs
+++ b/Gateway/MinistryPlatform.Translation/Services/LookupService.cs
@@ -5,7 +5,7 @@ using MinistryPlatform.Translation.Services.Interfaces;
 
 namespace MinistryPlatform.Translation.Services
 {
-    public class LookupService : BaseService
+    public class LookupService : BaseService, ILookupService
     {
         private readonly IMinistryPlatformService _ministryPlatformServiceImpl;
         public LookupService(IAuthenticationService authenticationService, IConfigurationWrapper configurationWrapper, IMinistryPlatformService ministryPlatformServiceImpl)
@@ -14,7 +14,7 @@ namespace MinistryPlatform.Translation.Services
             _ministryPlatformServiceImpl = ministryPlatformServiceImpl;
         }
 
-        public Dictionary<string, object> EmailSearch(String email, string token)
+        public Dictionary<string, object> EmailSearch(string email, string token)
         {
             return _ministryPlatformServiceImpl.GetLookupRecord(AppSettings("Emails"), email, token);
         }

--- a/Gateway/crds-angular.test/Services/AccountServiceTest.cs
+++ b/Gateway/crds-angular.test/Services/AccountServiceTest.cs
@@ -1,42 +1,110 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Configuration;
-using MinistryPlatform.Translation.Services;
-using MinistryPlatform.Translation;
+﻿using System.Collections.Generic;
+using crds_angular.Exceptions;
 using crds_angular.Models.Crossroads;
+using crds_angular.Services;
+using crds_angular.Services.Interfaces;
+using Crossroads.Utilities.Interfaces;
+using MinistryPlatform.Translation.Services.Interfaces;
+using Moq;
 using NUnit.Framework;
 
-//namespace crds_angular.test.Services
-//{
-//    public class AccountServiceTests
-//    {
-//        [Test]
-//        [Ignore("Test isn't working. Needs to be fixed in Registration story.")]
-//        public void shouldRegisterPerson()
-//        {
-//            User newUserData = new User();
-//            newUserData.firstName = "Automated";
-//            newUserData.lastName = "Test";
-//            newUserData.email = "auto02@crossroads.net"; // TODO Create a factory to create a unique email 
-//            newUserData.password = "password";
+namespace crds_angular.test.Services
+{
+    public class AccountServiceTests
+    {
+        private Mock<IAuthenticationService> _authenticationService;
+        private Mock<IConfigurationWrapper> _configurationWrapper;
+        private Mock<ILookupService> _lookupService;
+        private Mock<ICommunicationService> _comunicationService;
+        private Mock<ISubscriptionsService> _subscriptionService;
+        private Mock<IMinistryPlatformService> _ministryPlatformService;
 
-//            string token = AuthenticationService.authenticate(ConfigurationManager.AppSettings["ApiUser"], ConfigurationManager.AppSettings["ApiPass"]);
+        private AccountService _fixture;
 
-//            Dictionary<int, int> newIDs = crds_angular.Services.AccountService.RegisterPerson(newUserData);
+        [SetUp]
+        public void SetUp()
+        {
+            _authenticationService = new Mock<IAuthenticationService>();
+            _configurationWrapper = new Mock<IConfigurationWrapper>();
+            _lookupService = new Mock<ILookupService>();
+            _comunicationService = new Mock<ICommunicationService>();
+            _subscriptionService = new Mock<ISubscriptionsService>();
+            _ministryPlatformService = new Mock<IMinistryPlatformService>();
 
-//            Dictionary<string, object> clearContactIdDict = new Dictionary<string,object>();
-//            clearContactIdDict["User_Account"] = null;
-//            clearContactIdDict["Participant_Record"] = null;
-//            clearContactIdDict["Contact_ID"] = newIDs.First().Value;
-//            MinistryPlatformService.UpdateRecord(newIDs.First().Key,clearContactIdDict,token);
+            _fixture = new AccountService(_configurationWrapper.Object,
+                                          _comunicationService.Object,
+                                          _authenticationService.Object,
+                                          _subscriptionService.Object,
+                                          _ministryPlatformService.Object,
+                                          _lookupService.Object);
+        }
 
-//            foreach (KeyValuePair<int, int> entry in newIDs) // TODO Test cascading delete from contact
-//            {
-//                MinistryPlatformService.DeleteRecord(entry.Key, entry.Value, null, token);
-//            }
-//        }
-//    }
-//}
+        [Test]
+        [ExpectedException(typeof(DuplicateUserException))]
+        public void ShouldNotRegisterDuplicatePerson()
+        {
+            var newUserData = new User
+            {
+                firstName = "Automated",
+                lastName = "Test",
+                email = "auto02@crossroads.net",
+                password = "password"
+            };
+
+            _configurationWrapper.Setup(mocked => mocked.GetEnvironmentVarAsString("API_USER")).Returns("user");
+            _configurationWrapper.Setup(mocked => mocked.GetEnvironmentVarAsString("API_PASSWORD")).Returns("password");
+
+            _authenticationService.Setup(mocked => mocked.Authenticate("user", "password")).Returns(new Dictionary<string, object> {{"token", "auth_token"}});
+
+            _lookupService.Setup(mocked => mocked.EmailSearch(newUserData.email, "auth_token")).Returns(new Dictionary<string, object> { {"dp_RecordID", 123}});
+
+            _fixture.RegisterPerson(newUserData);
+
+            _ministryPlatformService.VerifyAll();
+        }
+
+        [Test]
+        public void ShouldRegisterPerson()
+        {
+            var newUserData = new User
+            {
+                firstName = "Automated",
+                lastName = "Test",
+                email = "auto02@crossroads.net",
+                password = "password"
+            };
+
+            _configurationWrapper.Setup(mocked => mocked.GetEnvironmentVarAsString("API_USER")).Returns("user");
+            _configurationWrapper.Setup(mocked => mocked.GetEnvironmentVarAsString("API_PASSWORD")).Returns("password");
+
+            _authenticationService.Setup(mocked => mocked.Authenticate("user", "password")).Returns(new Dictionary<string, object> { { "token", "auth_token" } });
+
+            _lookupService.Setup(mocked => mocked.EmailSearch(newUserData.email, "auth_token")).Returns(new Dictionary<string, object>());
+
+            _configurationWrapper.Setup(mocked => mocked.GetConfigIntValue("Households")).Returns(123);
+            _ministryPlatformService.Setup(mocked => mocked.CreateRecord(123, It.IsAny<Dictionary<string, object>>(), "auth_token", false)).Returns(321);
+
+            _configurationWrapper.Setup(mocked => mocked.GetConfigIntValue("Contacts")).Returns(456);
+            _ministryPlatformService.Setup(mocked => mocked.CreateRecord(456, It.IsAny<Dictionary<string, object>>(), "auth_token", false)).Returns(654);
+
+            _configurationWrapper.Setup(mocked => mocked.GetConfigIntValue("Users")).Returns(789);
+            _ministryPlatformService.Setup(mocked => mocked.CreateRecord(789, It.IsAny<Dictionary<string, object>>(), "auth_token", true)).Returns(987);
+
+            _configurationWrapper.Setup(mocked => mocked.GetConfigIntValue("ContactHouseholds")).Returns(234);
+            _ministryPlatformService.Setup(mocked => mocked.CreateRecord(234, It.IsAny<Dictionary<string, object>>(), "auth_token", false)).Returns(432);
+
+            _configurationWrapper.Setup(mocked => mocked.GetConfigIntValue("Users_Roles")).Returns(345);
+            _ministryPlatformService.Setup(mocked => mocked.CreateSubRecord(345, 987, It.IsAny<Dictionary<string, object>>(), "auth_token", false)).Returns(543);
+
+            _configurationWrapper.Setup(mocked => mocked.GetConfigIntValue("Participants")).Returns(567);
+            _ministryPlatformService.Setup(mocked => mocked.CreateRecord(567, It.IsAny<Dictionary<string, object>>(), "auth_token", false)).Returns(765);
+
+            _subscriptionService.Setup(mocked => mocked.SetSubscriptions(It.IsAny<Dictionary<string, object>>(), 654, "auth_token")).Returns(999);
+
+            _fixture.RegisterPerson(newUserData);
+
+            _ministryPlatformService.VerifyAll();
+            _subscriptionService.VerifyAll();
+        }
+    }
+}

--- a/Gateway/crds-angular.test/controllers/UserControllerTest.cs
+++ b/Gateway/crds-angular.test/controllers/UserControllerTest.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.Web.Http;
+using System.Web.Http.Results;
+using crds_angular.Controllers.API;
+using crds_angular.Exceptions;
+using crds_angular.Models.Crossroads;
+using crds_angular.Services.Interfaces;
+using Moq;
+using NUnit.Framework;
+
+namespace crds_angular.test.controllers
+{
+    public class UserControllerTest
+    {
+        private UserController _fixture;
+
+        private Mock<IAccountService> _accountService;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _accountService = new Mock<IAccountService>();
+
+            _fixture = new UserController(_accountService.Object);
+        }
+
+        [Test]
+        public void ShouldRegisterNewUser()
+        {
+            var user = new User();
+            var newUser = new Dictionary<string, string>();
+            _accountService.Setup(mocked => mocked.RegisterPerson(user)).Returns(newUser);
+
+            var response = _fixture.Post(user);
+            _accountService.VerifyAll();
+
+            Assert.IsNotNull(response);
+            Assert.IsInstanceOf<OkNegotiatedContentResult<Dictionary<string, string>>>(response);
+            var responseData = ((OkNegotiatedContentResult<Dictionary<string, string>>) response).Content;
+            Assert.IsNotNull(responseData);
+            Assert.AreSame(newUser, responseData);
+        }
+
+        [Test]
+        public void ShouldReturnBadResponseForDuplicateUser()
+        {
+            var user = new User();
+            _accountService.Setup(mocked => mocked.RegisterPerson(user)).Throws(new DuplicateUserException("me@here.com"));
+
+            try
+            {
+                _fixture.Post(user);
+                Assert.Fail("Expected exception was not thrown");
+            }
+            catch (HttpResponseException e)
+            {
+                // Expected
+            }
+            _accountService.VerifyAll();
+        }
+    }
+}

--- a/Gateway/crds-angular.test/crds-angular.test.csproj
+++ b/Gateway/crds-angular.test/crds-angular.test.csproj
@@ -173,6 +173,7 @@
     <Compile Include="controllers\ServeControllerTest.cs" />
     <Compile Include="controllers\ProgramControllerTest.cs" />
     <Compile Include="controllers\StripeEventControllerTest.cs" />
+    <Compile Include="controllers\UserControllerTest.cs" />
     <Compile Include="DataAccess\EzScanCheckScannerDaoTest.cs" />
     <Compile Include="Models\Crossroads\Events\EventHelpers.cs" />
     <Compile Include="Models\Crossroads\Events\EventMapperTest.cs" />

--- a/Gateway/crds-angular/Controllers/API/UserController.cs
+++ b/Gateway/crds-angular/Controllers/API/UserController.cs
@@ -10,6 +10,8 @@ namespace crds_angular.Controllers.API
     {
 
         private readonly IAccountService _accountService;
+        // Do not change this string without also changing the same in the corejs register_controller
+        private const string DUPLICATE_USER_MESSAGE = "Duplicate User";
 
         public UserController(IAccountService accountService)
         {
@@ -25,7 +27,7 @@ namespace crds_angular.Controllers.API
             }
             catch (DuplicateUserException e)
             {
-                var apiError = new ApiErrorDto("Duplicate User", e);
+                var apiError = new ApiErrorDto(DUPLICATE_USER_MESSAGE, e);
                 throw new HttpResponseException(apiError.HttpResponseMessage);                
             }
         }

--- a/Gateway/crds-angular/Controllers/API/UserController.cs
+++ b/Gateway/crds-angular/Controllers/API/UserController.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-using System.Web.Http;
-using AutoMapper;
+﻿using System.Web.Http;
+using crds_angular.Exceptions;
 using crds_angular.Models.Crossroads;
-using crds_angular.Services;
 using crds_angular.Services.Interfaces;
-using Crossroads.Utilities.Interfaces;
-using Crossroads.Utilities.Services;
-using MinistryPlatform.Translation.Services.Interfaces;
+using crds_angular.Exceptions.Models;
 
 namespace crds_angular.Controllers.API
 {
@@ -25,8 +18,16 @@ namespace crds_angular.Controllers.API
 
         public IHttpActionResult Post([FromBody] User user)
         {
-            var returnvalue = _accountService.RegisterPerson(user);
-            return this.Ok(returnvalue);
+            try
+            {
+                var returnvalue = _accountService.RegisterPerson(user);
+                return Ok(returnvalue);
+            }
+            catch (DuplicateUserException e)
+            {
+                var apiError = new ApiErrorDto("Duplicate User", e);
+                throw new HttpResponseException(apiError.HttpResponseMessage);                
+            }
         }
     }
 }

--- a/Gateway/crds-angular/Exceptions/DuplicateUserException.cs
+++ b/Gateway/crds-angular/Exceptions/DuplicateUserException.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace crds_angular.Exceptions
+{
+    public class DuplicateUserException : Exception
+    {
+        public DuplicateUserException(string userName) : base(string.Format("User {0} already exists", userName)) { }
+    }
+}

--- a/Gateway/crds-angular/Unity.config
+++ b/Gateway/crds-angular/Unity.config
@@ -164,6 +164,7 @@
     <register type="MinistryPlatform.Translation.Services.Interfaces.ICongregationService" mapTo="MinistryPlatform.Translation.Services.CongregationService" />
     <register type="MinistryPlatform.Translation.Services.Interfaces.IRoomService" mapTo="MinistryPlatform.Translation.Services.RoomService" />
     <register type="MinistryPlatform.Translation.Services.Interfaces.IEquipmentService" mapTo="MinistryPlatform.Translation.Services.EquipmentService" />
+    <register type="MinistryPlatform.Translation.Services.Interfaces.ILookupService" mapTo="MinistryPlatform.Translation.Services.LookupService" />
 
     <!-- Register Utility Dependencies -->
     <register type="Crossroads.Utilities.Interfaces.IConfigurationWrapper"

--- a/Gateway/crds-angular/crds-angular.csproj
+++ b/Gateway/crds-angular/crds-angular.csproj
@@ -258,6 +258,7 @@
     <Compile Include="Controllers\API\RoomController.cs" />
     <Compile Include="Controllers\API\StaffContactController.cs" />
     <Compile Include="Controllers\API\DonorStatementController.cs" />
+    <Compile Include="Exceptions\DuplicateUserException.cs" />
     <Compile Include="Models\Crossroads\CommunicationDTO.cs" />
     <Compile Include="Models\Crossroads\Congregation.cs" />
     <Compile Include="Models\Crossroads\DonorStatementDTO.cs" />


### PR DESCRIPTION
* [DE968](https://rally1.rallydev.com/#/27593764268d/detail/defect/50005367347)
* Now UserController will return a "Duplicate User" error if trying to register an email already in use.
* Looks like a lot of changes, but most of it was fixing broken windows (ReSharper warnings), which enabled some unit testing on AccountService