### PR TITLE
DE1139: Send recurring gift times as noon UTC instead of midnight UTC

### DIFF
--- a/Gateway/crds-angular.test/Services/StripeServiceTest.cs
+++ b/Gateway/crds-angular.test/Services/StripeServiceTest.cs
@@ -587,7 +587,7 @@ namespace crds_angular.test.Services
             const string customer = "cus_123";
             var trialEndDate = DateTime.Now.AddDays(1);
 
-            var expectedEpochTime = trialEndDate.ToUniversalTime().Date.ConvertDateTimeToEpoch();
+            var expectedEpochTime = trialEndDate.ToUniversalTime().Date.AddHours(12).ConvertDateTimeToEpoch();
 
             var response = _fixture.CreateSubscription(plan, customer, trialEndDate);
             _restClient.Verify(
@@ -669,7 +669,7 @@ namespace crds_angular.test.Services
             const string customer = "cus_123";
             const string plan = "plan_123";
             var trialDateTime = DateTime.Now.AddDays(2);
-            var expectedTrialEndDate = trialDateTime.ToUniversalTime().Date.ConvertDateTimeToEpoch();
+            var expectedTrialEndDate = trialDateTime.ToUniversalTime().Date.AddHours(12).ConvertDateTimeToEpoch();
 
             var response = _fixture.UpdateSubscriptionPlan(customer, sub, plan, trialDateTime);
             _restClient.Verify(

--- a/Gateway/crds-angular/Services/StripeService.cs
+++ b/Gateway/crds-angular/Services/StripeService.cs
@@ -388,7 +388,7 @@ namespace crds_angular.Services
             request.AddParameter("plan", planName);
             if (trialEndDate.ToUniversalTime().Date > DateTime.UtcNow.Date)
             {
-                request.AddParameter("trial_end", trialEndDate.ToUniversalTime().Date.ConvertDateTimeToEpoch());
+                request.AddParameter("trial_end", trialEndDate.ToUniversalTime().Date.AddHours(12).ConvertDateTimeToEpoch());
             }
 
             var response = _stripeRestClient.Execute<StripeSubscription>(request);
@@ -414,7 +414,7 @@ namespace crds_angular.Services
             request.AddParameter("plan", planId);
             if (trialEndDate != null && trialEndDate.Value.ToUniversalTime().Date > DateTime.UtcNow.Date)
             {
-                request.AddParameter("trial_end", trialEndDate.Value.ToUniversalTime().Date.ConvertDateTimeToEpoch());
+                request.AddParameter("trial_end", trialEndDate.Value.ToUniversalTime().Date.AddHours(12).ConvertDateTimeToEpoch());
             }
 
             var response = _stripeRestClient.Execute<StripeSubscription>(request);
@@ -443,4 +443,3 @@ namespace crds_angular.Services
         public Error Error { get; set; }
     }
 }
-


### PR DESCRIPTION
This allows gifts to process on the correct date selected by the Community Member, regardless of their timezone.

hotfix to prod