### PR TITLE
[DE1212] Dashboard should display all participants

### DIFF
--- a/crossroads.net/app/group_finder/directives/group_card/group_card.html
+++ b/crossroads.net/app/group_finder/directives/group_card/group_card.html
@@ -4,7 +4,7 @@
     <img ng-src="{{getUserImage(group.contactId)}}" err-src="{{defaultImage}}" alt="" ng-if="group.isHost === false">
   </div>
   <div class="group-images" ng-if="display==='members' || !display">
-    <img ng-src="{{getMemberImage(member)}}" err-src="{{defaultImage}}" alt="" ng-repeat="member in group.members | limitTo: 3" ng-if="member.groupRoleId == GROUP_ROLE_ID_PARTICIPANT">
+    <img ng-src="{{getMemberImage(member)}}" err-src="{{defaultImage}}" alt="" ng-repeat="member in group.members | filter: { groupRoleId: GROUP_ROLE_ID_PARTICIPANT } | limitTo: 3">
   </div>
   <div class="group-description" ng-if="!group.isPrivate">
     <p>{{groupDescription()}}. This group meets at <a target="_blank" href="{{mapAddress()}}">{{group.address.addressLine1}}, {{group.address.zip}}</a></p>


### PR DESCRIPTION
The dashboard participant list was being limited to 3 people before the host was being eliminated from the list.  The filtering of the host is now before the limit 3 which will ensure that 3 are shown if that many participants are in the group besides the host