### PR TITLE
[DE1219] Group details page Need Help? mailto subject line

### DIFF
--- a/crossroads.net/app/group_finder/dashboard/group_detail.controller.js
+++ b/crossroads.net/app/group_finder/dashboard/group_detail.controller.js
@@ -3,13 +3,14 @@
 
   module.exports = GroupDetailCtrl;
 
-  GroupDetailCtrl.$inject = ['$scope', '$stateParams', '$modal', 'GroupInfo', 'GROUP_ROLE_ID_PARTICIPANT'];
+  GroupDetailCtrl.$inject = ['$scope', '$stateParams', '$modal', 'AuthenticatedPerson', 'GroupInfo', 'GROUP_ROLE_ID_PARTICIPANT'];
 
-  function GroupDetailCtrl($scope, $stateParams, $modal, GroupInfo, GROUP_ROLE_ID_PARTICIPANT) {
+  function GroupDetailCtrl($scope, $stateParams, $modal, AuthenticatedPerson, GroupInfo, GROUP_ROLE_ID_PARTICIPANT) {
     var vm = this;
 
     vm.GROUP_ROLE_ID_PARTICIPANT = GROUP_ROLE_ID_PARTICIPANT;
     vm.group = GroupInfo.findHosting($stateParams.groupId);
+    vm.hostName = AuthenticatedPerson.nickName;
 
     vm.emailGroup = emailGroup;
 


### PR DESCRIPTION
* The host's nickName will be placed in the scope so that the CMS content can embed the nickname in the mailto link.  
* This is dependent on the CMS content for key: `$root.MESSAGES.groupFinderHostDashboardHelp.content` being changed to 

```
<h4 class="ng-scope">Need help?</h4>
<p class="ng-scope">Have a specific question about your BRAVE group? Send us an email to <a href="mailto:journey@crossroads.net?subject=Question+from+{{hostName}},+a+BRAVE+group+host.">host@crossroads.net</a>.</p>
```