### PR TITLE
DE1335: Pass Donation_Status from MP to crds-angular

### DIFF
--- a/Gateway/MinistryPlatform.Translation/Services/DonationService.cs
+++ b/Gateway/MinistryPlatform.Translation/Services/DonationService.cs
@@ -326,7 +326,7 @@ namespace MinistryPlatform.Translation.Services
             }
 
             var dictionary = result.First();
-          
+
             var d = new Donation()
             {
                 donationId = dictionary.ToInt("dp_RecordID"),
@@ -335,7 +335,8 @@ namespace MinistryPlatform.Translation.Services
                 donationAmt = (int)((dictionary["Donation_Amount"] as decimal? ?? 0M) * Constants.StripeDecimalConversionValue),
                 paymentTypeId = PaymentType.GetPaymentType(dictionary.ToString("Payment_Type")).id,
                 donationNotes = dictionary.ToString("Donation_Status_Notes"),
-                batchId = dictionary.ToNullableInt("Batch_ID")
+                batchId = dictionary.ToNullableInt("Batch_ID"),
+                donationStatus = dictionary.ToInt("Donation_Status_ID")
             };
 
             if (!retrieveDistributions)

--- a/Gateway/crds-angular.test/Services/DonationServiceTest.cs
+++ b/Gateway/crds-angular.test/Services/DonationServiceTest.cs
@@ -101,7 +101,8 @@ namespace crds_angular.test.Services
             {
                 donationId = 123,
                 donationAmt = 456,
-                batchId = 789
+                batchId = 789,
+                donationStatus = (int)crds_angular.Models.Crossroads.Stewardship.DonationStatus.Declined
             });
             var result = _fixture.GetDonationByProcessorPaymentId("123");
             _mpDonationService.VerifyAll();
@@ -109,6 +110,7 @@ namespace crds_angular.test.Services
             Assert.AreEqual(123+"", result.Id);
             Assert.AreEqual(456, result.Amount);
             Assert.AreEqual(789, result.BatchId);
+            Assert.AreEqual(crds_angular.Models.Crossroads.Stewardship.DonationStatus.Declined, result.Status);
         }
 
         [Test]

--- a/Gateway/crds-angular/Services/DonationService.cs
+++ b/Gateway/crds-angular/Services/DonationService.cs
@@ -50,7 +50,8 @@ namespace crds_angular.Services
             {
                 Amount = d.donationAmt,
                 Id = d.donationId + "",
-                BatchId = d.batchId
+                BatchId = d.batchId,
+                Status = (DonationStatus)d.donationStatus
             };
             return (donation);
         }


### PR DESCRIPTION
* [DE1335](https://rally1.rallydev.com/#/22244455064d/detail/defect/53100051269)
* Needed to pass Donation_Status_ID from MP DonationService up to crds-angular DonationService, in order to actually use the status in other services...