### PR TITLE
DE1348 Fix broken links

### DIFF
--- a/crossroads.net/app/go_volunteer/goVolunteer.routes.js
+++ b/crossroads.net/app/go_volunteer/goVolunteer.routes.js
@@ -109,7 +109,6 @@
           $stateParams: '$stateParams',
           $q: '$q',
           SkillsService: 'SkillsService',
-          loggedin: crds_utilities.checkLoggedin,
           CmsInfo: CmsInfo,
           Meta: Meta,
           Organization: Organization,


### PR DESCRIPTION
Somehow the route for non-crossroads page was trying to authenticate.
These pages do not need authentication, it must have been a copy and
paste error or a merge conflict issue.