### PR TITLE
Feature/us3559 group connector private

### DIFF
--- a/CI/SQL/201604062016102200_US3559-filter-view-to-non-private-connectors.sql
+++ b/CI/SQL/201604062016102200_US3559-filter-view-to-non-private-connectors.sql
@@ -1,0 +1,6 @@
+use MinistryPlatform;
+
+UPDATE [dbo].[dp_Page_Views]
+SET [View_Clause] = 'cr_GroupConnectors.[GroupConnector_ID] IS NOT NULL AND cr_GroupConnectors.[Private] = 0',
+[Field_List] = 'Primary_Registration_Table_Participant_ID_Table_Contact_ID_Table.[Display_Name] AS [Primary_Registration] , Primary_Registration_Table_Participant_ID_Table_Contact_ID_Table.[Contact_ID] AS [Primary_Registration_Contact_ID] , Project_ID_Table.[Project_Name] , Primary_Registration_Table_Preferred_Launch_Site_ID_Table.[Location_Name] AS [Preferred_Launch_Site] , Primary_Registration_Table_Organization_ID_Table.[Organization_ID] , Primary_Registration_Table_Organization_ID_Table.[Open_Signup] AS [Organization_Open_Signup] , Primary_Registration_Table_Initiative_ID_Table.[Initiative_ID] , Project_ID_Table_Project_Type_ID_Table.[Description] AS [Project_Type] , Project_ID_Table_Project_Type_ID_Table.[Minimum_Age] AS [Project_Minimum_Age] , Project_ID_Table.[_Volunteer_Count] AS [Volunteer_Count] , Project_ID_Table.[Maximum_Volunteers] AS [Project_Maximum_Volunteers] , cr_GroupConnectors.[GroupConnector_ID], cr_GroupConnectors.[Private]'
+WHERE [Page_View_ID] = 2219


### PR DESCRIPTION
Group connectors that are marked as private are showing in the UI. Only
connectors that are non-private should be shown.

* Updated the filter in the `GroupConnectorsByOrganization`
MinistryPlatform view to not show private connectors.