### PR TITLE
DE1439 Refresh in middle of Go Cincinnati Flow

### DIFF
--- a/crossroads.net/app/go_volunteer/goVolunteer.routes.js
+++ b/crossroads.net/app/go_volunteer/goVolunteer.routes.js
@@ -189,8 +189,9 @@
     return deferred.promise;
   }
 
-  function CmsInfo(Page, $state, $stateParams, GoVolunteerService, $q) {
+  function CmsInfo(Page, $state, $stateParams, GoVolunteerService, $q, $window) {
     var city = $stateParams.city || 'cincinnati';
+    $window.sessionStorage.setItem('go-volunteer.city', city);
     var organization = $stateParams.organizations || undefined;
     var link = buildLink(city, organization, $state, $stateParams);
     var deferred = $q.defer();
@@ -259,7 +260,9 @@
   function Locations($cookies, $q, GoVolunteerService, $stateParams, Organizations) {
     var deferred = $q.defer();
 
-    if ($stateParams.page === 'launch-site' && _.isEmpty(GoVolunteerService.launchSites)) {
+    if ($stateParams.page === 'launch-site' && 
+        _.isEmpty(GoVolunteerService.launchSites) && 
+        GoVolunteerService.organization.organizationId) {
       Organizations.LocationsForOrg.query({orgId: GoVolunteerService.organization.organizationId}, function(data) {
         GoVolunteerService.launchSites = data;
         deferred.resolve();

--- a/crossroads.net/app/go_volunteer/page/goVolunteerPage.component.js
+++ b/crossroads.net/app/go_volunteer/page/goVolunteerPage.component.js
@@ -53,7 +53,7 @@
         var fromReload = angular.fromJson($window.sessionStorage.getItem(vm.reload)) || false;
         if (fromReload) {
           $window.sessionStorage.setItem(vm.reload, angular.toJson(false));
-          $state.go('go-volunteer.crossroadspage', {page: 'profile'});
+          $state.go('go-volunteer.city.organizations', {city: $window.sessionStorage.getItem('go-volunteer.city')});
         }
       }
 


### PR DESCRIPTION
After a refresh in the middle of the GoCincy flow, we should be
redirected to the organizations page. This was not happening for
organizations other than Crossroads.

* The $state.go had the wrong route name - corrected.
* Locations resolve was looking for the organizationId but after a
refresh it did not exist. Added a guard clause.