### PR TITLE
Defect/de1466 fix groups by event id page view

### DIFF
--- a/CI/SQL/20160505085200_DE1466-GroupsByEventIdPageView.sql
+++ b/CI/SQL/20160505085200_DE1466-GroupsByEventIdPageView.sql
@@ -1,0 +1,34 @@
+USE [MinistryPlatform];
+GO
+
+SET IDENTITY_INSERT [dbo].[dp_Page_Views] ON;
+GO
+
+DECLARE @PageViewId INT = 2221;
+DECLARE @PageId INT = 408;
+DECLARE @PageViewTitle VARCHAR(50) = 'Groups By Event Id';
+DECLARE @FieldList VARCHAR(1000) = 'Event_ID_Table.[Event_ID]
+, Group_ID_Table.[Group_Name]
+, Event_Groups.[Event_Group_ID]
+, Group_ID_Table.[Group_ID]
+, Room_ID_Table.[Room_ID]
+, Event_Groups.[Closed]
+, Event_Room_ID_Table.[Event_Room_ID]';
+DECLARE @ViewClause VARCHAR(1000) = 'Event_ID_Table.[Event_ID] IS NOT NULL';
+DECLARE @Description VARCHAR(1000) = 'API View';
+
+DELETE FROM [dbo].[dp_Page_Views] WHERE Page_View_ID = @PageViewId;
+
+INSERT INTO [dbo].[dp_Page_Views]
+       ( [Page_View_ID],
+         [View_Title],
+         [Page_ID],
+         [Field_List],
+         [View_Clause],
+         [Description]
+       )
+VALUES( @PageViewId, @PageViewTitle, @PageId, @FieldList, @ViewClause, @Description );
+GO
+
+SET IDENTITY_INSERT [dbo].[dp_Page_Views] OFF;
+GO

--- a/Gateway/Crossroads.AsyncJobs/MinistryPlatform.config
+++ b/Gateway/Crossroads.AsyncJobs/MinistryPlatform.config
@@ -75,7 +75,7 @@
   <add key="GroupOpportunities" value="300"/>
   <add key="GroupOpportunitiesEvents" value="77"/>
   <add key="Groups" value="322"/>
-  <add key="GroupsByEventId" value="92180" />
+  <add key="GroupsByEventId" value="2221" />
   <add key="GroupEventsSubPageView" value="111"/>
   <add key="GroupsParticipants" value="298"/>
   <add key="GroupParticipantsById" value="92188" />

--- a/Gateway/MinistryPlatform.Translation.Test/Services/EventServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/EventServiceTest.cs
@@ -287,7 +287,7 @@ namespace MinistryPlatform.Translation.Test.Services
 
             Prop.ForAll<string, int>((token, eventId) =>
             {
-                var searchString = ",\"" + eventId + "\"";
+                var searchString = "\"" + eventId + "\",";
 
                 _ministryPlatformService.Setup(m => m.GetPageViewRecords(eventGroupPageViewId, token, searchString, "", 0)).Returns(GetMockedEventGroups(3));
                 _fixture.GetEventGroupsForEvent(eventId, token);

--- a/Gateway/MinistryPlatform.Translation.Test/Services/GroupServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/GroupServiceTest.cs
@@ -291,7 +291,7 @@ namespace MinistryPlatform.Translation.Test.Services
             //Arrange
             const int eventId = 123456;
             const int pageViewId = 999;
-            var searchString = eventId + ",";
+            var searchString = string.Format("\"{0}\",", eventId);
 
             var mpResponse = new List<Dictionary<string, object>>();
 
@@ -314,7 +314,7 @@ namespace MinistryPlatform.Translation.Test.Services
             //Arrange
             const int eventId = 123456;
             const int pageViewId = 999;
-            var searchString = eventId + ",";
+            var searchString = string.Format("\"{0}\",", eventId);
 
             configWrapper.Setup(m => m.GetConfigIntValue(It.IsAny<string>())).Returns(pageViewId);
             ministryPlatformService.Setup(m => m.GetPageViewRecords(pageViewId, It.IsAny<string>(), searchString, It.IsAny<string>(), It.IsAny<int>()))

--- a/Gateway/MinistryPlatform.Translation/Services/EventService.cs
+++ b/Gateway/MinistryPlatform.Translation/Services/EventService.cs
@@ -339,7 +339,7 @@ namespace MinistryPlatform.Translation.Services
 
         public List<EventGroup> GetEventGroupsForEvent(int eventId, string token)
         {
-            var searchString =  string.Format(",\"{0}\"", eventId);
+            var searchString =  string.Format("\"{0}\",", eventId);
             var records = _ministryPlatformService.GetPageViewRecords(_eventGroupsPageViewId, token, searchString);
 
             if (records == null)

--- a/Gateway/MinistryPlatform.Translation/Services/GroupService.cs
+++ b/Gateway/MinistryPlatform.Translation/Services/GroupService.cs
@@ -412,7 +412,7 @@ namespace MinistryPlatform.Translation.Services
 
         public List<Group> GetGroupsForEvent(int eventId)
         {
-            var searchString = eventId + ",";
+            var searchString = string.Format("\"{0}\",", eventId);
             var pageViewId = _configurationWrapper.GetConfigIntValue("GroupsByEventId");
             var token = ApiLogin();
             var records = ministryPlatformService.GetPageViewRecords(pageViewId, token, searchString);

--- a/Gateway/crds-angular/MinistryPlatform.config
+++ b/Gateway/crds-angular/MinistryPlatform.config
@@ -82,7 +82,7 @@
   <add key="GroupOpportunities" value="300"/>
   <add key="GroupOpportunitiesEvents" value="77"/>
   <add key="Groups" value="322"/>
-  <add key="GroupsByEventId" value="92180" />
+  <add key="GroupsByEventId" value="2221" />
   <add key="GroupEventsSubPageView" value="111"/>
   <add key="GroupsParticipants" value="298"/>
   <add key="GroupParticipantsById" value="92188" />


### PR DESCRIPTION
* [DE1466](https://rally1.rallydev.com/#/27593764268d/detail/defect/55401303202)
* Change page view 2221 to be usable by both GroupService.GetGroupsForEvent and EventService.GetEventGroupsForEvent.