### PR TITLE
US3242-Fixing Modal Household Header

### DIFF
--- a/crossroads.net/app/common/profile/household/profileHousehold.directive.js
+++ b/crossroads.net/app/common/profile/household/profileHousehold.directive.js
@@ -14,6 +14,7 @@
         householdInfo: '=',
         householdForm: '=',
         isCollapsed: '=?',
+        modalInstance: '=?',
         locations: '='
       },
       templateUrl: 'household/profileHousehold.template.html',

--- a/crossroads.net/app/common/profile/household/profileHousehold.template.html
+++ b/crossroads.net/app/common/profile/household/profileHousehold.template.html
@@ -22,7 +22,7 @@
                 <use xlink:href="#caret-up"></use>
               </svg>
             </a>
-            <div class="col-md-7">
+            <div ng-class="{'col-md-7':!household.modalInstance, 'col-lg-12':household.modalInstance}">
               <svg viewBox="0 0 32 32" class="icon icon-home">
                 <use xlink:href="#home"></use>
               </svg>
@@ -31,7 +31,7 @@
               </span>
               <span ng-if="!household.householdInfo.addressLine1">Set Address...</span>
             </div>
-            <div class="col-md-2">
+            <div ng-class="{'col-md-2':!household.modalInstance, 'col-lg-12':household.modalInstance}">
               <svg viewBox="0 0 32 32" class="icon icon-phone3">
                 <use xlink:href="#phone3"></use>
               </svg>
@@ -40,7 +40,7 @@
               </span>
               <span ng-if="!household.householdInfo.homePhone">Set Home Phone...</span>
             </div>
-            <div class="col-md-3">
+            <div ng-class="{'col-md-3':!household.modalInstance, 'col-lg-12':household.modalInstance}">
               <svg viewBox="0 0 32 32" class="icon icon-crossroads">
                 <use xlink:href="#crossroads"></use>
               </svg>

--- a/crossroads.net/app/common/profile/personal/profilePersonal.template.html
+++ b/crossroads.net/app/common/profile/personal/profilePersonal.template.html
@@ -276,7 +276,7 @@
 
 
     <div class="row" ng-if="profile.profileData.person.householdId!==undefined">
-      <profile-household household-info='profile.profileData.person' household-form='profile.householdForm' locations='profile.locations' is-collapsed='profile.isHouseholdCollapsed'/>
+      <profile-household modal-instance='profile.modalInstance' household-info='profile.profileData.person' household-form='profile.householdForm' locations='profile.locations' is-collapsed='profile.isHouseholdCollapsed'/>
     </div>
 
     <loading-button

--- a/crossroads.net/app/signup/community_group_signup/communityGroupSignupForm.html
+++ b/crossroads.net/app/signup/community_group_signup/communityGroupSignupForm.html
@@ -22,7 +22,7 @@
           <div class="col-sm-12">
           <label ng-show="groupsignup.response.length > 1 && !groupsignup.alreadySignedUp">Select participants:</label>
           <label ng-show="groupsignup.response.length <= 1 && !groupsignup.alreadySignedUp">Signing up:</label>
-          
+
           <form class="form-group" name="myForm" role="form" ng-submit="groupsignup.signup(myForm)" id="myForm">
               <div class="checkbox flush-top"
                    ng-repeat="person in groupsignup.response as people"
@@ -68,6 +68,7 @@
           </form>
         </div><!--/col-sm-12-->
       </div><!--row-->
+      <!--TODO this should use the Profile Modal -->
       <script type="text/ng-template" id="editProfile.html">
         <div class="modal-header">
           <a type="button" class="close" ng-click="groupsignup.modalInstance.close()">x</a>


### PR DESCRIPTION
Hacky fix, but bootstrap breakpoints aren’t based off the modal width
and thus we need different grid classes for modals