### PR TITLE
DE1526 Primary Keys for Request Status

### DIFF
--- a/CI/SQL/20160601090100_DE1526-script-request-status.sql
+++ b/CI/SQL/20160601090100_DE1526-script-request-status.sql
@@ -1,0 +1,35 @@
+use MinistryPlatform
+go
+
+DELETE FROM [dbo].[cr_Childcare_Requests]
+
+DELETE FROM [dbo].[cr_Childcare_Request_Statuses]
+
+SET IDENTITY_INSERT [dbo].[cr_Childcare_Request_Statuses] ON
+
+INSERT INTO [dbo].[cr_Childcare_Request_Statuses] ( 
+	 [Childcare_Request_Status_ID]
+	,[Domain_ID]
+	,[Request_Status]
+	) VALUES (
+		 1
+		,1
+		,N'Approved'
+	),
+	(
+		 2
+		,1
+		,N'Conditionally Approved'
+	),
+	(
+		 3
+		,1
+		,N'Pending'
+	) ,
+	(
+		 4
+		,1
+		,N'Rejected'
+	)
+
+SET IDENTITY_INSERT [dbo].[cr_Childcare_Request_Statuses] OFF


### PR DESCRIPTION
[DE1526](https://rally1.rallydev.com/#/22244455064d/detail/defect/56554432987)
We didn't script inserting the Childcare Request Statuses, so the id that
we referenced in the .NET code did not coorespond to the correct status.

* Wrote script to drop current statuses and insert again with explicit ID's