### PR TITLE
US4167:Updated node-sass package

### DIFF
--- a/crossroads.net/package.json
+++ b/crossroads.net/package.json
@@ -58,7 +58,7 @@
     "karma-webpack": "^1.7.0",
     "ng-annotate-loader": "0.0.10",
     "ngtemplate-loader": "^1.0.0",
-    "node-sass": "~3.4.2",
+    "node-sass": "^3.7.0",
     "phantomjs-polyfill": "0.0.1",
     "protractor": "^2.0.0",
     "protractor-html-screenshot-reporter": "0.0.19",


### PR DESCRIPTION
crds-core was updated to allow for node-sass compilation at version 3.7 and beyond. This is simply updating the package to pull the most recent instead of locking you into 3.4.2.