### PR TITLE
Setup parameters on any RequiresAuthorization endpoints

### DIFF
--- a/Gateway/crds-angular/App_Start/SwaggerConfig.cs
+++ b/Gateway/crds-angular/App_Start/SwaggerConfig.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http;
 using System.Web.Http.Description;
@@ -243,6 +244,13 @@ namespace crds_angular
 
             if (isAuthorized && !allowAnonymous)
             {
+                // Setup parameters if the endpoint doesn't have any.  This prevents
+                // a null pointer exception when adding the new authorization parameter.
+                if (operation.parameters == null)
+                {
+                    operation.parameters = new List<Parameter>();
+                }
+
                 operation.parameters.Add(new Parameter
                 {
                     name = "Authorization",


### PR DESCRIPTION
This allows us to specify RequiresAuthorization on endpoints that have no parameters.