### PR TITLE
US-4419 Production Ready Images

### DIFF
--- a/crossroads.net/app/streaming/streaming.component.html
+++ b/crossroads.net/app/streaming/streaming.component.html
@@ -33,7 +33,7 @@
 
 <section class="current-series">
   <figure class="container text-center">
-    <img src="//ample.imgix.net/series-death-to-religion.jpg?dpr=2&h=600" alt="" class="img-responsive" />
+    <img data-src="//crds-cms-uploads.imgix.net/content/images/streaming--series-death-to-religion.jpg?dpr=2&h=600" alt="" class="img-responsive imgix-fluid" />
     <figcaption>Current Series</figcaption>
   </figure>
 
@@ -61,7 +61,7 @@
 
         <figure>
           <a href="#">
-            <img src="//s3.amazonaws.com/ample-useast/streaming/series-week1.jpg" alt="" class="img-responsive" />
+            <img data-src="//crds-cms-uploads.imgix.net/content/images/streaming--series-week1.jpg" alt="" class="img-responsive img-fluid" />
           </a>
           <figcaption><a href="#">Spark #2</a></figcaption>
         </figure>
@@ -74,7 +74,7 @@
 
       <article>
         <figure>
-          <a href="#"><img src="//s3.amazonaws.com/ample-useast/streaming/series-week2.jpg" alt="" class="img-responsive" /></a>
+          <a href="#"><img data-src="//crds-cms-uploads.imgix.net/content/images/streaming--series-week2.jpg" alt="" class="img-responsive img-fluid" /></a>
           <figcaption><a href="#">The Super bowl of preaching</a></figcaption>
         </figure>
         <section>
@@ -84,7 +84,7 @@
 
       <article>
         <figure>
-          <a href="#"><img src="//s3.amazonaws.com/ample-useast/streaming/series-week3.jpg" alt="" class="img-responsive" /></a>
+          <a href="#"><img data-src="//crds-cms-uploads.imgix.net/content/images/streaming--series-week3.jpg" alt="" class="img-responsive img-fluid" /></a>
           <figcaption><a href="#">Life Hacks (4)</a></figcaption>
         </figure>
         <section>
@@ -95,7 +95,7 @@
 
       <article>
         <figure>
-          <a href="#"><img src="//s3.amazonaws.com/ample-useast/streaming/series-week4.jpg" alt="" class="img-responsive" /></a>
+          <a href="#"><img data-src="//crds-cms-uploads.imgix.net/content/images/streaming--series-week4.jpg" alt="" class="img-responsive img-fluid" /></a>
           <figcaption><a href="#">James: Putting your faith to work #1</a></figcaption>
         </figure>
         <section>
@@ -114,23 +114,23 @@
     </header>
     <div class="row">
       <figure class="desktops">
-        <div><img src="//s3.amazonaws.com/ample-useast/streaming/watch-desktop.png" alt="" class="img-responsive" /></div>
+        <div><img data-src="//crds-cms-uploads.imgix.net/content/images/streaming--watch-desktop.png" alt="" class="img-responsive img-fluid" /></div>
         <figcaption>Laptops &amp; Desktop Computers</figcaption>
       </figure>
       <figure class="tvs">
-        <div><img src="//s3.amazonaws.com/ample-useast/streaming/watch-smart-tv.png" alt="" class="img-responsive" /></div>
+        <div><img data-src="//crds-cms-uploads.imgix.net/content/images/streaming--watch-smart-tv.png" alt="" class="img-responsive img-fluid" /></div>
         <figcaption>Smart TVs <span>(Web Capable)</span></figcaption>
       </figure>
       <figure class="tablets">
-        <div><img src="//s3.amazonaws.com/ample-useast/streaming/watch-mobile.png" alt="" class="img-responsive" /></div>
+        <div><img data-src="//crds-cms-uploads.imgix.net/content/images/streaming--watch-mobile.png" alt="" class="img-responsive img-fluid" /></div>
         <figcaption>Phones &amp; Tablets</figcaption>
       </figure>
       <figure class="roku">
-        <div><img src="//s3.amazonaws.com/ample-useast/streaming/watch-roku.png" alt="" class="img-responsive" /></div>
+        <div><img data-src="//crds-cms-uploads.imgix.net/content/images/streaming--watch-roku.png" alt="" class="img-responsive img-fluid" /></div>
         <figcaption>Roku</figcaption>
       </figure>
       <figure class="apple-tv">
-        <div><img src="//s3.amazonaws.com/ample-useast/streaming/watch-apple-tv.png" alt="" class="img-responsive" /></div>
+        <div><img data-src="//crds-cms-uploads.imgix.net/content/images/streaming--watch-apple-tv.png" alt="" class="img-responsive img-fluid" /></div>
         <figcaption>Apple TV <span>(Version 4)<br>Download app in App Store, search "Crossroads Anywhere"</span></figcaption>
       </figure>
     </div>

--- a/crossroads.net/styles/pages/streaming.scss
+++ b/crossroads.net/styles/pages/streaming.scss
@@ -1,5 +1,5 @@
 // TODO Replace w/ CRDS endpoint once we have images in production S3 bucket.
-$streaming-imgix-domain: '//ample.imgix.net';
+$streaming-imgix-domain: '//crds-cms-uploads.imgix.net/content/images';
 
 // NOTE These vars aren't assumed to be global yet, hence the `streaming` prefix.
 $streaming-font-semi_cond: "acumin-pro-semi-condensed", sans-serif;
@@ -167,7 +167,7 @@ streaming {
 
   .intro {
     @include crds-jumbotron();
-    background: #2E2E30 url("#{$streaming-imgix-domain}/anywhere-hero.jpg?w=1&crop=faces&dpr=2&fit=crop");
+    background: #2E2E30 url("#{$streaming-imgix-domain}/streaming--anywhere-hero.jpg?w=1&crop=faces&dpr=2&fit=crop");
     background-repeat: no-repeat;
     background-position: center center;
     background-size: cover;
@@ -358,7 +358,7 @@ streaming {
 
   .community {
     @include crds-jumbotron();
-    background: #1D3C50 url("#{$streaming-imgix-domain}/anywhere-map.jpg?w=1&dpr=2&fit=crop");
+    background: #1D3C50 url("#{$streaming-imgix-domain}/streaming--anywhere-map.jpg?w=1&dpr=2&fit=crop");
     background-repeat: no-repeat;
     background-position: center center;
     background-size: cover;


### PR DESCRIPTION
This PR delivers [US-4419](https://rally1.rallydev.com/#/41662702253d/detail/userstory/58984628724) by implementing production ready URLs for any image associated with the streaming landing page.

Since this work originated as a sub-branch of `feature/US4291-bootstrap-for-angular2` this PR is attempting to merge these updates back into that branch vs development. 

