### PR TITLE
Properly Display Error Messages

### DIFF
--- a/crossroads.net/app/childcare_dashboard/childcare_group/childcareDashboardGroup.controller.js
+++ b/crossroads.net/app/childcare_dashboard/childcare_group/childcareDashboardGroup.controller.js
@@ -83,9 +83,9 @@ class ChildcareDashboardGroupController {
       child.rsvpness = !status;
       // display an error message...
       if (err.statusCode === 412) {
-        this.root.$emit('notify', 'childcareRsvpFull');
+        this.root.$emit('notify', this.root.MESSAGES.childcareRsvpFull);
       } else {
-        this.root.$emit('notify', 'childcareRsvpError');
+        this.root.$emit('notify', this.root.MESSAGES.childcareRsvpError);
       }
     });
   }

--- a/crossroads.net/spec/childcare_dashboard/childcare_group/childcareGroup.controller.spec.js
+++ b/crossroads.net/spec/childcare_dashboard/childcare_group/childcareGroup.controller.spec.js
@@ -151,7 +151,7 @@ describe('Childcare Group Component Controller', () => {
 
     expect(childcareDashboardService.saveRSVP).toHaveBeenCalledWith(100030266, 1234 ,false);
     expect(controller.communityGroup.eligibleChildren[0].rsvpness).toBe(true);
-    expect(rootScope.$emit).toHaveBeenCalledWith('notify', 'childcareRsvpError');
+    expect(rootScope.$emit).toHaveBeenCalledWith('notify', rootScope.MESSAGES.childcareRsvpError);
   });
 
   it('should display an error when the capacity is reached', () => {
@@ -170,7 +170,7 @@ describe('Childcare Group Component Controller', () => {
 
     expect(childcareDashboardService.saveRSVP).toHaveBeenCalledWith(100030266, 1234 ,false);
     expect(controller.communityGroup.eligibleChildren[0].rsvpness).toBe(true);
-    expect(rootScope.$emit).toHaveBeenCalledWith('notify', 'childcareRsvpFull');
+    expect(rootScope.$emit).toHaveBeenCalledWith('notify', rootScope.MESSAGES.childcareRsvpFull);
 
   });
 

--- a/crossroads.net/spec/spec_index.js
+++ b/crossroads.net/spec/spec_index.js
@@ -7,6 +7,6 @@ import core from '../core/core';
 // Other modules needed to instantiate crossroads module not referenced in other tests already
 import search from '../app/search/search.module';
 import media from '../app/media/media.module';
-
+import formly from '../app/formlyBuilder/formlyBuilder.module';
 var testsContext = require.context('./', true, /.spec$/);
 testsContext.keys().forEach(testsContext);


### PR DESCRIPTION
We passing a string to the `$rootScope.$emit('notify')` method. Updated to pass a cms message.  