### PR TITLE
US4541: Evaluate Event Status

### DIFF
--- a/crossroads.net/app/streaming/countdown.component.ts
+++ b/crossroads.net/app/streaming/countdown.component.ts
@@ -6,9 +6,6 @@ import { Countdown } from './countdown';
 import { StreamspotService } from './streamspot.service';
 
 var moment = require('moment-timezone');
-//var moment = require('moment/min/moment.min.js');
-//declare var moment: any;
-
 declare var _: any;
 
 @Component({
@@ -32,7 +29,7 @@ declare var _: any;
       </div>
     </div>
   `,
-  providers: [StreamspotService, HTTP_PROVIDERS]
+  providers: [HTTP_PROVIDERS]
 })
 
 export class CountdownComponent implements OnInit {
@@ -51,12 +48,10 @@ export class CountdownComponent implements OnInit {
   }
 
   private createCountdown() {
-    this.streamspotService.getEvents().then(response => {
-      this.event = _.last(response);
-      this.subscriber = Observable
-                    .interval(1000)
-                    .subscribe(() => this.parseEvent());
-    })
+    this.streamspotService.nextEvent.subscribe((event: Event) => {
+      this.event = event;
+      this.subscriber = Observable.interval(1000).subscribe(() => this.parseEvent());
+    });
   }
 
   private pad(value:number): string {

--- a/crossroads.net/app/streaming/event.ts
+++ b/crossroads.net/app/streaming/event.ts
@@ -1,7 +1,7 @@
 var moment = require('moment-timezone');
 
 export class Event {
-  eventId:   number;
+  eventId:   any;
   dayOfYear: number;
   date:      any;
   deleted:   any;
@@ -9,12 +9,13 @@ export class Event {
   start:     any;
   end:       any;
   title:     string;
+  [key: string]: any;
 
   static asEvents(jsonArray: Array<Object>) {
     return jsonArray.map((jsonEvent: any) => Event.build(jsonEvent));
   }
 
-  static build(object: Object) {
+  static build(object: any) {
     var title: string = object['title'];
     var start: string = object['start'];
     var end: string = object['end'];

--- a/crossroads.net/app/streaming/event.ts
+++ b/crossroads.net/app/streaming/event.ts
@@ -1,3 +1,5 @@
+var moment = require('moment-timezone');
+
 export class Event {
   eventId:   number;
   dayOfYear: number;
@@ -9,21 +11,32 @@ export class Event {
   title:     string;
 
   static asEvents(jsonArray: Array<Object>) {
-    return jsonArray.map((jsonEvent: any) => Event.asEvent(jsonEvent));
+    return jsonArray.map((jsonEvent: any) => Event.build(jsonEvent));
   }
 
-  static asEvent(json: any) {
-    var id: number = json['eventId'];
-    var title: string = json['title'];
-    var start: string = json['start'];
-    var end: string = json['end'];
+  static build(object: Object) {
+    var title: string = object['title'];
+    var start: string = object['start'];
+    var end: string = object['end'];
     return new Event(title, start, end);
   }
 
   constructor(title: string, start: string, end: string) {
-    this.title = title;
-    this.start = start;
-    this.end = end;
+    this.title      = title;
+    this.start      = moment.tz(start, 'America/New_York');;
+    this.end        = moment.tz(end, 'America/New_York');
+    this.dayOfYear  = this.start.dayOfYear();
+    this.time       = this.start.format('LT [EST]');
+  }
+
+  isUpcoming() {
+    return moment().tz(moment.tz.guess()).isBefore(this.start);
+  }
+
+  isBroadcasting() {
+    let hasStarted = moment().tz(moment.tz.guess()).isAfter(this.start);
+    let hasNotEnded = moment().tz(moment.tz.guess()).isBefore(this.end);
+    return hasStarted && hasNotEnded;
   }
 
   json() {

--- a/crossroads.net/app/streaming/streaming.component.ts
+++ b/crossroads.net/app/streaming/streaming.component.ts
@@ -1,18 +1,26 @@
 import { Component } from '@angular/core';
 import { ScheduleComponent } from './schedule.component';
 import { CountdownComponent } from './countdown.component';
+import { StreamspotService } from './streamspot.service';
 
 var WOW = require('wow.js/dist/wow.min.js');
 
 @Component({
   selector: 'streaming',
   directives: [ScheduleComponent, CountdownComponent],
+  providers: [StreamspotService],
   templateUrl: './streaming.ng2component.html'
 })
 
 export class StreamingComponent {
-  displayStreamCTA: boolean = false;
-  constructor() {
+  inProgress: boolean = false;
+
+  constructor(private streamspotService: StreamspotService) {
+
+    this.streamspotService.isBroadcasting.subscribe((inProgress: boolean) => {
+      this.inProgress = inProgress;
+    });
+
     new WOW({
       offset: 100,
       mobile: false

--- a/crossroads.net/app/streaming/streaming.ng2component.html
+++ b/crossroads.net/app/streaming/streaming.ng2component.html
@@ -15,7 +15,7 @@
   <div class="wow fadeInUp">
     <h1>crossroads anywhere</h1>
     <p>Et possimus voluptas atque eos. Commodi eligendi nostrum cumque. Fugiat quae reprehenderit molestias et nihil facere.</p>
-    <p template="ngIf displayStreamCTA"><a href="#" class="btn btn-primary">Watch Now</a></p>
+    <p *ngIf="inProgress" class="wow fadeIn"><a href="#" class="btn btn-primary">Watch Now</a></p>
   </div>
 </section>
 

--- a/crossroads.net/app/streaming/streamspot.service.ts
+++ b/crossroads.net/app/streaming/streamspot.service.ts
@@ -39,8 +39,9 @@ export class StreamspotService {
       .toPromise()
       .catch(this.handleError)
       .then((response) => {
+        let events = response.json().data.events;
         return _
-          .chain(response.json().data.events)
+          .chain(events)
           .sortBy('start')
           .map((object:Event) => {
             // create event objects
@@ -53,6 +54,7 @@ export class StreamspotService {
           .value();
       })
       .then((events) => {
+        if(events.length == 0) return events;
         let event = _(events).first();
         // dispatch updates
         this.isBroadcasting.emit(event.isBroadcasting());

--- a/crossroads.net/app/streaming/streamspot.service.ts
+++ b/crossroads.net/app/streaming/streamspot.service.ts
@@ -1,4 +1,4 @@
-import { Injectable }    from '@angular/core';
+import { Injectable, EventEmitter } from '@angular/core';
 import { Headers, Http, Response } from '@angular/http';
 
 import 'rxjs/add/operator/toPromise';
@@ -22,37 +22,44 @@ export class StreamspotService {
     'x-API-Key': this.apiKey
   });
 
-  public isBroadcasting: boolean = false;
+  public isBroadcasting: EventEmitter<any> = new EventEmitter();
+  public nextEvent: EventEmitter<any> = new EventEmitter();
+  public events: Promise<Event[]>;
 
-  constructor(private http: Http) { }
+  constructor(private http: Http) {
+    this.events = this.getEvents();
+  }
 
   getEvents(): Promise<Event[]> {
     let url = `${this.url}broadcaster/${this.id}/events`;
     // let url = 'http://localhost:3000/app/streaming/events.json'
 
-    return this.http.get(url, {headers: this.headers})
+    return this.http
+      .get(url, {headers: this.headers})
       .toPromise()
-      .then(response => _.chain(response.json().data.events)
-        .sortBy('start')
-        .filter((event:Event) => {
-          // get upcoming or currently broadcasting events
-          let currentTimestamp = moment().tz(moment.tz.guess());
-          let eventStartTimestamp   = moment.tz(event.start, 'America/New_York');
-          let eventEndTimestamp   = moment.tz(event.end, 'America/New_York');
-          
-          return currentTimestamp.isBefore(eventStartTimestamp)
-                || (currentTimestamp.isAfter(eventStartTimestamp) && currentTimestamp.isBefore(eventEndTimestamp))
-        })
-        .map((event:Event) => {
-          event.start     = moment.tz(event.start, 'America/New_York');
-          event.end       = moment.tz(event.end, 'America/New_York');
-          event.dayOfYear = event.start.dayOfYear();
-          event.time      = event.start.format('LT [EST]');
-          return event;
-        })
-        .value()
-      )
-      .catch(this.handleError);
+      .catch(this.handleError)
+      .then((response) => {
+        return _
+          .chain(response.json().data.events)
+          .sortBy('start')
+          .map((object:Event) => {
+            // create event objects
+            return Event.build(object);
+          })
+          .filter((event:Event) => {
+            // return only current or upcoming events
+            return event.isBroadcasting() || event.isUpcoming();
+          })
+          .value();
+      })
+      .then((events) => {
+        let event = _(events).first();
+        // dispatch updates
+        this.isBroadcasting.emit(event.isBroadcasting());
+        this.nextEvent.emit(event);
+        return events;
+      })
+      ;
   }
 
   getEventsByDate(): Promise<Object[]> {

--- a/crossroads.net/spec-ts/streaming/countdown.component.spec.ts
+++ b/crossroads.net/spec-ts/streaming/countdown.component.spec.ts
@@ -10,12 +10,21 @@ import { CountdownComponent } from '../../app/streaming/countdown.component';
 
 var moment = require('moment-timezone');
 
+class MockStreamspotService extends StreamspotService {
+  constructor() {
+    super(null)
+  }
+  getEvents(): any {
+    return [];
+  }
+}
+
 describe('Component: Countdown', () => {
 
   beforeEach(() =>
     addProviders([
       HTTP_PROVIDERS,
-      { provide: StreamspotService, useClass: StreamspotService }
+      { provide: StreamspotService, useClass: MockStreamspotService }
     ])
   );
 

--- a/crossroads.net/spec-ts/streaming/countdown.component.spec.ts
+++ b/crossroads.net/spec-ts/streaming/countdown.component.spec.ts
@@ -38,7 +38,7 @@ describe('Component: Countdown', () => {
       let start = moment().add({ 'days': 2 }).format('YYYY-MM-DD HH:mm:ss');
       let end = moment().add({ 'days': 2 }).format('YYYY-MM-DD HH:mm:ss');
 
-      component.event = new Event('title', moment.tz(start,'America/New_York'), moment.tz(end,'America/New_York'));
+      component.event = new Event('title', start, end);
       component.parseEvent();
 
       expect(component.countdown.days).toBe('01');

--- a/crossroads.net/spec-ts/streaming/countdown.component.spec.ts
+++ b/crossroads.net/spec-ts/streaming/countdown.component.spec.ts
@@ -1,4 +1,5 @@
 import { provide } from '@angular/core';
+import { HTTP_PROVIDERS } from '@angular/http';
 import { describe, it, expect, inject, beforeEach, addProviders } from '@angular/core/testing';
 import { MockBackend, MockConnection } from '@angular/http/testing';
 import { TestComponentBuilder, ComponentFixture } from '@angular/compiler/testing';
@@ -13,6 +14,7 @@ describe('Component: Countdown', () => {
 
   beforeEach(() =>
     addProviders([
+      HTTP_PROVIDERS,
       { provide: StreamspotService, useClass: StreamspotService }
     ])
   );

--- a/crossroads.net/spec-ts/streaming/countdown.component.spec.ts
+++ b/crossroads.net/spec-ts/streaming/countdown.component.spec.ts
@@ -44,7 +44,6 @@ describe('Component: Countdown', () => {
       expect(component.countdown.days).toBe('01');
       expect(component.countdown.hours).toBe('23');
       expect(component.countdown.minutes).toBe('59');
-      expect(component.countdown.seconds).toBe('59');
     });
   }));
 

--- a/crossroads.net/spec-ts/streaming/event.spec.ts
+++ b/crossroads.net/spec-ts/streaming/event.spec.ts
@@ -11,7 +11,7 @@ describe('Object: Event', () => {
   };
 
   it('should return json', () => {
-    let e = new Event('title', 'start', 'end');
+    let e = new Event('title', '2016-07-13 05:01:29', '2016-07-13 07:01:29');
     expect(e.json()).toBeTruthy();
   });
 

--- a/crossroads.net/spec-ts/streaming/event.spec.ts
+++ b/crossroads.net/spec-ts/streaming/event.spec.ts
@@ -16,7 +16,7 @@ describe('Object: Event', () => {
   });
 
   it('should consume json and return an event object', () => {
-    let event = Event.asEvent(eventJson);
+    let event = Event.build(eventJson);
     expect(event instanceof Event).toBeTruthy();
     expect(event.title).toBe('Testing');
   });

--- a/crossroads.net/spec-ts/streaming/event.spec.ts
+++ b/crossroads.net/spec-ts/streaming/event.spec.ts
@@ -1,5 +1,6 @@
 import { Event } from '../../app/streaming/event';
 var _ = require('lodash');
+var moment = require('moment/min/moment.min');
 
 describe('Object: Event', () => {
 
@@ -27,6 +28,18 @@ describe('Object: Event', () => {
       expect(event instanceof Event).toBeTruthy();
     });
     expect(events.length).toBe(3);
+  });
+
+  it('should evaluate whether an event is underway', () => {
+    let date = moment();
+    let event = new Event('Some Event', date.add({ 'hours': -1 }).format('YYYY-MM-DD HH:mm:ss'), date.add({ 'hours': 2 }).format('YYYY-MM-DD HH:mm:ss'))
+    expect(event.isBroadcasting()).toBeTruthy();
+  });
+
+  it('should evaluate whether an event is upcoming', () => {
+    let date = moment().add({ 'days': 1 });
+    let event = new Event('Some Event', date.add({ 'hours': -1 }).format('YYYY-MM-DD HH:mm:ss'), date.add({ 'hours': 2 }).format('YYYY-MM-DD HH:mm:ss'))
+    expect(event.isUpcoming()).toBeTruthy();
   });
 
 });

--- a/crossroads.net/spec-ts/streaming/streaming.component.spec.ts
+++ b/crossroads.net/spec-ts/streaming/streaming.component.spec.ts
@@ -1,20 +1,24 @@
 /* tslint:disable:no-unused-variable */
 
-import { By }           from '@angular/platform-browser';
+import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
-
-import {
-  beforeEach, beforeEachProviders,
-  describe, xdescribe,
-  expect, it, xit,
-  async, inject
-} from '@angular/core/testing';
+import { HTTP_PROVIDERS } from '@angular/http';
+import { beforeEach, describe, it, addProviders } from '@angular/core/testing';
 
 import { StreamingComponent } from '../../app/streaming/streaming.component';
+import { StreamspotService } from '../../app/streaming/streamspot.service';
 
 describe('Component: Streaming', () => {
+
+  beforeEach(() =>
+    addProviders([
+      HTTP_PROVIDERS,
+      { provide: StreamspotService, useClass: StreamspotService }
+    ])
+  );
+
   it('should create an instance', () => {
-    let component = new StreamingComponent();
-    expect(component).toBeTruthy();
+    // let component = new StreamingComponent();
+    // expect(component).toBeTruthy();
   });
 });

--- a/crossroads.net/spec-ts/streaming/streaming.component.spec.ts
+++ b/crossroads.net/spec-ts/streaming/streaming.component.spec.ts
@@ -8,17 +8,28 @@ import { beforeEach, describe, it, addProviders } from '@angular/core/testing';
 import { StreamingComponent } from '../../app/streaming/streaming.component';
 import { StreamspotService } from '../../app/streaming/streamspot.service';
 
+
+class MockStreamspotService extends StreamspotService {
+  constructor() {
+    super(null)
+  }
+  getEvents(): any {
+    return [];
+  }
+}
+
 describe('Component: Streaming', () => {
 
-  beforeEach(() =>
+  beforeEach(() => {
     addProviders([
       HTTP_PROVIDERS,
-      { provide: StreamspotService, useClass: StreamspotService }
+      { provide: StreamspotService, useClass: MockStreamspotService }
     ])
-  );
+  });
 
   it('should create an instance', () => {
-    // let component = new StreamingComponent();
-    // expect(component).toBeTruthy();
+    let service = new MockStreamspotService();
+    let component = new StreamingComponent(service);
+    expect(component).toBeTruthy();
   });
 });

--- a/crossroads.net/spec-ts/streaming/streamspot.service.spec.ts
+++ b/crossroads.net/spec-ts/streaming/streamspot.service.spec.ts
@@ -71,14 +71,15 @@ describe('Service: StreamspotService', () => {
 
   it('should return upcoming events, grouped by DOY', () => {
     service.getEventsByDate().then((events: Event[]) => {
-        let idx = Object.keys(events)[0];
+        let idx: number = parseInt(Object.keys(events)[0]);
+        let event: any = _.first(events[idx]);
 
         expect(events instanceof Object).toBeTruthy();
         // test for numeric keys
-        expect(parseInt(idx)).toEqual(jasmine.any(Number));
+        expect(idx).toEqual(jasmine.any(Number));
         // test for order
-        expect(_.first(events[idx]).title).toBe('Next event');
+        expect(event.title).toBe('Next event');
       })
   });
-  
+
 })


### PR DESCRIPTION
This PR refactors the `streamspot.service.ts` by implementing a couple EventEmitter objects. This way, the service can be utilized as a singleton so we can listen for the successful promise resolution from more than one location.

/cc @samueljmello 