### PR TITLE
US4454 Refactor Schedule to Content Blocks

### DIFF
--- a/crossroads.net/app/streaming/streaming.component.ts
+++ b/crossroads.net/app/streaming/streaming.component.ts
@@ -6,6 +6,7 @@ import { StreamspotService } from './streamspot.service';
 import { DynamicContentNg2Component } from '../../core/dynamic_content/dynamic-content-ng2.component'
 
 var WOW = require('wow.js/dist/wow.min.js');
+var $:any = require('jquery');
 
 @Component({
   selector: 'streaming',
@@ -27,5 +28,12 @@ export class StreamingComponent {
       offset: 100,
       mobile: false
     }).init();
+  }
+
+  scrollToSchedule() {
+    $('html, body').animate({
+      scrollTop: $('schedule').offset().top
+    }, 1000);
+    return false;
   }
 }

--- a/crossroads.net/app/streaming/streaming.ng2component.html
+++ b/crossroads.net/app/streaming/streaming.ng2component.html
@@ -1,6 +1,6 @@
 <section class="navbar-section">
   <div class="container wow fadeIn">
-    <a href="#series" class="btn see-schedule">
+    <a href="#" class="btn see-schedule" (click)="scrollToSchedule()">
       See Schedule
       <svg viewBox="0 0 32 32" class="icon icon-arrow-down9">
 	      <use xlink:href="#arrow-down9"></use>

--- a/crossroads.net/e2e/streaming/schedule.e2e.js
+++ b/crossroads.net/e2e/streaming/schedule.e2e.js
@@ -1,0 +1,28 @@
+var env = require("../environment");
+
+describe('Streaming landing', function() {
+
+  beforeEach(function () {
+    browser.get(env.baseUrl + '/#/live');
+    browser.ignoreSynchronization = true;
+  });
+
+  it('should render link to see schedule', function() {
+    var scheduleBtn = element.all(by.css('streaming')).all(by.css('.see-schedule'));
+    expect(scheduleBtn.isDisplayed()).toBeTruthy()
+  });
+
+  it('should scroll to schedule content', function() {
+    browser.executeScript('return document.body.scrollTop').then(function(scrollTop){
+      expect(scrollTop).toBe(0);
+      var scheduleBtn = element.all(by.css('streaming')).all(by.css('.see-schedule'));
+          scheduleBtn.click();
+
+      browser.sleep(2000); // wait for animation
+      browser.executeScript('return document.body.scrollTop').then(function(scrollTop){
+        expect(scrollTop > 0).toBeTruthy();
+      });
+    });
+  });
+
+});

--- a/crossroads.net/styles/pages/streaming.scss
+++ b/crossroads.net/styles/pages/streaming.scss
@@ -64,8 +64,12 @@ streaming {
       position: absolute;
       right: 0;
       display: none;
+
       @media (min-width: $screen-xs-min) {
         display: block;
+      }
+      @media (max-width: $screen-sm-min) {
+        margin-top: -5px;
       }
     }
 
@@ -107,6 +111,9 @@ streaming {
           font-weight: 100;
           position: relative;
           top: -0.25em;
+          @media only screen and (max-width:  $screen-xs-min){
+            display: none;
+          }
         }
       }
 
@@ -169,7 +176,10 @@ streaming {
     }
 
     h1 {
-      font-size: 338%;
+      font-size: 238%;
+      @media (min-width: $screen-md-min) {
+        font-size: 338%;
+      }
       line-height: 100%;
       margin-bottom: 0.5em;
     }

--- a/crossroads.net/typings.json
+++ b/crossroads.net/typings.json
@@ -2,6 +2,7 @@
   "globalDependencies": {
     "core-js": "registry:dt/core-js#0.0.0+20160317120654",
     "jasmine": "registry:dt/jasmine#2.2.0+20160505161446",
+    "jquery": "registry:dt/jquery#1.10.0+20160704162008",
     "node": "registry:dt/node#6.0.0+20160613154055"
   }
 }


### PR DESCRIPTION
This PR delivers updates that should resolve @bzmillerboy's comments on [US4454](https://rally1.rallydev.com/#/41662702253d/detail/userstory/59153053473).

I've added a couple E2E specs that pass locally using Chrome & v2.53.1 of Selenium's Standalone web-driver. I have not committed any updates to `protractor.conf.js` for fear it would have implications on the build process. Let me know if you'd prefer those updates be included here as well. 