### PR TITLE
US4619 - Add the correct link from My Groups to Lead a Group page

### DIFF
--- a/crossroads.net/app/group_tool/my_groups/myGroups.html
+++ b/crossroads.net/app/group_tool/my_groups/myGroups.html
@@ -29,7 +29,7 @@
             </div>
 
             <div ng-class="{ 'col-md-6 col-sm-12': myGroups.groupsEven() }">
-              <div class="my-groups-static panel panel-default text-center">
+              <div class="my-groups-static panel panel-default text-center pointer" ui-sref="grouptool.create">
                 <div class="my-groups-static-vert">
                   <div>Lead a Group</div>
                   <svg viewBox="0 0 32 32" class="icon plus4 text-primary">


### PR DESCRIPTION
The target link `/groups/create` will automatically redirect non-leaders to the Leadership Training page