### PR TITLE
US4617 - Rename My Group page group cards "View Invites" button

### DIFF
--- a/crossroads.net/app/group_tool/my_groups/group_card/groupCard.html
+++ b/crossroads.net/app/group_tool/my_groups/group_card/groupCard.html
@@ -56,7 +56,7 @@
             <svg viewBox="0 0 32 32" class="icon icon-user6">
               <use xlink:href="#user6"></use>
             </svg>
-            View Invites
+            View Requests
           </button>
         </div>
 

--- a/crossroads.net/styles/modules/group-cards.scss
+++ b/crossroads.net/styles/modules/group-cards.scss
@@ -58,6 +58,18 @@ group-card {
   }
 
   .group-card-buttons {
+    .btn {
+      // Adjust group card button text for medium size where the text is overlapping the button at 100%
+      @media (min-width: $screen-md-min) and (max-width: $screen-lg-min) {
+        font-size: 92%;
+      }
+    }
+
+    // Adjust the vertical centering of the button icons to line up with the button text
+    svg {
+      margin-bottom: 3px;
+    }
+
     .row {
       margin-left: -8px;
       margin-right: -8px;


### PR DESCRIPTION
* Rename "View Invites" to "View Requests"
* Adjust font size on card buttons from @media (max-width: 1200px) and (min-width: 992px) so that "View Requests" will fit in the button and look correct
* Adjust button icon vertical centering