### PR TITLE
US4618 - Disable the find a group tool on the My Groups page until Aug 27

### DIFF
--- a/crossroads.net/app/group_tool/my_groups/myGroups.html
+++ b/crossroads.net/app/group_tool/my_groups/myGroups.html
@@ -17,27 +17,32 @@
 
         <div ng-class="{ 'col-md-12 col-sm-12': myGroups.groupsEven(), 'col-md-6 col-sm-12': myGroups.groupsOdd() }">
           <div ng-class="{ 'row': myGroups.groupsEven() }">
-            <div ng-class="{ 'col-md-6 col-sm-12': myGroups.groupsEven() }">
-              <div class="my-groups-static panel panel-default text-center">
-                <div class="my-groups-static-vert">
-                  <div>Find a Group</div>
-                  <svg viewBox="0 0 32 32" class="icon search3 text-primary">
-                    <use xlink:href="#search3"></use>
-                  </svg>
-                </div>
-              </div>
-            </div>
 
+            <!-- Lead a Group -->
             <div ng-class="{ 'col-md-6 col-sm-12': myGroups.groupsEven() }">
               <div class="my-groups-static panel panel-default text-center pointer" ui-sref="grouptool.create">
                 <div class="my-groups-static-vert">
-                  <div>Lead a Group</div>
+                  <div class="push-half-bottom">Lead a Group</div>
                   <svg viewBox="0 0 32 32" class="icon plus4 text-primary">
                     <use xlink:href="#plus4"></use>
                   </svg>
                 </div>
               </div>
             </div>
+
+            <!-- Find a Group -->
+            <div ng-class="{ 'col-md-6 col-sm-12': myGroups.groupsEven() }">
+              <div class="my-groups-static panel panel-default text-center">
+                <div class="my-groups-static-vert">
+                  <div>Find a Group</div>
+                  <div class="find-disabled">Available on Saturday, August 27</div>
+                  <svg viewBox="0 0 32 32" class="icon search3 find-disabled">
+                    <use xlink:href="#search3"></use>
+                  </svg>
+                </div>
+              </div>
+            </div>
+
           </div>
         </div>
 

--- a/crossroads.net/styles/modules/group-cards.scss
+++ b/crossroads.net/styles/modules/group-cards.scss
@@ -36,6 +36,16 @@ my-groups {
       width: 65px;
       height: 65px;
     }
+
+    // Find a Group disabled until Aug 27
+    div.find-disabled {
+      font-weight: normal;
+      margin-top: -5px;
+    }
+
+    svg.find-disabled {
+      color: $gray-lighter;
+    }
   }
 
   .my-groups-links {


### PR DESCRIPTION
* The order of the Lead a Group and Find a Group tools has been temporarily reversed
* The Find a Group tool has text explaining it is not yet available
* The Find a Group icon appears disabled

![image](https://cloud.githubusercontent.com/assets/2341619/17368134/d1731b80-5960-11e6-87b2-bb778b490be1.png)
