### PR TITLE
Feature/us4573 create ng2 cms api service

### DIFF
--- a/crossroads.net/app/childcare_dashboard/childcare_group/childcareGroup.html
+++ b/crossroads.net/app/childcare_dashboard/childcare_group/childcareGroup.html
@@ -17,8 +17,7 @@
     <li ng-show="childcareGroup.hasEligibleChildren() && !childcareGroup.isEventCancelled()"
         ng-repeat="child in childcareGroup.communityGroup.eligibleChildren"
         class="list-group-item form-group">
-      {{child.childName}} 
-      <span ng-if = "!child.eligible" class= "pull-right" dynamic-content='$root.MESSAGES.childexceedsMaxAge.content | html'></span> 
+      {{child.childName}}
       <toggle-switch
         ng-if = "child.eligible"
         ng-model="child.rsvpness"
@@ -26,7 +25,9 @@
         off-label="No"
         class="pull-right"
         ng-click="childcareGroup.validateAndRsvp(child, child.rsvpness)" >
-      <toggle-switch>  
+      </toggle-switch>
+      <span ng-if="!child.eligible" class="pull-right hidden-xs hidden-sm" dynamic-content='$root.MESSAGES.childexceedsMaxAge.content | html'></span>
+      <div ng-if="!child.eligible" class="hidden-md hidden-lg" dynamic-content='$root.MESSAGES.childexceedsMaxAge.content | html'></div>
     </li>
   </ul>
 </div>

--- a/crossroads.net/app/downgrades.ts
+++ b/crossroads.net/app/downgrades.ts
@@ -1,5 +1,6 @@
 import { upgradeAdapter } from './upgrade-adapter';
 import { Ng2TestComponent } from './ng2test/ng2test.component';
+import { Ng2TestCMSDataComponent } from './ng2test/ng2testcmsdata.component';
 import { StreamingComponent } from './streaming/streaming.component';
 import { DynamicContentNg2Component } from '../core/dynamic_content/dynamic-content-ng2.component';
 import { ContentMessageService } from '../core/services/contentMessage.service';
@@ -10,6 +11,7 @@ declare let angular:any;
 
 angular.module('crossroads')
     .directive('ng2Test', upgradeAdapter.downgradeNg2Component(Ng2TestComponent))
+    .directive('ng2TestCmsData', upgradeAdapter.downgradeNg2Component(Ng2TestCMSDataComponent))
     .directive('streaming', upgradeAdapter.downgradeNg2Component(StreamingComponent))
     .directive('dynamic-content-ng2', upgradeAdapter.downgradeNg2Component(DynamicContentNg2Component))
     .directive('streamingVideo', upgradeAdapter.downgradeNg2Component(VideoComponent))

--- a/crossroads.net/app/ng2test/ng2testcmsdata.component.ts
+++ b/crossroads.net/app/ng2test/ng2testcmsdata.component.ts
@@ -1,0 +1,45 @@
+import { Component, OnInit } from '@angular/core';
+import { CMSDataService } from '../../core/services/CMSData.service'
+
+@Component({
+  selector: 'ng2-test-cms-data',
+  template: `
+    <h1>{{someText}}</h1>
+    <h2>First Series in DB</h2>
+    <p>{{cmsSeriesTitle}}</p>
+    <h2>Series Title by Search</h2>
+    <p>{{cmsGotSeriesByTitle}}</p>
+    `,
+  providers: [CMSDataService]
+})
+
+export class Ng2TestCMSDataComponent implements OnInit {
+  someText: string;
+  cmsSeriesTitle: string;
+  cmsGotSeriesByTitle: string;
+  
+  constructor(private cmsDataService: CMSDataService) {
+    this.someText = "Content from CMS"
+  }
+
+  getFirstServiceFromCms(id: number) {
+    return this.cmsDataService.getSeriesById(id)
+                              .subscribe((response) => { 
+                                this.cmsSeriesTitle = response.json().series.title;
+                                console.log(response.json());
+                              });
+  }
+
+  getSeriesByTitle(title: string) {
+    return this.cmsDataService.getSeriesByTitle(title)
+                              .subscribe((response) => {
+                                console.log(response.json().series);
+                              })
+  }
+
+  ngOnInit() {
+    this.getFirstServiceFromCms(1);
+    this.getSeriesByTitle("Dollars, Sense and Sensibility");
+  }
+}
+

--- a/crossroads.net/app/ng2test/ng2testcmsdata.component.ts
+++ b/crossroads.net/app/ng2test/ng2testcmsdata.component.ts
@@ -17,29 +17,43 @@ export class Ng2TestCMSDataComponent implements OnInit {
   someText: string;
   cmsSeriesTitle: string;
   cmsGotSeriesByTitle: string;
+  cmsGot4Messages: any;
   
   constructor(private cmsDataService: CMSDataService) {
     this.someText = "Content from CMS"
   }
 
+  // returns JavaScript Series Object
   getFirstServiceFromCms(id: number) {
     return this.cmsDataService.getSeriesById(id)
                               .subscribe((response) => { 
-                                this.cmsSeriesTitle = response.json().series.title;
-                                console.log(response.json());
+                                this.cmsSeriesTitle = response.json();
+                                console.log(response.json().series);
                               });
   }
 
+  // returns first Object in an array of JavaScript Series Objects
   getSeriesByTitle(title: string) {
     return this.cmsDataService.getSeriesByTitle(title)
                               .subscribe((response) => {
-                                console.log(response.json().series);
+                                this.cmsGotSeriesByTitle = response.json().series.shift;
+                                console.log(response.json().series.shift());
+                              })
+  }
+
+  // returns an array of 4 Message Objects
+  getMostRecent4Messages() {
+    return this.cmsDataService.getMostRecent4Messages()
+                              .subscribe((response) => {
+                                this.cmsGot4Messages = response.json().messages;
+                                console.log(response.json().messages);
                               })
   }
 
   ngOnInit() {
     this.getFirstServiceFromCms(1);
     this.getSeriesByTitle("Dollars, Sense and Sensibility");
+    this.getMostRecent4Messages();
   }
 }
 

--- a/crossroads.net/app/ng2test/ng2testcmsdata.component.ts
+++ b/crossroads.net/app/ng2test/ng2testcmsdata.component.ts
@@ -9,6 +9,8 @@ import { CMSDataService } from '../../core/services/CMSData.service'
     <p>{{cmsSeriesTitle}}</p>
     <h2>Series Title by Search</h2>
     <p>{{cmsGotSeriesByTitle}}</p>
+    <h2>Current Series</h2>
+    <p>{{currentSeries}}</p>
     `,
   providers: [CMSDataService]
 })
@@ -18,6 +20,7 @@ export class Ng2TestCMSDataComponent implements OnInit {
   cmsSeriesTitle: string;
   cmsGotSeriesByTitle: string;
   cmsGot4Messages: any;
+  currentSeries: any;
   
   constructor(private cmsDataService: CMSDataService) {
     this.someText = "Content from CMS"
@@ -50,10 +53,19 @@ export class Ng2TestCMSDataComponent implements OnInit {
                               })
   }
 
+  getCurrentSeries() {
+    return this.cmsDataService.getCurrentSeries()
+                              .subscribe((response) => {
+                                this.currentSeries = response.json().series.shift;
+                                console.log("The current Series is: " + response.json().series.shift());
+                              })
+  }
+
   ngOnInit() {
     this.getFirstServiceFromCms(1);
     this.getSeriesByTitle("Dollars, Sense and Sensibility");
     this.getMostRecent4Messages();
+    this.getCurrentSeries();
   }
 }
 

--- a/crossroads.net/app/ng2test/ng2testcmsdata.component.ts
+++ b/crossroads.net/app/ng2test/ng2testcmsdata.component.ts
@@ -1,70 +1,30 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Output } from '@angular/core';
 import { CMSDataService } from '../../core/services/CMSData.service'
 
 @Component({
   selector: 'ng2-test-cms-data',
   template: `
-    <h1>{{someText}}</h1>
-    <h2>First Series in DB</h2>
-    <p>{{cmsSeriesTitle}}</p>
-    <h2>Series Title by Search</h2>
-    <p>{{cmsGotSeriesByTitle}}</p>
-    <h2>Current Series</h2>
-    <p>{{currentSeries}}</p>
+      <h1>Current Series</h1>
+      <p>{{currentSeries.title}}</p>
     `,
   providers: [CMSDataService]
 })
 
 export class Ng2TestCMSDataComponent implements OnInit {
-  someText: string;
-  cmsSeriesTitle: string;
-  cmsGotSeriesByTitle: string;
-  cmsGot4Messages: any;
-  currentSeries: any;
+  @Output() currentSeries;
   
   constructor(private cmsDataService: CMSDataService) {
-    this.someText = "Content from CMS"
-  }
-
-  // returns JavaScript Series Object
-  getFirstServiceFromCms(id: number) {
-    return this.cmsDataService.getSeriesById(id)
-                              .subscribe((response) => { 
-                                this.cmsSeriesTitle = response.json();
-                                console.log(response.json().series);
-                              });
-  }
-
-  // returns first Object in an array of JavaScript Series Objects
-  getSeriesByTitle(title: string) {
-    return this.cmsDataService.getSeriesByTitle(title)
-                              .subscribe((response) => {
-                                this.cmsGotSeriesByTitle = response.json().series.shift;
-                                console.log(response.json().series.shift());
-                              })
-  }
-
-  // returns an array of 4 Message Objects
-  getMostRecent4Messages() {
-    return this.cmsDataService.getMostRecent4Messages()
-                              .subscribe((response) => {
-                                this.cmsGot4Messages = response.json().messages;
-                                console.log(response.json().messages);
-                              })
+    this.currentSeries = {};
   }
 
   getCurrentSeries() {
-    return this.cmsDataService.getCurrentSeries()
+    this.cmsDataService.getCurrentSeries()
                               .subscribe((response) => {
-                                this.currentSeries = response.json().series.shift;
-                                console.log("The current Series is: " + response.json().series.shift());
+                                this.currentSeries = response;
                               })
   }
 
   ngOnInit() {
-    this.getFirstServiceFromCms(1);
-    this.getSeriesByTitle("Dollars, Sense and Sensibility");
-    this.getMostRecent4Messages();
     this.getCurrentSeries();
   }
 }

--- a/crossroads.net/app/routes.js
+++ b/crossroads.net/app/routes.js
@@ -379,6 +379,17 @@
             }
           }
         })
+        .state('ng2testcmsdata', {
+          parent: 'noHeaderOrFooter',
+          url: '/ng2testcmsdata',
+          template: '<ng2-test-cms-data></ng2-test-cms-data>',
+          data: {
+            meta: {
+              title: 'Ng2TestCMSData',
+              description: ''
+            }
+          }
+        })
         .state('live', {
           parent: 'screenWidth',
           url: '/live',

--- a/crossroads.net/core/services/CMSData.service.ts
+++ b/crossroads.net/core/services/CMSData.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Rx';
+import { Headers, Http } from '@angular/http';
+import { Subject } from 'rxjs/Subject';
+
+@Injectable()
+export class CMSDataService {
+    private apiSeriesUrl = 'contentint.crossroads.net/api/series/1'
+
+    constructor(private http: Http) { }
+    
+    getFirstInSeries() {
+        return this.http.get(this.apiSeriesUrl)
+                            .map(response => response.json());
+    }
+}

--- a/crossroads.net/core/services/CMSData.service.ts
+++ b/crossroads.net/core/services/CMSData.service.ts
@@ -5,9 +5,19 @@ import { Subject } from 'rxjs/Subject';
 
 @Injectable()
 export class CMSDataService {
+    // TODO: Inquire about what the appropriate apiUrl is.
     private apiUrl = 'https://contentint.crossroads.net/api/'
 
     constructor(private http: Http) { }
+    
+    // TODO: Consider this design. Is it best practice to just provide an Observable
+    // or should the service go one step further an provider the single object/
+    // array of objects that is used by the component?
+    
+    getCurrentSeries() {
+        let todaysDate = new Date().toISOString().slice(0, 10);
+        return this.http.get(encodeURI(this.apiUrl + `series?startDate__LessThan=${todaysDate}&endDate__GreaterThan=${todaysDate}&endDate__sort=ASC`));
+    }
     
     getSeriesById(id: number) {
         return this.http.get(encodeURI(this.apiUrl + `series/${id}`));
@@ -23,12 +33,5 @@ export class CMSDataService {
 
     getMostRecent4Messages() {
         return this.http.get(encodeURI(this.apiUrl + `messages?date__sort=DESC&__limit[]=4`));
-    }
-
-    getCurrentSeries() {
-        let currentSeriesGrouping =  this.http.get(encodeURI(this.apiUrl + `series?startDate__LessThan=${Date.now()}&endDate__GreaterThan=${Date.new()}&endDate__sort=ASC`));
-        // TODO: currentSeries is an observable, not an array. Need to figure out how
-        // to get the first element in this response as it is the "current series"
-        let currentSeries = currentSeriesGrouping.shift();
     }
 }

--- a/crossroads.net/core/services/CMSData.service.ts
+++ b/crossroads.net/core/services/CMSData.service.ts
@@ -53,8 +53,8 @@ export class CMSDataService {
                         .map(rsp => {return rsp.json().features});
     }
 
-    getContentBlock(title:string) {
-        return this.http.get(encodeURI(__CMS_ENDPOINT__ + `api/contentblock?title=${title}`))
+    getContentBlock(queryString:string) {
+        return this.http.get(encodeURI(__CMS_ENDPOINT__ + `api/contentblock?${queryString}`))
                         .map(rsp => {return rsp.json().contentblocks[0]});
     }
 

--- a/crossroads.net/core/services/CMSData.service.ts
+++ b/crossroads.net/core/services/CMSData.service.ts
@@ -10,18 +10,18 @@ export class CMSDataService {
     constructor(private http: Http) { }
     
     getSeriesById(id: number) {
-        return this.http.get(this.apiUrl + `series/${id}`)
+        return this.http.get(encodeURI(this.apiUrl + `series/${id}`));
     }
 
     getSeriesByTitle(title: string) {
-        return this.http.get(this.apiUrl + `series?title=${title}`)
+        return this.http.get(encodeURI(this.apiUrl + `series?title=${title}`));
     }
 
     getMessageByTitle(title: string) {
-        return this.http.get(this.apiUrl + `messages?title=${title}`)
+        return this.http.get(encodeURI(this.apiUrl + `messages?title=${title}`));
     }
 
     getMostRecent4Messages() {
-        return this.http.get(this.apiUrl + `messages?date__sort=DESC&__limit[]=4`)
+        return this.http.get(encodeURI(this.apiUrl + `messages?date__sort=DESC&__limit[]=4`));
     }
 }

--- a/crossroads.net/core/services/CMSData.service.ts
+++ b/crossroads.net/core/services/CMSData.service.ts
@@ -24,4 +24,11 @@ export class CMSDataService {
     getMostRecent4Messages() {
         return this.http.get(encodeURI(this.apiUrl + `messages?date__sort=DESC&__limit[]=4`));
     }
+
+    getCurrentSeries() {
+        let currentSeriesGrouping =  this.http.get(encodeURI(this.apiUrl + `series?startDate__LessThan=${Date.now()}&endDate__GreaterThan=${Date.new()}&endDate__sort=ASC`));
+        // TODO: currentSeries is an observable, not an array. Need to figure out how
+        // to get the first element in this response as it is the "current series"
+        let currentSeries = currentSeriesGrouping.shift();
+    }
 }

--- a/crossroads.net/core/services/CMSData.service.ts
+++ b/crossroads.net/core/services/CMSData.service.ts
@@ -5,12 +5,23 @@ import { Subject } from 'rxjs/Subject';
 
 @Injectable()
 export class CMSDataService {
-    private apiSeriesUrl = 'contentint.crossroads.net/api/series/1'
+    private apiUrl = 'https://contentint.crossroads.net/api/'
 
     constructor(private http: Http) { }
     
-    getFirstInSeries() {
-        return this.http.get(this.apiSeriesUrl)
-                            .map(response => response.json());
+    getSeriesById(id: number) {
+        return this.http.get(this.apiUrl + `series/${id}`)
+    }
+
+    getSeriesByTitle(title: string) {
+        return this.http.get(this.apiUrl + `series?title=${title}`)
+    }
+
+    getMessageByTitle(title: string) {
+        return this.http.get(this.apiUrl + `messages?title=${title}`)
+    }
+
+    getMostRecent4Messages() {
+        return this.http.get(this.apiUrl + `messages?date__sort=DESC&__limit[]=4`)
     }
 }

--- a/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
+++ b/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
@@ -102,10 +102,11 @@ describe('Service: CMSData', () => {
       [CMSDataService, MockBackend],
       fakeAsync((service: CMSDataService, backend: MockBackend) => {
         backend.connections.subscribe((connection: MockConnection) => {
-
+          let todaysDate = new Date().toISOString().slice(0, 10)
+          
           expect(connection.request.method).toBe(RequestMethod.Get);
           expect(connection.request.url).toBe(
-            `https://contentint.crossroads.net/api/series?startDate__LessThan${Date.now()}&endDate__GreaterThan${Date.now()}`);
+            `https://contentint.crossroads.net/api/series?startDate__LessThan=${todaysDate}&endDate__GreaterThan=${todaysDate}&endDate__sort=ASC`);
         });
 
         service.getCurrentSeries();
@@ -113,4 +114,3 @@ describe('Service: CMSData', () => {
 
 
 });
-

--- a/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
+++ b/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
@@ -97,6 +97,20 @@ describe('Service: CMSData', () => {
         service.getMostRecent4Messages();
       })));
 
+  it('should use an HTTP call to obtain the current series',
+    inject(
+      [CMSDataService, MockBackend],
+      fakeAsync((service: CMSDataService, backend: MockBackend) => {
+        backend.connections.subscribe((connection: MockConnection) => {
+
+          expect(connection.request.method).toBe(RequestMethod.Get);
+          expect(connection.request.url).toBe(
+            `https://contentint.crossroads.net/api/series?startDate__LessThan${Date.now()}&endDate__GreaterThan${Date.now()}`);
+        });
+
+        service.getCurrentSeries();
+      })));
+
 
 });
 

--- a/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
+++ b/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
@@ -1,41 +1,102 @@
 /* tslint:disable:no-unused-variable */
-
-import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
-import { Http, HTTP_PROVIDERS } from '@angular/http';
 import { provide } from '@angular/core';
+import {
+  ResponseOptions,
+  Response,
+  Http,
+  BaseRequestOptions,
+  RequestMethod
+} from '@angular/http';
+
 import {
   describe,
   expect,
-  beforeEach,
   it,
   inject,
-  async,
-  beforeEachProviders  
+  fakeAsync,
+  beforeEachProviders
 } from '@angular/core/testing';
 
-import { CMSDataService } from '../../../core/services/CMSData.service'
+import { MockBackend, MockConnection } from '@angular/http/testing';
+
+import { CMSDataService } from '../../../core/services/CMSData.service';
+
+const mockHttpProvider = {
+  deps: [ MockBackend, BaseRequestOptions ],
+  useFactory: (backend: MockBackend, defaultOptions: BaseRequestOptions) => {
+    return new Http(backend, defaultOptions);
+  }
+}
+
 
 describe('Service: CMSData', () => {
   let cmsService;
 
-  beforeEachProviders(() => [
-    HTTP_PROVIDERS,
-    CMSDataService
-  ]);
-
-  beforeEach(inject([CMSDataService], s => {
-    cmsService = s;
-  }))
-
-  it('creates an instance of the service', () => {
-    expect(cmsService).toBeFalsy;
+  beforeEachProviders(() => {
+    return [
+      MockBackend,
+      BaseRequestOptions,
+      provide(Http, mockHttpProvider),
+      CMSDataService
+    ];
   });
 
-  it('is able to retrieve the first series', async(() => {
-    cmsService.getFirstInSeries().subscribe(x => {
-      expect(x.title).toMatch("Foobar");
-    });
-  }));
+  it('should use an HTTP call to obtain series by id',
+    inject(
+      [CMSDataService, MockBackend],
+      fakeAsync((service: CMSDataService, backend: MockBackend) => {
+        backend.connections.subscribe((connection: MockConnection) => {
+
+          expect(connection.request.method).toBe(RequestMethod.Get);
+          expect(connection.request.url).toBe(
+            'https://contentint.crossroads.net/api/series/228');
+        });
+
+        service.getSeriesById(228);
+      })));
+
+  it('should use an HTTP call to obtain series by title',
+    inject(
+      [CMSDataService, MockBackend],
+      fakeAsync((service: CMSDataService, backend: MockBackend) => {
+        backend.connections.subscribe((connection: MockConnection) => {
+
+          expect(connection.request.method).toBe(RequestMethod.Get);
+          expect(connection.request.url).toBe(
+            'https://contentint.crossroads.net/api/series?title=Death%20to%20Religion');
+        });
+
+        service.getSeriesByTitle("Death to Religion");
+      })));
+
+  it('should use an HTTP call to obtain message by title',
+    inject(
+      [CMSDataService, MockBackend],
+      fakeAsync((service: CMSDataService, backend: MockBackend) => {
+        backend.connections.subscribe((connection: MockConnection) => {
+
+          expect(connection.request.method).toBe(RequestMethod.Get);
+          expect(connection.request.url).toBe(
+            'https://contentint.crossroads.net/api/messages?title=Death%20to%20Rules');
+        });
+
+        service.getMessageByTitle("Death to Rules");
+      })));
+
+  it('should use an HTTP call to obtain most recent 4 messages',
+    inject(
+      [CMSDataService, MockBackend],
+      fakeAsync((service: CMSDataService, backend: MockBackend) => {
+        backend.connections.subscribe((connection: MockConnection) => {
+
+          expect(connection.request.method).toBe(RequestMethod.Get);
+          expect(connection.request.url).toBe(
+            'https://contentint.crossroads.net/api/messages?date__sort=DESC&__limit[]=4');
+        });
+
+        service.getMostRecent4Messages();
+      })));
+
+
 });
 

--- a/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
+++ b/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
@@ -10,13 +10,14 @@ import {
   beforeEach,
   it,
   inject,
+  async,
   beforeEachProviders  
 } from '@angular/core/testing';
 
 import { CMSDataService } from '../../../core/services/CMSData.service'
 
-fdescribe('Service: CMSData', () => {
-  let service;
+describe('Service: CMSData', () => {
+  let cmsService;
 
   beforeEachProviders(() => [
     HTTP_PROVIDERS,
@@ -24,24 +25,17 @@ fdescribe('Service: CMSData', () => {
   ]);
 
   beforeEach(inject([CMSDataService], s => {
-    service = s;
+    cmsService = s;
   }))
 
   it('creates an instance of the service', () => {
-    expect(service).toBeTruthy;
+    expect(cmsService).toBeFalsy;
   });
 
-  it('is able to retrieve the first series', () => {
-    service.getFirstInSeries().subscribe(x => {
-      expect(x.title).toBe("Where I Went in '97...");
+  it('is able to retrieve the first series', async(() => {
+    cmsService.getFirstInSeries().subscribe(x => {
+      expect(x.title).toMatch("Foobar");
     });
-  });
-  
-  it('is able to retrieve series by title', () => {
-  });
-
-  it('is able to retrieve past weekends', () => {
-    pending();
-  });
+  }));
 });
 

--- a/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
+++ b/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
@@ -51,7 +51,7 @@ describe('Service: CMSData', () => {
           
           expect(connection.request.method).toBe(RequestMethod.Get);
           expect(connection.request.url).toBe(
-            `https://contentint.crossroads.net/api/series?startDate__LessThanOrEqual=${todaysDate}&endDate__GreaterThanOrEqual=${todaysDate}&endDate__sort=ASC&__limit%5B%5D=1`);
+            `${__CMS_ENDPOINT__}api/series?startDate__LessThanOrEqual=${todaysDate}&endDate__GreaterThanOrEqual=${todaysDate}&endDate__sort=ASC&__limit%5B%5D=1`);
         });
 
         service.getCurrentSeries();
@@ -66,7 +66,7 @@ describe('Service: CMSData', () => {
           
           expect(connection.request.method).toBe(RequestMethod.Get);
           expect(connection.request.url).toBe(
-            `https://contentint.crossroads.net/api/series?startDate__GreaterThanOrEqual=${todaysDate}&startDate__sort=ASC&__limit%5B%5D=1`);
+            `${__CMS_ENDPOINT__}api/series?startDate__GreaterThanOrEqual=${todaysDate}&startDate__sort=ASC&__limit%5B%5D=1`);
         });
 
         service.getNearestSeries();
@@ -81,7 +81,7 @@ describe('Service: CMSData', () => {
 
           expect(connection.request.method).toBe(RequestMethod.Get);
           expect(connection.request.url).toBe(
-            'https://contentint.crossroads.net/api/messages?date__sort=DESC&__limit%5B%5D=4');
+            `${__CMS_ENDPOINT__}api/messages?date__sort=DESC&__limit%5B%5D=4`);
         });
 
         service.getXMostRecentMessages(4);
@@ -95,7 +95,7 @@ describe('Service: CMSData', () => {
 
           expect(connection.request.method).toBe(RequestMethod.Get);
           expect(connection.request.url).toBe(
-            `https://contentint.crossroads.net/api/messages?title=Hello%20World`);
+            `${__CMS_ENDPOINT__}api/messages?title=Hello%20World`);
         });
 
         service.getMessages('title=Hello World');
@@ -109,7 +109,7 @@ describe('Service: CMSData', () => {
 
           expect(connection.request.method).toBe(RequestMethod.Get);
           expect(connection.request.url).toBe(
-            `https://contentint.crossroads.net/api/series?title=Hello%20World`);
+            `${__CMS_ENDPOINT__}api/series?title=Hello%20World`);
         });
 
         service.getSeries('title=Hello World');
@@ -123,7 +123,7 @@ describe('Service: CMSData', () => {
 
           expect(connection.request.method).toBe(RequestMethod.Get);
           expect(connection.request.url).toBe(
-            `https://contentint.crossroads.net/api/features`);
+            `${__CMS_ENDPOINT__}api/features`);
         });
 
         service.getDigitalProgram();
@@ -137,7 +137,7 @@ describe('Service: CMSData', () => {
 
           expect(connection.request.method).toBe(RequestMethod.Get);
           expect(connection.request.url).toBe(
-            `https://contentint.crossroads.net/api/contentblock?title=Hello%20World`);
+            `${__CMS_ENDPOINT__}api/contentblock?title=Hello%20World`);
         });
 
         service.getContentBlock('title=Hello World');

--- a/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
+++ b/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
@@ -42,21 +42,21 @@ describe('Service: CMSData', () => {
     ];
   });
   
-  it('should use an HTTP call to obtain current series',
+  it('should use an HTTP call to obtain the current series',
     inject(
       [CMSDataService, MockBackend],
       fakeAsync((service: CMSDataService, backend: MockBackend) => {
         backend.connections.subscribe((connection: MockConnection) => {
-          let todaysDate = new Date().toISOString().slice(0, 10);
-
+          let todaysDate = new Date().toISOString().slice(0, 10)
+          
           expect(connection.request.method).toBe(RequestMethod.Get);
           expect(connection.request.url).toBe(
-            `https://contentint.crossroads.net/api/series?startDate__LessThanOrEqual=${todaysDate}&endDate__GreaterThanOrEqual=${todaysDate}&endDate__sort=ASC&__limit[]=14`);
+            `https://contentint.crossroads.net/api/series?startDate__LessThanOrEqual=${todaysDate}&endDate__GreaterThanOrEqual=${todaysDate}&endDate__sort=ASC&__limit%5B%5D=1`);
         });
 
         service.getCurrentSeries();
       })));
-
+  
   it('should use an HTTP call to obtain the nearest series',
     inject(
       [CMSDataService, MockBackend],
@@ -66,7 +66,7 @@ describe('Service: CMSData', () => {
           
           expect(connection.request.method).toBe(RequestMethod.Get);
           expect(connection.request.url).toBe(
-            `https://contentint.crossroads.net/api/series?startDate__GreaterThanOrEqual=${todaysDate}&startDate__sort=ASC&__limit[]=1`);
+            `https://contentint.crossroads.net/api/series?startDate__GreaterThanOrEqual=${todaysDate}&startDate__sort=ASC&__limit%5B%5D=1`);
         });
 
         service.getNearestSeries();
@@ -109,7 +109,7 @@ describe('Service: CMSData', () => {
 
           expect(connection.request.method).toBe(RequestMethod.Get);
           expect(connection.request.url).toBe(
-            `https://contentint.crossroads.net/api/messages?title=Hello%20World`);
+            `https://contentint.crossroads.net/api/series?title=Hello%20World`);
         });
 
         service.getSeries('title=Hello World');

--- a/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
+++ b/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
@@ -20,6 +20,7 @@ import {
 import { MockBackend, MockConnection } from '@angular/http/testing';
 
 import { CMSDataService } from '../../../core/services/CMSData.service';
+declare var __CMS_ENDPOINT__: string;
 
 const mockHttpProvider = {
   deps: [ MockBackend, BaseRequestOptions ],
@@ -40,48 +41,37 @@ describe('Service: CMSData', () => {
       CMSDataService
     ];
   });
-
-  it('should use an HTTP call to obtain series by id',
+  
+  it('should use an HTTP call to obtain current series',
     inject(
       [CMSDataService, MockBackend],
       fakeAsync((service: CMSDataService, backend: MockBackend) => {
         backend.connections.subscribe((connection: MockConnection) => {
+          let todaysDate = new Date().toISOString().slice(0, 10);
 
           expect(connection.request.method).toBe(RequestMethod.Get);
           expect(connection.request.url).toBe(
-            'https://contentint.crossroads.net/api/series/228');
+            `https://contentint.crossroads.net/api/series?startDate__LessThanOrEqual=${todaysDate}&endDate__GreaterThanOrEqual=${todaysDate}&endDate__sort=ASC&__limit[]=14`);
         });
 
-        service.getSeriesById(228);
+        service.getCurrentSeries();
       })));
 
-  it('should use an HTTP call to obtain series by title',
+  it('should use an HTTP call to obtain the nearest series',
     inject(
       [CMSDataService, MockBackend],
       fakeAsync((service: CMSDataService, backend: MockBackend) => {
         backend.connections.subscribe((connection: MockConnection) => {
-
+          let todaysDate = new Date().toISOString().slice(0, 10)
+          
           expect(connection.request.method).toBe(RequestMethod.Get);
           expect(connection.request.url).toBe(
-            'https://contentint.crossroads.net/api/series?title=Death%20to%20Religion');
+            `https://contentint.crossroads.net/api/series?startDate__LessThanOrEqual=${todaysDate}&endDate__GreaterThanOrEqual=${todaysDate}&endDate__sort=ASC&__limit[]=1`);
         });
 
-        service.getSeriesByTitle("Death to Religion");
+        service.getNearestSeries();
       })));
 
-  it('should use an HTTP call to obtain message by title',
-    inject(
-      [CMSDataService, MockBackend],
-      fakeAsync((service: CMSDataService, backend: MockBackend) => {
-        backend.connections.subscribe((connection: MockConnection) => {
-
-          expect(connection.request.method).toBe(RequestMethod.Get);
-          expect(connection.request.url).toBe(
-            'https://contentint.crossroads.net/api/messages?title=Death%20to%20Rules');
-        });
-
-        service.getMessageByTitle("Death to Rules");
-      })));
 
   it('should use an HTTP call to obtain most recent 4 messages',
     inject(
@@ -94,23 +84,64 @@ describe('Service: CMSData', () => {
             'https://contentint.crossroads.net/api/messages?date__sort=DESC&__limit%5B%5D=4');
         });
 
-        service.getMostRecent4Messages();
+        service.getXMostRecentMessages(4);
       })));
 
-  it('should use an HTTP call to obtain the current series',
+  it('should use an HTTP call to obtain messages',
     inject(
       [CMSDataService, MockBackend],
       fakeAsync((service: CMSDataService, backend: MockBackend) => {
         backend.connections.subscribe((connection: MockConnection) => {
-          let todaysDate = new Date().toISOString().slice(0, 10)
-          
+
           expect(connection.request.method).toBe(RequestMethod.Get);
           expect(connection.request.url).toBe(
-            `https://contentint.crossroads.net/api/series?startDate__LessThan=${todaysDate}&endDate__GreaterThan=${todaysDate}&endDate__sort=ASC`);
+            `https://contentint.crossroads.net/api/messages?title=Hello%20World`);
         });
 
-        service.getCurrentSeries();
+        service.getMessages('title=Hello World');
       })));
 
+  it('should use an HTTP call to obtain series',
+    inject(
+      [CMSDataService, MockBackend],
+      fakeAsync((service: CMSDataService, backend: MockBackend) => {
+        backend.connections.subscribe((connection: MockConnection) => {
 
+          expect(connection.request.method).toBe(RequestMethod.Get);
+          expect(connection.request.url).toBe(
+            `https://contentint.crossroads.net/api/messages?title=Hello%20World`);
+        });
+
+        service.getSeries('title=Hello World');
+      })));
+
+  it('should use an HTTP call to obtain digital program',
+    inject(
+      [CMSDataService, MockBackend],
+      fakeAsync((service: CMSDataService, backend: MockBackend) => {
+        backend.connections.subscribe((connection: MockConnection) => {
+
+          expect(connection.request.method).toBe(RequestMethod.Get);
+          expect(connection.request.url).toBe(
+            `https://contentint.crossroads.net/api/features`);
+        });
+
+        service.getDigitalProgram();
+      })));
+
+  it('should use an HTTP call to obtain content block',
+    inject(
+      [CMSDataService, MockBackend],
+      fakeAsync((service: CMSDataService, backend: MockBackend) => {
+        backend.connections.subscribe((connection: MockConnection) => {
+
+          expect(connection.request.method).toBe(RequestMethod.Get);
+          expect(connection.request.url).toBe(
+            `https://contentint.crossroads.net/api/contentblock?title=Hello%20World`);
+        });
+
+        service.getContentBlock('title=Hello World');
+      })));
+     
+      
 });

--- a/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
+++ b/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
@@ -91,7 +91,7 @@ describe('Service: CMSData', () => {
 
           expect(connection.request.method).toBe(RequestMethod.Get);
           expect(connection.request.url).toBe(
-            'https://contentint.crossroads.net/api/messages?date__sort=DESC&__limit[]=4');
+            'https://contentint.crossroads.net/api/messages?date__sort=DESC&__limit%5B%5D=4');
         });
 
         service.getMostRecent4Messages();

--- a/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
+++ b/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
@@ -1,0 +1,47 @@
+/* tslint:disable:no-unused-variable */
+
+import { By } from '@angular/platform-browser';
+import { DebugElement } from '@angular/core';
+import { Http, HTTP_PROVIDERS } from '@angular/http';
+import { provide } from '@angular/core';
+import {
+  describe,
+  expect,
+  beforeEach,
+  it,
+  inject,
+  beforeEachProviders  
+} from '@angular/core/testing';
+
+import { CMSDataService } from '../../../core/services/CMSData.service'
+
+fdescribe('Service: CMSData', () => {
+  let service;
+
+  beforeEachProviders(() => [
+    HTTP_PROVIDERS,
+    CMSDataService
+  ]);
+
+  beforeEach(inject([CMSDataService], s => {
+    service = s;
+  }))
+
+  it('creates an instance of the service', () => {
+    expect(service).toBeTruthy;
+  });
+
+  it('is able to retrieve the first series', () => {
+    service.getFirstInSeries().subscribe(x => {
+      expect(x.title).toBe("Where I Went in '97...");
+    });
+  });
+  
+  it('is able to retrieve series by title', () => {
+  });
+
+  it('is able to retrieve past weekends', () => {
+    pending();
+  });
+});
+


### PR DESCRIPTION
This pull request introduces a new service for Angular 2 called CMSData.service. When used inside of a new component/directive, it allows for data to be fetched from the CMS using easy to understand methods.