### PR TITLE
US4624 - Group Detail - About - Mobile responsive layout fix

### DIFF
--- a/crossroads.net/app/group_tool/group_detail/about/groupDetail.about.html
+++ b/crossroads.net/app/group_tool/group_detail/about/groupDetail.about.html
@@ -77,7 +77,7 @@
 
   <div class='row push-top' ng-if='groupDetailAbout.isLeader'>
     <div class='col-md-12'>
-      <p class='text-center'><button type='button' ng-click='grouptool.edit({ groupId: createGroupPreview.state.params.groupId })' class='btn btn-primary'>Edit</button></p>
+      <p class='text-center'><button type='button' ng-click='grouptool.edit({ groupId: createGroupPreview.state.params.groupId })' class='btn btn-primary btn-block-mobile pull-right'>Edit</button></p>
     </div>
   </div>
 

--- a/crossroads.net/app/group_tool/group_detail/about/groupDetail.about.html
+++ b/crossroads.net/app/group_tool/group_detail/about/groupDetail.about.html
@@ -5,56 +5,81 @@
     <div class='col-md-12' dynamic-content="$root.MESSAGES.groupToolDetailPageAboutHeadingSubtext.content | html"></div>
   </div>
   <p></p>
-  <div class='row'>
-    <div class='col-md-1'><img class='img-responsive imgix-fluid' ng-src='{{groupDetailAbout.data.primaryContact.imageUrl}}' err-src='{{groupDetailAbout.defaultProfileImageUrl}}'></div>
-    <div class='col-md-11'>
-      <div class='row'>
-        <div class='col-md-2'><strong>Group Name</strong></div>
-        <div class='col-md-4'>{{groupDetailAbout.data.groupName}}</div>
-        <div class='col-md-2'><strong>Age Range</strong></div>
-        <div class='col-md-4'>{{groupDetailAbout.data.ageRange.join(', ')}}</div>
-      </div>
-      <div class='row'>
-        <div class='col-md-2'><strong>Category</strong></div>
-        <div class='col-md-4'>{{groupDetailAbout.data.categories.join(', ')}}</div>
-        <div class='col-md-2'><strong>Where</strong></div>
-         <div  class='col-md-4'>{{groupDetailAbout.getAddress()}}</div>
-         <!--<div ng-if='(groupDetailAbout.userInGroup() || groupDetailAbout.forInvitation) && groupDetailAbout.groupExists() '>
-           <div  class='col-md-4'>{{groupDetailAbout.data.address.toString()}}</div>
+
+  <div class="row">
+    <div class='col-md-1 col-sm-2 col-xs-3 push-quarter-bottom'><img class='img-responsive imgix-fluid' ng-src='{{groupDetailAbout.data.primaryContact.imageUrl}}' err-src='{{groupDetailAbout.defaultProfileImageUrl}}'></div>
+    <div class='col-xs-9 hidden-sm hidden-md hidden-lg push-quarter-bottom'><h4 class="mobile-push-half-top">{{groupDetailAbout.data.groupName}}</h4></div>
+
+    <div class="col-md-11 col-sm-10 col-xs-12">
+      <div class="row">
+
+        <div class="col-sm-6">
+          <div class="row hidden-xs push-half-bottom">
+            <div class='group-detail-label col-sm-4'><strong>Group Name</strong></div>
+            <div class='col-sm-8'>{{groupDetailAbout.data.groupName}}</div>
+          </div>
+          <div class="row push-quarter-bottom">
+            <div class='group-detail-label col-sm-4'><strong>Category</strong></div>
+            <div class='col-sm-8'>{{groupDetailAbout.data.categories.join(', ')}}</div>
+          </div>
+          <div class="row push-quarter-bottom">
+            <div class='group-detail-label col-sm-4'><strong>Group Type</strong></div>
+            <div class='col-sm-8'>{{groupDetailAbout.data.groupType.name}}</div>
+          </div>
+          <div class="row push-quarter-bottom">
+            <div class='group-detail-label col-sm-4'><strong>Leaders</strong></div>
+            <div class='col-sm-8'>
+              <span ng-repeat='leader in groupDetailAbout.data.leaders()'>{{leader.displayName()}}<span ng-if='!$last'>,&nbsp;</span></span>
+            </div>
+          </div>
+          <div class='row push-quarter-bottom' ng-if='(groupDetailAbout.userInGroup() || groupDetailAbout.forInvitation)'>
+            <div class='group-detail-label col-sm-4'><strong>Visibility</strong></div>
+            <div class='col-sm-8'>{{groupDetailAbout.data.visibility()}}</div>
+          </div>
         </div>
-        <div ng-if='(!groupDetailAbout.userInGroup() && !groupDetailAbout.forInvitation)'>
-          <div  class='col-md-4'>{{groupDetailAbout.data.address.getZip()}}</div>
-        </div>-->
-      </div>
-      <div class='row'>
-        <div class='col-md-2'><strong>Group Type</strong></div>
-        <div class='col-md-4'>{{groupDetailAbout.data.groupType.name}}</div>
-        <div class='col-md-2'><strong>When</strong></div>
-        <div class='col-md-4'>{{groupDetailAbout.data.meetingTimeFrequency}}</div>
-      </div>
-      <div class='row'>
-        <div class='col-md-2'><strong>Leaders</strong></div>
-        <div class='col-md-4'>
-          <span ng-repeat='leader in groupDetailAbout.data.leaders()'>{{leader.displayName()}}<span ng-if='!$last'>,&nbsp;</span></span>
+
+        <div class="col-sm-6">
+          <div class="row push-quarter-bottom">
+            <div class='group-detail-label col-sm-4'><strong>Age Range</strong></div>
+            <div class='col-sm-8'>{{groupDetailAbout.data.ageRange.join(', ')}}</div>
+          </div>
+          <div class="row push-quarter-bottom">
+            <div class='group-detail-label col-sm-4'><strong>Where</strong></div>
+            <div class="col-sm-8">{{groupDetailAbout.getAddress()}}</div>
+            <!--<div ng-if='(groupDetailAbout.userInGroup() || groupDetailAbout.forInvitation) && groupDetailAbout.groupExists() '>-->
+              <!--<div  class='col-sm-8'>{{groupDetailAbout.data.address.toString()}}</div>-->
+            <!--</div>-->
+            <!--<div ng-if='(!groupDetailAbout.userInGroup() && !groupDetailAbout.forInvitation)'>-->
+              <!--<div  class='col-sm-8'>{{groupDetailAbout.data.address.getZip()}}</div>-->
+            <!--</div>-->
+          </div>
+          <div class="row push-quarter-bottom">
+            <div class='group-detail-label col-sm-4'><strong>When</strong></div>
+            <div class='col-sm-8'>{{groupDetailAbout.data.meetingTimeFrequency}}</div>
+          </div>
+          <div class="row push-quarter-bottom">
+            <div class='group-detail-label col-sm-4'><strong>Kids Welcome</strong></div>
+            <div class='col-sm-8'>{{groupDetailAbout.data.kidsWelcome | yesNo}}</div>
+          </div>
         </div>
-        <div class='col-md-2'><strong>Kids Welcome</strong></div>
-        <div class='col-md-4'>{{groupDetailAbout.data.kidsWelcome | yesNo}}</div>
+
       </div>
-      <div class='row' ng-if='(groupDetailAbout.userInGroup() || groupDetailAbout.forInvitation)'>
-        <div class='col-md-2'><strong>Visibility</strong></div>
-        <div class='col-md-4'>{{groupDetailAbout.data.visibility()}}</div>
+
+      <div class='row hidden-xs'>&nbsp;</div>
+
+      <div class="row">
+        <div class='col-sm-2'><strong>Description</strong></div>
+        <div class='col-sm-10'>{{groupDetailAbout.data.groupDescription}}</div>
       </div>
-      <div class='row'>&nbsp;</div>
-      <div class='row'>
-        <div class='col-md-2'><strong>Description</strong></div>
-        <div class='col-md-10'>{{groupDetailAbout.data.groupDescription}}</div>
-      </div>
+
     </div>
   </div>
-  <div class='row'>&nbsp;</div>
-  <div class='row' ng-if='groupDetailAbout.isLeader'>
+
+  <div class='row push-top' ng-if='groupDetailAbout.isLeader'>
     <div class='col-md-12'>
       <p class='text-center'><button type='button' ng-click='grouptool.edit({ groupId: createGroupPreview.state.params.groupId })' class='btn btn-primary'>Edit</button></p>
     </div>
   </div>
+
+
 </div>

--- a/crossroads.net/styles/helpers/utilities.scss
+++ b/crossroads.net/styles/helpers/utilities.scss
@@ -185,6 +185,10 @@ a.underline,
     margin-left: $line-height-computed / 2;
 }
 
+.push-quarter-bottom {
+  margin-bottom: $line-height-computed / 4;
+}
+
 .flush {
     margin: 0;
 }

--- a/crossroads.net/styles/main.scss
+++ b/crossroads.net/styles/main.scss
@@ -18,6 +18,7 @@
 @import 'modules/cards.scss';
 @import 'modules/crds-card.scss';
 @import 'modules/crds-hero.scss';
+@import 'modules/group-detail-about.scss';
 @import 'modules/group-participants-cards.scss';
 @import 'modules/group-requests.scss';
 @import 'modules/group-cards.scss';

--- a/crossroads.net/styles/modules/group-detail-about.scss
+++ b/crossroads.net/styles/modules/group-detail-about.scss
@@ -1,0 +1,6 @@
+group-detail-about {
+  .group-detail-label {
+    line-height: 1.3;
+    margin-top: 3px;
+  }
+}


### PR DESCRIPTION
Fix layout of the Group Detail About tab component so that on tablet/mobile the missing profile image does not take up a huge amount of space.  The profile image will be to the left of the group name on mobile and the group name will have a larger font size
![image](https://cloud.githubusercontent.com/assets/2341619/17414796/dc3c3eda-5a54-11e6-984c-b30909339010.png)


Re-build the row/column layout so that the entire right column of key/values drops below the left column on mobile, instead of interleaving.  
![image](https://cloud.githubusercontent.com/assets/2341619/17414829/15cbce68-5a55-11e6-8978-9ba9b57ab15d.png)


Right align Edit button on desktop, full width on mobile
**Desktop**
![image](https://cloud.githubusercontent.com/assets/2341619/17414855/3680a444-5a55-11e6-9d87-6281c97c866a.png)

**mobile**
![image](https://cloud.githubusercontent.com/assets/2341619/17414890/559be9ba-5a55-11e6-86cf-f0e4b154aeea.png)
