### PR TITLE
Move constructor logic to onInit lifecycle hook

### DIFF
--- a/crossroads.net/app/childcare_dashboard/childcare_group/childcareDashboardGroup.controller.js
+++ b/crossroads.net/app/childcare_dashboard/childcare_group/childcareDashboardGroup.controller.js
@@ -8,11 +8,14 @@ class ChildcareDashboardGroupController {
     this.modal = $modal;
     this.root = $rootScope;
     this.childcareService = ChildcareDashboardService;
+  }
+
+  $onInit() {
     if(this.isEventClosed()) {
-      this.message = $rootScope.MESSAGES.childcareEventClosed.content;
+      this.message = this.root.MESSAGES.childcareEventClosed.content;
     }
     if(!this.hasEligibleChildren()) {
-      this.message = $rootScope.MESSAGES.noEligibleChildren.content;
+      this.message = this.root.MESSAGES.noEligibleChildren.content;
     }
   }
 

--- a/crossroads.net/spec/childcare_dashboard/childcare_group/childcareGroup.controller.spec.js
+++ b/crossroads.net/spec/childcare_dashboard/childcare_group/childcareGroup.controller.spec.js
@@ -44,7 +44,7 @@ describe('Childcare Group Component Controller', () => {
 
     controller = new ChildcareDashboardGroupController(rootScope, scope, modal, childcareDashboardService);
     controller.communityGroup = {eligibleChildren: [] };
-
+    controller.$onInit();
     spyOn(rootScope, '$emit').and.callThrough();
 
   }));


### PR DESCRIPTION
[DE1656](https://rally1.rallydev.com/#/27593501023d/detail/defect/59666065140)

Setup logic belongs in lifecycle hooks.