### PR TITLE
DE1734 - Fix button alignment and sizing for the Group Detail About page

### DIFF
--- a/crossroads.net/app/group_tool/group_detail/about/groupDetail.about.html
+++ b/crossroads.net/app/group_tool/group_detail/about/groupDetail.about.html
@@ -77,7 +77,7 @@
 
   <div class='row push-top' ng-if='groupDetailAbout.isLeader'>
     <div class='col-md-12'>
-      <p class='text-center'><button type='button' ng-click='groupDetailAbout.goToEdit()' class='btn btn-primary'>Edit</button></p>
+      <p class='text-right'><button type='button' ng-click='groupDetailAbout.goToEdit()' class='btn btn-primary btn-block-mobile'>Edit</button></p>
     </div>
   </div>
 


### PR DESCRIPTION
* Group Detail About page "Edit" button will be right aligned on desktop
![image](https://cloud.githubusercontent.com/assets/2341619/17446040/7b5e43c6-5b15-11e6-9fbb-05460fd324c9.png)

* Group Detail About page "Edit" button will be full width on mobile
![image](https://cloud.githubusercontent.com/assets/2341619/17446047/7f7acc18-5b15-11e6-9c78-dd8ca1dacd70.png)
