### PR TITLE
Fix requests page display when there are not both requests and invites

### DIFF
--- a/crossroads.net/app/group_tool/group_detail/requests/groupDetail.requests.controller.js
+++ b/crossroads.net/app/group_tool/group_detail/requests/groupDetail.requests.controller.js
@@ -125,4 +125,16 @@ export default class GroupDetailRequestsController {
   denyView() {
     return this.currentView === 'Deny';
   }
+
+  hasRequests() {
+    return this.inquired && this.inquired.length > 0;
+  }
+
+  hasInvites() {
+    return this.invited && this.invited.length > 0;
+  }
+
+  hasRequestsOrInvites() {
+    return this.hasRequests() || this.hasInvites();
+  }
 }

--- a/crossroads.net/app/group_tool/group_detail/requests/groupDetail.requests.html
+++ b/crossroads.net/app/group_tool/group_detail/requests/groupDetail.requests.html
@@ -1,8 +1,8 @@
-<preloader full-screen='false' ng-if="!groupDetailRequests.ready && groupDetailRequests.currentView = 'List'"> </preloader>
+<preloader full-screen='false' ng-if="!groupDetailRequests.ready && groupDetailRequests.listView()"> </preloader>
 
 <div ng-if='groupDetailRequests.listView() && groupDetailRequests.ready'>
   <div class="table-responsive push-bottom">
-    <table class="table group-requests-list" ng-if="groupDetailRequests.inquired.length > 0 && groupDetailRequests.invited.length > 0">
+    <table class="table group-requests-list" ng-if="groupDetailRequests.hasRequestsOrInvites()">
       <thead>
         <th class='col-md-1'></th>
         <th class='col-md-2'>Name</th>
@@ -57,7 +57,7 @@
     </table>
   </div>
 
-  <div ng-if="groupDetailRequests.inquired.length == 0 && groupDetailRequests.invited.length == 0" class="row push-bottom push-top">
+  <div ng-if="!groupDetailRequests.hasRequestsOrInvites()" class="row push-bottom push-top">
     <div class="col-sm-8 col-md-6 col-sm-offset-2 col-md-offset-3">
       <p dynamic-content="$root.MESSAGES.groupToolDetailRequestsHelpText.content | html" class="text-center"></p>
     </div>

--- a/crossroads.net/spec-es6/group_tool/group_detail/requests/groupDetail.requests.controller.spec.js
+++ b/crossroads.net/spec-es6/group_tool/group_detail/requests/groupDetail.requests.controller.spec.js
@@ -342,5 +342,51 @@ describe('GroupDetailRequestsController', () => {
         expect(rootScope.$emit).toHaveBeenCalledWith('notify', rootScope.MESSAGES.groupToolDenyInquiryFailureGrowler);
       });
     });
+
+    describe('Request and invite method', () => {
+      it('hasRequests() should be false with no requests', () => {
+        fixture.inquired = [];
+        expect(fixture.hasRequests()).toBeFalsy();
+      });
+
+      it('hasRequests() should be true with some requests', () => {
+        fixture.inquired = [ {} ];
+        expect(fixture.hasRequests()).toBeTruthy();
+      });
+
+      it('hasInvites() should be false with no invites', () => {
+        fixture.invited = [];
+        expect(fixture.hasInvites()).toBeFalsy();
+      });
+
+      it('hasInvites() should be true with some invites', () => {
+        fixture.invited = [ {} ];
+        expect(fixture.hasInvites()).toBeTruthy();
+      });
+
+      it('hasRequestsOrInvites() should be false with no requests or invites', () => {
+        fixture.invited = [];
+        fixture.inquired = [];
+        expect(fixture.hasRequestsOrInvites()).toBeFalsy();
+      });
+
+      it('hasRequestsOrInvites() should be true with no requests but some invites', () => {
+        fixture.invited = [ {} ];
+        fixture.inquired = [];
+        expect(fixture.hasRequestsOrInvites()).toBeTruthy();
+      });
+
+      it('hasRequestsOrInvites() should be true with no invites but some requests', () => {
+        fixture.invited = [ ];
+        fixture.inquired = [ {} ];
+        expect(fixture.hasRequestsOrInvites()).toBeTruthy();
+      });
+
+      it('hasRequestsOrInvites() should be true with requests and invites', () => {
+        fixture.invited = [ {} ];
+        fixture.inquired = [ {} ];
+        expect(fixture.hasRequestsOrInvites()).toBeTruthy();
+      });
+    });
   });
 });


### PR DESCRIPTION
* Related to changes made for [US4644](https://rally1.rallydev.com/#/22244455064d/detail/userstory/60309945483)
* Page was not displaying results if the group only had requests or invites (but not both)
* Also some js errors were popping up in the console, related to this - fixed by adding some new controller methods
