### PR TITLE
US4626 - Rebuild Group Detail Requests tab for responsiveness

### DIFF
--- a/crossroads.net/app/group_tool/group_detail/requests/groupDetail.requests.html
+++ b/crossroads.net/app/group_tool/group_detail/requests/groupDetail.requests.html
@@ -4,7 +4,7 @@
 
   <!-- Invite text and button for Mobile -->
   <div class="hidden-sm hidden-md hidden-lg">
-    <div ng-if="groupDetailRequests.hasRequestsOrInvites()" class="row push-bottom push-top">
+    <div ng-if="!groupDetailRequests.hasRequestsOrInvites()" class="row push-bottom push-top">
       <div class="col-sm-8 col-md-6 col-sm-offset-2 col-md-offset-3">
         <p dynamic-content="$root.MESSAGES.groupToolDetailRequestsHelpText.content | html" class="text-center"></p>
       </div>
@@ -16,7 +16,7 @@
   </div>
 
   <!-- Requests Table -->
-  <div ng-if="groupDetailRequests.inquired.length > 0 && groupDetailRequests.invited.length > 0" class="push-bottom">
+  <div ng-if="groupDetailRequests.hasRequestsOrInvites()" class="push-bottom">
     <!-- Header Row -->
     <div class="group-request-header row hidden-xs push-top soft-half-bottom">
       <div class="col-sm-10 col-md-9">

--- a/crossroads.net/app/group_tool/group_detail/requests/groupDetail.requests.html
+++ b/crossroads.net/app/group_tool/group_detail/requests/groupDetail.requests.html
@@ -2,7 +2,20 @@
 
 <div ng-if='groupDetailRequests.listView() && groupDetailRequests.ready'>
 
+  <!-- Invite text and button for Mobile -->
+  <div class="hidden-sm hidden-md hidden-lg">
+    <div ng-if="groupDetailRequests.inquired.length == 0 && groupDetailRequests.invited.length == 0" class="row push-bottom push-top">
+      <div class="col-sm-8 col-md-6 col-sm-offset-2 col-md-offset-3">
+        <p dynamic-content="$root.MESSAGES.groupToolDetailRequestsHelpText.content | html" class="text-center"></p>
+      </div>
+    </div>
 
+    <p class='text-center'><button type='button' class='btn btn-primary btn-block-mobile' ng-click="groupDetailRequests.setView('Invite', false)">Invite Someone</button></p>
+
+    <h4 class="group-detail-title-mobile push-top soft-half-bottom">Requests</h4>
+  </div>
+
+  <!-- Requests Table -->
   <div ng-if="groupDetailRequests.inquired.length > 0 && groupDetailRequests.invited.length > 0" class="push-bottom">
     <!-- Header Row -->
     <div class="group-request-header row hidden-xs push-top soft-half-bottom">
@@ -77,76 +90,17 @@
     </div>
   </div>
 
-
-  <!--<div class="table-responsive push-bottom">-->
-    <!--<table class="table group-requests-list" ng-if="groupDetailRequests.inquired.length > 0 && groupDetailRequests.invited.length > 0">-->
-      <!--<thead>-->
-        <!--<th class='col-md-1'></th>-->
-        <!--<th class='col-md-2'>Name</th>-->
-        <!--<th class='col-md-2'>Request Type</th>-->
-        <!--<th class='col-md-2'>Email Address</th>-->
-        <!--<th class='col-md-2'>Request Date</th>-->
-        <!--<th class='col-md-3'></th>-->
-      <!--</thead>-->
-      <!--<tbody>-->
-        <!--<tr ng-repeat='inquiry in groupDetailRequests.inquired track by $index'>-->
-          <!--<td>-->
-            <!--<img class='img-responsive imgix-fluid requestor-image' ng-src='{{inquiry.imageUrl}}' err-src='{{inquiry.defaultProfileImageUrl}}'>-->
-          <!--</td>-->
-          <!--<td>-->
-            <!--{{inquiry.recipientName()}}-->
-          <!--</td>-->
-          <!--<td>-->
-            <!--Requested to Join-->
-          <!--</td>-->
-          <!--<td>-->
-            <!--{{inquiry.emailAddress}}-->
-          <!--</td>-->
-          <!--<td>-->
-            <!--{{inquiry.requestDate | date: 'MM/dd/yyyy'}}-->
-          <!--</td>-->
-          <!--<td>-->
-            <!--<button type='button' class='btn btn-standard' ng-click="groupDetailRequests.deny(inquiry)">Deny</button>-->
-            <!--<button type='button' class='btn btn-primary' ng-click="groupDetailRequests.approve(inquiry)">Approve</button>-->
-          <!--</td>-->
-        <!--</tr>-->
-        <!--<tr ng-repeat='invite in groupDetailRequests.invited track by $index'>-->
-          <!--<td>-->
-            <!--<img class='img-responsive imgix-fluid requestor-image' ng-src='{{invite.imageUrl}}'>-->
-          <!--</td>-->
-          <!--<td>-->
-            <!--{{invite.recipientName}}-->
-          <!--</td>-->
-          <!--<td>-->
-            <!--Invite Sent-->
-          <!--</td>-->
-          <!--<td>-->
-            <!--{{invite.emailAddress}}-->
-          <!--</td>-->
-          <!--<td>-->
-            <!--{{invite.requestDate | date: 'MM/dd/yyyy'}}-->
-          <!--</td>-->
-          <!--<td>-->
-            <!--&nbsp;-->
-          <!--</td>-->
-        <!--</tr>-->
-      <!--</tbody>-->
-    <!--</table>-->
-  <!--</div>-->
-
-  <div ng-if="groupDetailRequests.inquired.length == 0 && groupDetailRequests.invited.length == 0" class="row push-bottom push-top">
-    <div class="col-sm-8 col-md-6 col-sm-offset-2 col-md-offset-3">
-      <p dynamic-content="$root.MESSAGES.groupToolDetailRequestsHelpText.content | html" class="text-center"></p>
-    </div>
-  </div>
-
-  <div class='container-fluid'>
-    <div class='row'>
-      <div class='col-sm-12'>
-        <p class='text-center'><button type='button' class='btn btn-primary' ng-click="groupDetailRequests.setView('Invite', false)">Invite Someone</button></p>
+  <!-- Invite text and button for Desktop -->
+  <div class="hidden-xs">
+    <div ng-if="groupDetailRequests.inquired.length == 0 && groupDetailRequests.invited.length == 0" class="row push-bottom push-top">
+      <div class="col-sm-8 col-md-6 col-sm-offset-2 col-md-offset-3">
+        <p dynamic-content="$root.MESSAGES.groupToolDetailRequestsHelpText.content | html" class="text-center"></p>
       </div>
     </div>
+
+    <p class='text-center'><button type='button' class='btn btn-primary' ng-click="groupDetailRequests.setView('Invite', false)">Invite Someone</button></p>
   </div>
+
 </div>
 
 <div class='container-fluid' ng-if='groupDetailRequests.approveView()'>

--- a/crossroads.net/app/group_tool/group_detail/requests/groupDetail.requests.html
+++ b/crossroads.net/app/group_tool/group_detail/requests/groupDetail.requests.html
@@ -1,61 +1,138 @@
 <preloader full-screen='false' ng-if="!groupDetailRequests.ready && groupDetailRequests.currentView = 'List'"> </preloader>
 
 <div ng-if='groupDetailRequests.listView() && groupDetailRequests.ready'>
-  <div class="table-responsive push-bottom">
-    <table class="table group-requests-list" ng-if="groupDetailRequests.inquired.length > 0 && groupDetailRequests.invited.length > 0">
-      <thead>
-        <th class='col-md-1'></th>
-        <th class='col-md-2'>Name</th>
-        <th class='col-md-2'>Request Type</th>
-        <th class='col-md-2'>Email Address</th>
-        <th class='col-md-2'>Request Date</th>
-        <th class='col-md-3'></th>
-      </thead>
-      <tbody>
-        <tr ng-repeat='inquiry in groupDetailRequests.inquired track by $index'>
-          <td>
-            <img class='img-responsive imgix-fluid requestor-image' ng-src='{{inquiry.imageUrl}}' err-src='{{inquiry.defaultProfileImageUrl}}'>
-          </td>
-          <td>
+
+
+  <div ng-if="groupDetailRequests.inquired.length > 0 && groupDetailRequests.invited.length > 0" class="push-bottom">
+    <!-- Header Row -->
+    <div class="group-request-header row hidden-xs push-top soft-half-bottom">
+      <div class="col-sm-10 col-md-9">
+        <div class="group-request-data row">
+          <div class="col-sm-3">
+            Name
+          </div>
+          <div class="col-sm-3">
+            Request Type
+          </div>
+          <div class="col-sm-3">
+            Email Address
+          </div>
+          <div class="col-sm-3">
+            Request Date
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Inquiries -->
+    <div ng-repeat='inquiry in groupDetailRequests.inquired track by $index' class="group-request-row row soft-half-top soft-half-bottom">
+      <div class="col-sm-10 col-md-9">
+        <img class='img-responsive imgix-fluid group-request-image' ng-src='{{inquiry.imageUrl}}' err-src='{{inquiry.defaultProfileImageUrl}}'>
+        <div class="group-request-data row">
+          <div class="col-sm-3 ellipsis">
             {{inquiry.recipientName()}}
-          </td>
-          <td>
+          </div>
+          <div class="col-sm-3 ellipsis">
             Requested to Join
-          </td>
-          <td>
+          </div>
+          <div class="col-sm-3 ellipsis">
             {{inquiry.emailAddress}}
-          </td>
-          <td>
+          </div>
+          <div class="col-sm-3 ellipsis">
             {{inquiry.requestDate | date: 'MM/dd/yyyy'}}
-          </td>
-          <td>
-            <button type='button' class='btn btn-standard' ng-click="groupDetailRequests.deny(inquiry)">Deny</button>
-            <button type='button' class='btn btn-primary' ng-click="groupDetailRequests.approve(inquiry)">Approve</button>
-          </td>
-        </tr>
-        <tr ng-repeat='invite in groupDetailRequests.invited track by $index'>
-          <td>
-            <img class='img-responsive imgix-fluid requestor-image' ng-src='{{invite.imageUrl}}'>
-          </td>
-          <td>
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-2 col-md-3">
+        <div class="row group-request-buttons">
+          <div class="col-xs-6 col-sm-12 col-md-6">
+            <button type='button' class='btn btn-standard btn-block push-quarter-bottom' ng-click="groupDetailRequests.deny(inquiry)">Deny</button>
+          </div>
+          <div class="col-xs-6 col-sm-12 col-md-6">
+            <button type='button' class='btn btn-primary btn-block push-quarter-bottom' ng-click="groupDetailRequests.approve(inquiry)">Approve</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Invites -->
+    <div ng-repeat='invite in groupDetailRequests.invited track by $index' class="group-request-row row soft-half-top soft-half-bottom">
+      <div class="col-sm-10 col-md-9">
+        <img class='img-responsive imgix-fluid group-request-image' ng-src='{{invite.imageUrl}}'>
+        <div class="group-request-data row">
+          <div class="col-sm-3 ellipsis">
             {{invite.recipientName}}
-          </td>
-          <td>
+          </div>
+          <div class="col-sm-3 ellipsis">
             Invite Sent
-          </td>
-          <td>
+          </div>
+          <div class="col-sm-3 ellipsis">
             {{invite.emailAddress}}
-          </td>
-          <td>
+          </div>
+          <div class="col-sm-3 ellipsis">
             {{invite.requestDate | date: 'MM/dd/yyyy'}}
-          </td>
-          <td>
-            &nbsp;
-          </td>
-        </tr>
-      </tbody>
-    </table>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
+
+
+  <!--<div class="table-responsive push-bottom">-->
+    <!--<table class="table group-requests-list" ng-if="groupDetailRequests.inquired.length > 0 && groupDetailRequests.invited.length > 0">-->
+      <!--<thead>-->
+        <!--<th class='col-md-1'></th>-->
+        <!--<th class='col-md-2'>Name</th>-->
+        <!--<th class='col-md-2'>Request Type</th>-->
+        <!--<th class='col-md-2'>Email Address</th>-->
+        <!--<th class='col-md-2'>Request Date</th>-->
+        <!--<th class='col-md-3'></th>-->
+      <!--</thead>-->
+      <!--<tbody>-->
+        <!--<tr ng-repeat='inquiry in groupDetailRequests.inquired track by $index'>-->
+          <!--<td>-->
+            <!--<img class='img-responsive imgix-fluid requestor-image' ng-src='{{inquiry.imageUrl}}' err-src='{{inquiry.defaultProfileImageUrl}}'>-->
+          <!--</td>-->
+          <!--<td>-->
+            <!--{{inquiry.recipientName()}}-->
+          <!--</td>-->
+          <!--<td>-->
+            <!--Requested to Join-->
+          <!--</td>-->
+          <!--<td>-->
+            <!--{{inquiry.emailAddress}}-->
+          <!--</td>-->
+          <!--<td>-->
+            <!--{{inquiry.requestDate | date: 'MM/dd/yyyy'}}-->
+          <!--</td>-->
+          <!--<td>-->
+            <!--<button type='button' class='btn btn-standard' ng-click="groupDetailRequests.deny(inquiry)">Deny</button>-->
+            <!--<button type='button' class='btn btn-primary' ng-click="groupDetailRequests.approve(inquiry)">Approve</button>-->
+          <!--</td>-->
+        <!--</tr>-->
+        <!--<tr ng-repeat='invite in groupDetailRequests.invited track by $index'>-->
+          <!--<td>-->
+            <!--<img class='img-responsive imgix-fluid requestor-image' ng-src='{{invite.imageUrl}}'>-->
+          <!--</td>-->
+          <!--<td>-->
+            <!--{{invite.recipientName}}-->
+          <!--</td>-->
+          <!--<td>-->
+            <!--Invite Sent-->
+          <!--</td>-->
+          <!--<td>-->
+            <!--{{invite.emailAddress}}-->
+          <!--</td>-->
+          <!--<td>-->
+            <!--{{invite.requestDate | date: 'MM/dd/yyyy'}}-->
+          <!--</td>-->
+          <!--<td>-->
+            <!--&nbsp;-->
+          <!--</td>-->
+        <!--</tr>-->
+      <!--</tbody>-->
+    <!--</table>-->
+  <!--</div>-->
 
   <div ng-if="groupDetailRequests.inquired.length == 0 && groupDetailRequests.invited.length == 0" class="row push-bottom push-top">
     <div class="col-sm-8 col-md-6 col-sm-offset-2 col-md-offset-3">

--- a/crossroads.net/styles/modules/group-requests.scss
+++ b/crossroads.net/styles/modules/group-requests.scss
@@ -1,9 +1,47 @@
-.group-requests-list {
-  .requestor-image {
-    border: 1px solid black;
+group-detail-requests {
+  .group-request-header {
+    border-bottom: 2px solid $gray-lighter;
+    font-weight: bold;
+    line-height: 1.2;
+
+    @media (min-width: $screen-sm-min) {
+      font-size: 92%;
+    }
   }
 
-  td {
-    vertical-align: middle !important;
+  .group-request-row {
+    border-bottom: 1px solid $gray-lighter;
+  }
+
+  .group-request-image {
+    float: left;
+    width: 55px;
+    border: solid 1px $gray;
+  }
+
+  .group-request-data {
+    margin-left: 70px;
+
+    @media (min-width: $screen-sm-min) {
+      padding-top: 16px;
+      font-size: 92%;
+    }
+  }
+
+  .group-request-buttons {
+    margin-left: -5px;
+    margin-right: -5px;
+    padding-top: 9px;
+
+    [class*='col-'] {
+      padding-left: 5px;
+      padding-right: 5px;
+
+      button {
+        @media (min-width: $screen-sm-min) {
+          font-size: 92%;
+        }
+      }
+    }
   }
 }

--- a/crossroads.net/styles/modules/group-requests.scss
+++ b/crossroads.net/styles/modules/group-requests.scss
@@ -1,4 +1,8 @@
 group-detail-requests {
+  .group-detail-title-mobile {
+    border-bottom: solid 1px $gray-lighter;
+  }
+
   .group-request-header {
     border-bottom: 2px solid $gray-lighter;
     font-weight: bold;


### PR DESCRIPTION
Rebuild the requests tab as a bootstrap grid instead of table for better control over responsive behaviors.

* Deny / Approve button stack above each other at `sm` size
* Deny / Approve button stack below user data at `xs` size
* Invite Someone button moves to top at `xs` size for mobile
* User photo is a fixed size with margin instead of taking up a bootstrap col / table col
* Use .ellipsis on data cells to avoid text overlaps

### Desktop
![large view](https://cloud.githubusercontent.com/assets/2341619/17449654/04b778e0-5b2a-11e6-800d-6241a0d786ee.png)

### Tablet 
![image](https://cloud.githubusercontent.com/assets/2341619/17449659/0b2a07d8-5b2a-11e6-99c6-124f180fc436.png)

### Mobile
![image](https://cloud.githubusercontent.com/assets/2341619/17449664/0e796be0-5b2a-11e6-95d2-5177c46ac385.png)
