### PR TITLE
DE1767 - Fix participant layout on iOS 8

### DIFF
--- a/crossroads.net/styles/modules/group-participants-cards.scss
+++ b/crossroads.net/styles/modules/group-participants-cards.scss
@@ -6,12 +6,16 @@
 }
 
 .group-detail-participant-list {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  @media (min-width: $screen-md) {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
 
   .group-detail-participant-item {
-    flex: 1 1 auto;
+    @media (min-width: $screen-md) {
+      flex: 1 1 auto;
+    }
   }
 }
 


### PR DESCRIPTION
Ignore flex CSS styling properties on iOS 8 and display as list of divs with bootstrap styling.  This fixes iPhone and iPad at iOS 8.