### PR TITLE
US4696 - Request to Join - Confirm Request Modal

### DIFF
--- a/crossroads.net/app/group_tool/confirm_request/confirmRequest.component.js
+++ b/crossroads.net/app/group_tool/confirm_request/confirmRequest.component.js
@@ -1,0 +1,20 @@
+import controller from './confirmRequest.controller';
+
+ConfirmRequestComponent.$inject = [ ];
+
+export default function ConfirmRequestComponent() {
+
+  let confirmRequestComponent = {
+    bindings: {
+      group: '<',
+      modalInstance: '<'
+    },
+    restrict: 'E',
+    templateUrl: 'confirm_request/confirmRequest.html',
+    controller: controller,
+    controllerAs: 'confirmRequest',
+    bindToController: true
+  };
+
+  return confirmRequestComponent;
+}

--- a/crossroads.net/app/group_tool/confirm_request/confirmRequest.controller.js
+++ b/crossroads.net/app/group_tool/confirm_request/confirmRequest.controller.js
@@ -1,0 +1,19 @@
+export default class ConfirmRequestController {
+  /*@ngInject*/
+  constructor() {
+    this.processing = false;
+  }
+
+  cancel() {
+    this.modalInstance.dismiss();
+  }
+
+  submit() {
+    this.processing = true;
+
+    // TODO - Remove timeout faking submission for loading-button
+    window.setTimeout(() => {
+      this.modalInstance.dismiss();
+    }, 2000);
+  }
+}

--- a/crossroads.net/app/group_tool/confirm_request/confirmRequest.html
+++ b/crossroads.net/app/group_tool/confirm_request/confirmRequest.html
@@ -1,0 +1,17 @@
+<div class="modal-header">
+  <h3 class="modal-title">Confirm Request</h3>
+</div>
+<div class="modal-body">
+  <group-detail-about data="confirmRequest.group"></group-detail-about>
+</div>
+<div class="modal-footer">
+  <button type="button" class="btn btn-standard btn-block-mobile mobile-push-half-bottom" ng-click="confirmRequest.cancel()">Back to Search Results</button>
+  <loading-button
+    ng-click="confirmRequest.submit()"
+    input-type='button'
+    normal-text='Send Request'
+    loading-text='Sending...'
+    loading='confirmRequest.processing'
+    loading-class='disabled'
+    input-classes='btn btn-primary btn-block-mobile mobile-push-half-bottom'></loading-button>
+</div>

--- a/crossroads.net/app/group_tool/confirm_request/index.js
+++ b/crossroads.net/app/group_tool/confirm_request/index.js
@@ -1,0 +1,7 @@
+import ConfirmRequestComponent from './confirmRequest.component';
+import CONSTANTS from 'crds-constants';
+import html from './confirmRequest.html';
+
+export default angular.
+module(CONSTANTS.MODULES.GROUP_TOOL).
+component('confirmRequest', ConfirmRequestComponent());

--- a/crossroads.net/app/group_tool/group_detail/about/groupDetail.about.html
+++ b/crossroads.net/app/group_tool/group_detail/about/groupDetail.about.html
@@ -67,8 +67,8 @@
       <div class='row hidden-xs'>&nbsp;</div>
 
       <div class="row">
-        <div class='col-sm-2'><strong>Description</strong></div>
-        <div class='col-sm-10'>{{groupDetailAbout.data.groupDescription}}</div>
+        <div class='col-md-2'><strong>Description</strong></div>
+        <div class='col-md-10'>{{groupDetailAbout.data.groupDescription}}</div>
       </div>
 
     </div>

--- a/crossroads.net/app/group_tool/group_search_results/groupSearchResults.controller.js
+++ b/crossroads.net/app/group_tool/group_search_results/groupSearchResults.controller.js
@@ -19,10 +19,10 @@ export default class GroupSearchResultsController {
 
   $onInit() {
     this.search = {
-      query: this.state.params.query || 'tallent',
+      query: this.state.params.query,
       location: this.state.params.location
     };
-    this.doSearch(this.state.params.query || 'tallent', this.state.params.location);
+    this.doSearch(this.state.params.query, this.state.params.location);
   }
 
   doSearch(query, location) {

--- a/crossroads.net/app/group_tool/group_search_results/groupSearchResults.controller.js
+++ b/crossroads.net/app/group_tool/group_search_results/groupSearchResults.controller.js
@@ -1,8 +1,9 @@
 
 export default class GroupSearchResultsController {
   /*@ngInject*/
-  constructor(NgTableParams, GroupService, $state) {
+  constructor(NgTableParams, GroupService, $state, $modal) {
     this.groupService = GroupService;
+    this.$modal = $modal;
 
     this.search = null;
     this.processing = false;
@@ -18,10 +19,10 @@ export default class GroupSearchResultsController {
 
   $onInit() {
     this.search = {
-      query: this.state.params.query,
+      query: this.state.params.query || 'tallent',
       location: this.state.params.location
     };
-    this.doSearch(this.state.params.query, this.state.params.location);
+    this.doSearch(this.state.params.query || 'tallent', this.state.params.location);
   }
 
   doSearch(query, location) {
@@ -59,5 +60,23 @@ export default class GroupSearchResultsController {
 
   submit() {
     this.doSearch(this.search.query, this.search.location);
+  }
+
+  requestToJoin(group) {
+    console.debug("Request to Join", group);
+    var modalInstance = this.$modal.open({
+      template: '<confirm-request group="confirmRequestModal.group" modal-instance="confirmRequestModal.modalInstance"></confirm-request>',
+      controller: function(group, $modalInstance) {
+        this.group = group;
+        this.modalInstance = $modalInstance;
+      },
+      controllerAs: 'confirmRequestModal',
+      size: 'lg',
+      resolve: {
+        group: function () {
+          return group;
+        }
+      }
+    });
   }
 }

--- a/crossroads.net/app/group_tool/group_search_results/groupSearchResults.html
+++ b/crossroads.net/app/group_tool/group_search_results/groupSearchResults.html
@@ -58,7 +58,7 @@
         <group-detail-about data="group" for-search="true"></group-detail-about>
         <div class="text-right push-half-bottom soft-half-right">
           <button type="button" class="btn btn-secondary" ng-click="group.expanded = false">Close</button>
-          <button type="button" class="btn btn-primary">Request to Join</button>
+          <button type="button" class="btn btn-primary" ng-click="groupSearchResults.requestToJoin(group)">Request to Join</button>
         </div>
       </td>
     </tr>
@@ -78,7 +78,7 @@
     <div ng-if="group.expanded" ng-repeat-end class="gray-lighter push-bottom">
       <group-detail-about data="group" for-search="true"></group-detail-about>
       <div class="soft-half">
-        <button type="button" class="btn btn-primary btn-block">Request to Join</button>
+        <button type="button" class="btn btn-primary btn-block" ng-click="groupSearchResults.requestToJoin(group)">Request to Join</button>
         <button type="button" class="btn btn-secondary btn-block" ng-click="group.expanded = false">Close</button>
       </div>
     </div>

--- a/crossroads.net/app/group_tool/index.js
+++ b/crossroads.net/app/group_tool/index.js
@@ -22,6 +22,7 @@ export default angular.
   ;
 
 import myGroups from './my_groups';
+import confirmRequest from './confirm_request';
 import createGroup from './create_group';
 import groupDetail from './group_detail';
 import groupMessage from './group_message';


### PR DESCRIPTION
Note:   UI layout only, Submitting request functionality is mocked
Clicking "Back to Search Results" dismisses the modal
Clicking on the darkened window overlay dismisses the modal
Clicking the "Send Request" button mocks the API call with 2 sec timeout, then dismisses modal

### Displays as large modal on Desktop
![image](https://cloud.githubusercontent.com/assets/2341619/17654328/056abda4-6270-11e6-907a-6ce99dc927b4.png)


### Displays as small modal on smaller screens.  
"Description" label stacks with description text to avoid overlaying
![image](https://cloud.githubusercontent.com/assets/2341619/17654331/0d323440-6270-11e6-9bd7-74b6340d2785.png)


### Displays as scrollable modal on mobile screens
![image](https://cloud.githubusercontent.com/assets/2341619/17654332/10798068-6270-11e6-9b2c-0aea369e6f72.png)


### Displays correctly on older iPhones
![image](https://cloud.githubusercontent.com/assets/2341619/17654334/1378a62c-6270-11e6-8b53-6615776052a0.png)


### Clicking "Send Request" displays button loading state "Sending..."
![image](https://cloud.githubusercontent.com/assets/2341619/17654335/171e295a-6270-11e6-927c-2484b6799829.png)
