### PR TITLE
DE1779: Handle groups with missing age range

### DIFF
--- a/crossroads.net/app/group_tool/group_search_filter/groupSearchFilter.controller.js
+++ b/crossroads.net/app/group_tool/group_search_filter/groupSearchFilter.controller.js
@@ -65,6 +65,11 @@ export default class GroupSearchResultsController {
       this.applyFilters();
     };
 
+    // Guard against errors if group has no age ranges.  Shouldn't happen, but just in case...
+    if(!searchResult.ageRange || !Array.isArray(searchResult.ageRange)) {
+      return false;
+    }
+    
     let filteredResults = searchResult.ageRange.filter((a) => {
       return selectedAgeRanges.find((s) => { return s === a.attributeId; }) !== undefined;
     });

--- a/crossroads.net/spec-es6/group_tool/group_search_filter/groupSearchFilter.controller.spec.js
+++ b/crossroads.net/spec-es6/group_tool/group_search_filter/groupSearchFilter.controller.spec.js
@@ -173,6 +173,16 @@ describe('GroupSearchFilter', () => {
         expect(fixture.ageRangeFilter(searchResult)).toBeFalsy();
         expect(fixture.currentFilters['Age Range']).toBeDefined();
       });
+
+      it('should return false if the search result does not contain an age range', () => {
+        fixture.ageRanges = [
+          { selected: false, attributeId: 123 },
+          { selected: true, attributeId: 456 }
+        ];
+        let searchResult = { };
+        expect(fixture.ageRangeFilter(searchResult)).toBeFalsy();
+        expect(fixture.currentFilters['Age Range']).toBeDefined();
+      });
     });
 
     describe('clearAgeRangeFilter', () => {


### PR DESCRIPTION
* [DE1779 - Filters not working for groups without age range](https://rally1.rallydev.com/#/27593764268d/detail/defect/60997784532)