### PR TITLE
defect/DE1786 remove future messages from past weekends

### DIFF
--- a/crossroads.net/core/services/CMSData.service.ts
+++ b/crossroads.net/core/services/CMSData.service.ts
@@ -33,7 +33,8 @@ export class CMSDataService {
     }
     
     getXMostRecentMessages(limit:number) {
-        return this.http.get(encodeURI(__CMS_ENDPOINT__ + `api/messages?date__sort=DESC&SeriesID__GreaterThan=0&__limit[]=${limit}`))
+        let todaysDate = new Date().toISOString().slice(0, 10);
+        return this.http.get(encodeURI(__CMS_ENDPOINT__ + `api/messages?date__LessThanOrEqual=${todaysDate}&date__sort=DESC&SeriesID__GreaterThan=0&__limit[]=${limit}`))
                         .map(rsp => {return rsp.json().messages});
     }
     

--- a/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
+++ b/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
@@ -82,7 +82,7 @@ describe('Service: CMSData', () => {
 
           expect(connection.request.method).toBe(RequestMethod.Get);
           expect(connection.request.url).toBe(
-            `${__CMS_ENDPOINT__}api/messages?date__LessThanOrEqual=${todaysDate}&date__sort=DESC&SeriesID__GreaterThan=0&__limit[]=4`);
+            `${__CMS_ENDPOINT__}api/messages?date__LessThanOrEqual=${todaysDate}&date__sort=DESC&SeriesID__GreaterThan=0&__limit%5B%5D=4`);
         });
 
         service.getXMostRecentMessages(4);

--- a/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
+++ b/crossroads.net/spec-ts/core/services/CMSData.service.spec.ts
@@ -78,10 +78,11 @@ describe('Service: CMSData', () => {
       [CMSDataService, MockBackend],
       fakeAsync((service: CMSDataService, backend: MockBackend) => {
         backend.connections.subscribe((connection: MockConnection) => {
+          let todaysDate = new Date().toISOString().slice(0, 10)
 
           expect(connection.request.method).toBe(RequestMethod.Get);
           expect(connection.request.url).toBe(
-            `${__CMS_ENDPOINT__}api/messages?date__sort=DESC&SeriesID__GreaterThan=0&__limit%5B%5D=4`);
+            `${__CMS_ENDPOINT__}api/messages?date__LessThanOrEqual=${todaysDate}&date__sort=DESC&SeriesID__GreaterThan=0&__limit[]=4`);
         });
 
         service.getXMostRecentMessages(4);


### PR DESCRIPTION
Update CMSDataService.getXRecentMessages to exclude future messages from displaying on Past Weekends