### PR TITLE
US4568: Add required message functionality to message component

### DIFF
--- a/crossroads.net/app/group_tool/group_detail/participants/groupDetail.participants.html
+++ b/crossroads.net/app/group_tool/group_detail/participants/groupDetail.participants.html
@@ -42,6 +42,7 @@
     email-template-text="groupToolRemoveParticipantEmailTemplateText"
     cancel-action="groupDetailParticipants.cancelRemoveParticipant(person)"
     submit-action="groupDetailParticipants.removeParticipant(person)"
+    email-message-required="true"
     processing="groupDetailParticipants.processing"
     ></group-message>
 </div>

--- a/crossroads.net/app/group_tool/group_detail/requests/groupDetail.requests.html
+++ b/crossroads.net/app/group_tool/group_detail/requests/groupDetail.requests.html
@@ -125,6 +125,7 @@
     email-template-text="groupToolDenyInquiryEmailTemplateText"
     cancel-action="groupDetailRequests.cancel(person)"
     submit-action="groupDetailRequests.submitDeny(person)"
+    email-message-required="true"
     processing="groupDetailRequests.processing"
     ></group-message>
 </div>

--- a/crossroads.net/app/group_tool/group_message/groupMessage.component.js
+++ b/crossroads.net/app/group_tool/group_message/groupMessage.component.js
@@ -15,6 +15,8 @@ export default function GroupMessageComponent() {
       subHeaderText: '@',
       contactText: '@',
       emailTemplateText: '@',
+      emailMessageLabel: '@',
+      emailMessageRequired: '@',
       cancelAction: '&',
       submitAction: '&',
       processing: '<',

--- a/crossroads.net/app/group_tool/group_message/groupMessage.controller.js
+++ b/crossroads.net/app/group_tool/group_message/groupMessage.controller.js
@@ -1,9 +1,26 @@
 
 export default class GroupMessageController {
   /*@ngInject*/
-  constructor() { }
+  constructor($rootScope) {
+    this.rootScope = $rootScope;
+  }
 
-  submit() {
+  $onInit() {
+    this.emailMessageRequired = Boolean(this.emailMessageRequired);  
+    if(!this.emailMessageLabel) {
+      this.emailMessageLabel = 'Your Message';
+      if(!this.emailMessageRequired) {
+        this.emailMessageLabel = `${this.emailMessageLabel} (Optional)`;
+      }
+    }
+  }
+
+  submit(groupMessageForm) {
+    // Validate the form - if ok, then invoke the submit callback
+    if(!groupMessageForm.$valid) {
+      this.rootScope.$emit('notify', this.rootScope.MESSAGES.generalError);
+      return;
+    }
     this.submitAction({person: this.person});
   }
 
@@ -12,14 +29,14 @@ export default class GroupMessageController {
   }
 
   hasSubHeaderText() {
-    return !(this.subHeaderText === null || this.subHeaderText === undefined)
+    return !(this.subHeaderText === null || this.subHeaderText === undefined);
   }
 
   hasContactText() {
-    return !(this.contactText === null || this.contactText === undefined)
+    return !(this.contactText === null || this.contactText === undefined);
   }
 
   hasEmailTemplateText() {
-    return !(this.emailTemplateText === null || this.emailTemplateText === undefined)
+    return !(this.emailTemplateText === null || this.emailTemplateText === undefined);
   }
 }

--- a/crossroads.net/app/group_tool/group_message/groupMessage.html
+++ b/crossroads.net/app/group_tool/group_message/groupMessage.html
@@ -1,4 +1,4 @@
-<form ng-submit='groupMessage.submit()'>
+<form name='groupMessageForm' ng-submit='groupMessage.submit(groupMessageForm)' novalidate>
   <div class='row'>
     <div class='col-md-6 col-md-offset-3'>
 
@@ -22,9 +22,12 @@
 
       <div class='row'>
         <div class='col-md-12'>
-          <div class='form-group'>
-            <label for='emailMessage' class='wide-label'>Your Message (Optional)</label>
-            <textarea type='textarea' rows='8' class='form-control' name='emailMessage' ng-model='groupMessage.person.message'></textarea>
+          <div class='form-group' ng-class='{"has-error": groupMessageForm.$submitted && groupMessageForm.emailMessage.$invalid}'>
+            <label for='emailMessage' class='control-label wide-label' ng-class='{"required": groupMessage.emailMessageRequired}'>{{ groupMessage.emailMessageLabel }}</label>
+            <textarea type='textarea' rows='8' class='form-control' name='emailMessage' ng-model='groupMessage.person.message' ng-required='groupMessage.emailMessageRequired'></textarea>
+            <ng-messages for="groupMessageForm.emailMessage.$error" ng-if="groupMessageForm.$submitted && groupMessageForm.emailMessage.$invalid">
+              <ng-messages-include src="on-submit-messages"></ng-messages-include>
+            </ng-messages>
           </div>
         </div>
       </div>

--- a/crossroads.net/spec-es6/group_tool/group_message/groupMessage.controller.spec.js
+++ b/crossroads.net/spec-es6/group_tool/group_message/groupMessage.controller.spec.js
@@ -3,31 +3,96 @@ import constants from 'crds-constants';
 import GroupMessageController from '../../../app/group_tool/group_message/groupMessage.controller';
 
 describe('GroupMessageController', () => {
-    let fixture;
+  let fixture,
+    rootScope;
 
-    beforeEach(angular.mock.module(constants.MODULES.GROUP_TOOL));
+  beforeEach(angular.mock.module(constants.MODULES.GROUP_TOOL));
 
-    beforeEach(inject(function(/* $injector */) {
-        fixture = new GroupMessageController();
-        fixture.person = {id: 123};
-    }));
-    
-    describe('submit() function', () => {
-        it('should invoke action', () => {
-          fixture.submitAction = jasmine.createSpy('submitAction');
-          fixture.submit();
+  beforeEach(inject(function ($injector) {
+    rootScope = $injector.get('$rootScope');
+    rootScope.MESSAGES = {
+      generalError: 'oh no!'
+    };
+    fixture = new GroupMessageController(rootScope);
+    fixture.person = { id: 123 };
+  }));
 
-          expect(fixture.submitAction).toHaveBeenCalledWith({person: fixture.person});
-        });
+  describe('$onInit function', () => {
+    it('should properly initialize email message label if not specified and required == undefined', () => {
+      fixture.emailMessageRequired = undefined;
+      fixture.emailMessageLabel = undefined;
+
+      fixture.$onInit();
+
+      expect(fixture.emailMessageRequired).toEqual(false);
+      expect(fixture.emailMessageLabel).toEqual('Your Message (Optional)');
     });
-    
-    describe('cancel() function', () => {
-        it('should invoke action', () => {
-          fixture.cancelAction = jasmine.createSpy('cancelAction');
-          fixture.cancel();
 
-          expect(fixture.cancelAction).toHaveBeenCalledWith({person: fixture.person});
-        });
+    it('should properly initialize email message label if not specified and required == null', () => {
+      fixture.emailMessageRequired = null;
+      fixture.emailMessageLabel = null;
+
+      fixture.$onInit();
+
+      expect(fixture.emailMessageRequired).toEqual(false);
+      expect(fixture.emailMessageLabel).toEqual('Your Message (Optional)');
     });
-    
+
+    it('should properly initialize email message label if not specified and required == false', () => {
+      fixture.emailMessageRequired = false;
+      fixture.emailMessageLabel = '';
+
+      fixture.$onInit();
+
+      expect(fixture.emailMessageRequired).toEqual(false);
+      expect(fixture.emailMessageLabel).toEqual('Your Message (Optional)');
+    });
+
+    it('should properly initialize email message label if not specified and required == true', () => {
+      fixture.emailMessageRequired = true;
+      fixture.emailMessageLabel = undefined;
+
+      fixture.$onInit();
+
+      expect(fixture.emailMessageRequired).toEqual(true);
+      expect(fixture.emailMessageLabel).toEqual('Your Message');
+    });
+  });
+
+  describe('submit() function', () => {
+    let form;
+    beforeEach(() => {
+      form = {
+        $valid: true
+      };
+    });
+
+    it('should invoke action if form is valid', () => {
+      fixture.submitAction = jasmine.createSpy('submitAction');
+      fixture.submit(form);
+
+      expect(fixture.submitAction).toHaveBeenCalledWith({ person: fixture.person });
+    });
+
+    it('should not invoke action if form is invalid', () => {
+      form.$valid = false;
+
+      fixture.submitAction = jasmine.createSpy('submitAction');
+      rootScope.$emit = jasmine.createSpy('$emit');
+      fixture.submit(form);
+
+      expect(fixture.submitAction).not.toHaveBeenCalled();
+      expect(rootScope.$emit).toHaveBeenCalledWith('notify', rootScope.MESSAGES.generalError);
+    });
+  });
+
+  describe('cancel() function', () => {
+    it('should invoke action', () => {
+      fixture.cancelAction = jasmine.createSpy('cancelAction');
+      fixture.cancel();
+
+      expect(fixture.cancelAction).toHaveBeenCalledWith({ person: fixture.person });
+    });
+  });
+
 });


### PR DESCRIPTION
* [US4568 - Require message when denying request or removing participant](https://rally1.rallydev.com/#/27593764268d/detail/userstory/59861948287)
* Note that this story is only to refactor the message component to allow users to specify whether the message is required or not, and prevent sending an email without a message if required.
* There is an existing defect, [DE1775](https://rally1.rallydev.com/#/27593764268d/detail/defect/60974721637), that will address issues with the actual email.