### PR TITLE
US4536: Streaming Video Embed

### DIFF
--- a/crossroads.net/app/streaming/videojs.component.ts
+++ b/crossroads.net/app/streaming/videojs.component.ts
@@ -21,6 +21,7 @@ export class VideoJSComponent implements AfterViewInit {
   id: string = "videojs-player";
   player: any;
   visible: boolean = false;
+  debug: boolean = false;
 
   constructor(private streamspot: StreamspotService) {}
 
@@ -54,6 +55,7 @@ export class VideoJSComponent implements AfterViewInit {
           "fluid": true,
           "poster" : defaultPlayer.bgLink,
           "preload": 'auto',
+          "controls": true,
           "html5": {
             "hlsjsConfig": {
               "debug": false
@@ -81,23 +83,8 @@ export class VideoJSComponent implements AfterViewInit {
           }
         });
             
-        if ( broadcaster.isBroadcasting === true ) {
-    
-          this.player.src([
-            {
-              "type": "application/x-mpegURL",
-              "src": broadcaster.live_src.cdn_hls
-            }
-          ]);
-
-          this.visible = true;
-
-          this.player.ready(() => {
-
-            this.player.play();
-
-          });
-          
+        if ( broadcaster.isBroadcasting === true || this.debug ) {
+          this.playerInit(broadcaster);
         }
         else {
           console.log('No broadcast available.');
@@ -111,6 +98,20 @@ export class VideoJSComponent implements AfterViewInit {
 
     });
 
+  }
+
+  playerInit(broadcaster) {
+    let src = this.debug ? "http://vjs.zencdn.net/v/oceans.mp4" : broadcaster.live_src.cdn_hls;
+    let type = this.debug ? "video/mp4" : "application/x-mpegURL";
+
+    this.player.src([
+      {
+        "type": type,
+        "src": src
+      }
+    ]);
+    this.visible = true;
+    this.player.ready(() => this.player.play());
   }
 
 }

--- a/crossroads.net/app/streaming/videojs.ng2component.html
+++ b/crossroads.net/app/streaming/videojs.ng2component.html
@@ -1,5 +1,5 @@
 <div [hidden]="!visible">
-  <video id="{{id}}" class="video-js vjs-default-skin vjs-big-play-centered" controls width="640" height="280">
+  <video id="{{id}}" class="video-js vjs-crds-skin vjs-big-play-centered" width="640" height="280">
     <p class="vjs-no-js">
       To view this video please enable JavaScript, and consider upgrading to a web browser that
       <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a>

--- a/crossroads.net/styles/pages/streaming.scss
+++ b/crossroads.net/styles/pages/streaming.scss
@@ -745,3 +745,92 @@ streaming {
     }
   }
 } // .live-stream
+
+
+
+.vjs-crds-skin {
+  overflow: hidden;
+
+  .vjs-control-bar {
+    background: transparent;
+  }
+
+  .vjs-progress-holder {
+    background-color: #4B4A51;
+  }
+
+  .vjs-load-progress {
+    background-color: #878A95;
+  }
+
+  .vjs-play-progress {
+    background-color: $streaming-blue;
+  }
+
+  .vjs-remaining-time {
+    display: none;
+  }
+
+  .vjs-current-time,
+  .vjs-duration,
+  .vjs-time-divider {
+    display: block;
+    order: 5;
+    width: auto;
+  }
+
+  .vjs-current-time {
+    padding-right: 0;
+  }
+
+  .vjs-duration {
+    padding-left: 0;
+  }
+
+  .vjs-time-divider {
+    margin: 0;
+  }
+
+  .vjs-current-time {
+    margin-left: 1em;
+  }
+
+  .vjs-volume-menu-button {
+    order: 6;
+  }
+
+  .vjs-chromecast-button,
+  .vjs-fullscreen-control {
+    order: 7;
+    flex: none;
+    position: absolute;
+    right: 0;
+  }
+
+  .vjs-chromecast-button {
+    right: 5.5em;
+  }
+
+  .vjs-fullscreen-control {
+    font-size: 120%;
+    margin-top: -0.35em;
+  }
+
+  .vjs-play-control {
+    flex: none;
+    align-self: center;
+    font-size: 250%;
+    margin-top: -3.2em;
+    width: 2em;
+  }
+
+  .vjs-progress-control {
+    flex: none;
+    position: absolute;
+    width: 100%;
+    bottom: 2em;
+    padding-right: 6em;
+    left: 5.35em;
+  }
+
+} // .vjs-crds-skin


### PR DESCRIPTION
This PR customizes the VJS player per the notes in [US4536](https://rally1.rallydev.com/#/41662702253d/detail/userstory/59651875173). I also refactored `videojs.component` by adding a new `debug` instance variable which allows you to bypass the redirect during times when a live stream is not available. 