### PR TITLE
US4697 - Right align group tool buttons, stack on mobile

### DIFF
--- a/crossroads.net/app/group_tool/create_group/createGroup.html
+++ b/crossroads.net/app/group_tool/create_group/createGroup.html
@@ -3,8 +3,8 @@
   <div dynamic-content="$root.MESSAGES.groupToolCreateGroupHeading.content | html"></div>
   <form ng-submit="createGroup.previewGroup()" novalidate name="createGroup.createGroupForm">
     <formly-form model="createGroup.createGroupService.model" fields="createGroup.fields" form="createGroup.createGroupForm" options="createGroup.options" ng-cloak>
-      <div class="col-md-12 push-top text-center">
-        <button type="submit" class="btn btn-primary submit-button">Preview Group</button>
+      <div class="col-md-12 push-top text-center sm-text-right">
+        <button type="submit" class="btn btn-primary btn-block-mobile submit-button">Preview Group</button>
       </div>
     </formly-form>
   </form>

--- a/crossroads.net/app/group_tool/create_group/preview/createGroup.preview.html
+++ b/crossroads.net/app/group_tool/create_group/preview/createGroup.preview.html
@@ -1,11 +1,13 @@
 <group-detail-about data="createGroupPreview.groupData"> </group-detail-about>
-      <button ng-if="!createGroupPreview.edit" type="submit" class="btn btn-primary" ui-sref='grouptool.create'>Edit</button>
-      <button ng-if="createGroupPreview.edit" type="submit" class="btn btn-primary" ui-sref='grouptool.edit({ groupId: createGroupPreview.groupData.groupId })'>Edit</button>
-      <loading-button
-            normal-text='Submit Group'
-            loading-text='Saving...'
-            loading='createGroupPreview.saving'
-            loading-class='disabled'
-            input-classes='btn btn-primary'
-            type="submit"
-            ng-click='createGroupPreview.submit()'></loading-button>
+<div class="text-center sm-text-right">
+  <button ng-if="!createGroupPreview.edit" type="submit" class="btn btn-standard btn-block-mobile mobile-push-half-bottom" ui-sref='grouptool.create'>Edit</button>
+  <button ng-if="createGroupPreview.edit" type="submit" class="btn btn-standard btn-block-mobile mobile-push-half-bottom" ui-sref='grouptool.edit({ groupId: createGroupPreview.groupData.groupId })'>Edit</button>
+  <loading-button
+    normal-text='Submit Group'
+    loading-text='Saving...'
+    loading='createGroupPreview.saving'
+    loading-class='disabled'
+    input-classes='btn btn-primary btn-block-mobile mobile-push-half-bottom'
+    type="submit"
+    ng-click='createGroupPreview.submit()'></loading-button>
+</div>

--- a/crossroads.net/app/group_tool/edit_group/editGroup.html
+++ b/crossroads.net/app/group_tool/edit_group/editGroup.html
@@ -6,8 +6,8 @@
   <p>Hi leader! </p>
   <form ng-submit="editGroup.previewGroup()" novalidate name="editGroup.editGroupForm">
     <formly-form model="editGroup.createGroupService.model" fields="editGroup.fields" form="editGroup.editGroupForm" options="editGroup.options" ng-cloak>
-      <div class="col-md-12 push-top text-center">
-        <button type="submit" class="btn btn-primary submit-button">Preview Group</button>
+      <div class="col-md-12 push-top text-center sm-text-right">
+        <button type="submit" class="btn btn-primary submit-button btn-block-mobile">Preview Group</button>
       </div>
     </formly-form>
   </form>

--- a/crossroads.net/app/group_tool/end_group/endGroup.html
+++ b/crossroads.net/app/group_tool/end_group/endGroup.html
@@ -5,14 +5,14 @@
   <form ng-submit="endGroup.endGroup()" novalidate name="endGroup.endGroupForm">
     <formly-form model="endGroup.model" fields="endGroup.fields" form="endGroup.endGroupForm"
       options="createGroup.options" ng-cloak>
-      <div class="col-md-12 push-top text-center">
-        <button type="submit" class="btn btn-standard" ng-click="endGroup.cancel()">Cancel</button>
+      <div class="col-md-12 push-top text-center sm-text-right">
+        <button type="submit" class="btn btn-standard btn-block-mobile mobile-push-half-bottom" ng-click="endGroup.cancel()">Cancel</button>
         <loading-button
             normal-text='Submit'
             loading-text='Ending...'
             loading='endGroup.saving'
             loading-class='disabled'
-            input-classes='btn btn-primary submit-button'
+            input-classes='btn btn-primary submit-button btn-block-mobile mobile-push-half-bottom'
             type="submit"
             ng-click='endGroup.submit()'></loading-button>
       </div>

--- a/crossroads.net/app/group_tool/group_detail/participants/groupDetail.participants.html
+++ b/crossroads.net/app/group_tool/group_detail/participants/groupDetail.participants.html
@@ -18,20 +18,20 @@
 
   <div ng-if="groupDetailParticipants.isListView() && groupDetailParticipants.isLeader" dynamic-content="$root.MESSAGES.groupToolDetailParticipantsHelpText.content | html" class="text-center"></div>
 
-  <div ng-if="groupDetailParticipants.data.length > 1" class="text-center sm-text-right">
-    <div ng-if='groupDetailParticipants.isListView()' class="inline">
+  <div class="text-center sm-text-right">
+    <div ng-if='groupDetailParticipants.data.length > 1 && groupDetailParticipants.isListView()'>
+      <a type='button' class='btn btn-standard btn-block-mobile push-half-bottom' href='#' ng-click='groupDetailParticipants.setEditView()' ng-if='groupDetailParticipants.isLeader'>Edit</a>
       <a type='button' class='btn btn-primary btn-block-mobile push-half-bottom' href="mailto:?bcc={{groupDetailParticipants.emailList()}}" target="_top">Email Group</a>
-      <a type='button' class='btn btn-primary btn-block-mobile push-half-bottom' href='#' ng-click='groupDetailParticipants.setEditView()' ng-if='groupDetailParticipants.isLeader'>Edit</a>
+      <a ui-sref="grouptool.mygroups" class="sm-pull-left">
+        <svg viewBox="0 0 32 32" class="icon icon-large arrow-circle-o-left">
+          <use xlink:href="#arrow-circle-o-left"></use>
+        </svg>
+        Back to My Groups
+      </a>
     </div>
-    <div class='text-center' ng-if='groupDetailParticipants.isEditView()' class="inline">
+    <div ng-if='groupDetailParticipants.isEditView()' class="inline">
       <a type='button' class='btn btn-primary btn-block-mobile push-half-bottom' href='#' ng-click='groupDetailParticipants.setListView()' ng-if='groupDetailParticipants.isLeader'>Cancel</a>
     </div>
-    <a ui-sref="grouptool.mygroups" class="sm-pull-left">
-      <svg viewBox="0 0 32 32" class="icon icon-large arrow-circle-o-left">
-        <use xlink:href="#arrow-circle-o-left"></use>
-      </svg>
-      Back to My Groups
-    </a>
   </div>
 </div>
 

--- a/crossroads.net/app/group_tool/group_detail/requests/invite/groupDetail.invite.html
+++ b/crossroads.net/app/group_tool/group_detail/requests/invite/groupDetail.invite.html
@@ -41,19 +41,15 @@
 
         <div class='row'>&nbsp;</div>
 
-        <div class='row'>
-          <div class='col-md-12'>
-            <p class='text-center'>
-              <button type='button' class='btn btn-standard' ng-click='groupDetailInvite.cancel()'>Cancel</button>
-              <loading-button 
-                input-type='submit'
-                normal-text='Send'
-                loading-text='Sending...'
-                loading='groupDetailInvite.processing'
-                loading-class='disabled'
-                input-classes='btn btn-primary'/>
-            </p>
-          </div>
+        <div class='text-center sm-text-right'>
+          <button type='button' class='btn btn-standard btn-block-mobile mobile-push-half-bottom' ng-click='groupDetailInvite.cancel()'>Cancel</button>
+          <loading-button
+            input-type='submit'
+            normal-text='Send'
+            loading-text='Sending...'
+            loading='groupDetailInvite.processing'
+            loading-class='disabled'
+            input-classes='btn btn-primary btn-block-mobile mobile-push-half-bottom'/>
         </div>
       </div>
     </div>

--- a/crossroads.net/app/group_tool/group_invitation/groupInvitation.html
+++ b/crossroads.net/app/group_tool/group_invitation/groupInvitation.html
@@ -22,50 +22,46 @@
         <group-detail-about data="groupInvitation.group" for-invitation="true"></group-detail-about>
       </div>
     </div>
-    <div class='row'>
-      <div class='col-md-12'>
-        <p class='text-center'>
-          <!-- shows at page load and if processing a deny -->
-          <loading-button
-                  normal-text='No Thanks'
-                  loading-text='Denying Invite...'
-                  loading='groupInvitation.processingDeny'
-                  loading-class='disabled'
-                  input-classes='btn btn-standard'
-                  ng-click='groupInvitation.deny()'
-                  ng-if='(!groupInvitation.processingAccept && !groupInvitation.processingDeny) || groupInvitation.processingDeny'></loading-button>
-          
-          <!-- shows when processing a accept request -->
-          <loading-button
-                  normal-text='No Thanks'
-                  loading-text='No Thanks'
-                  loading='groupInvitation.processingAccept'
-                  loading-class='disabled'
-                  input-classes='btn btn-standard'
-                  ng-click='groupInvitation.deny()'
-                  ng-if='groupInvitation.processingAccept && !groupInvitation.processingDeny'></loading-button>
+    <div class='push-top text-center sm-text-right'>
+      <!-- shows at page load and if processing a deny -->
+      <loading-button
+              normal-text='No Thanks'
+              loading-text='Denying Invite...'
+              loading='groupInvitation.processingDeny'
+              loading-class='disabled'
+              input-classes='btn btn-standard btn-block-mobile mobile-push-half-bottom'
+              ng-click='groupInvitation.deny()'
+              ng-if='(!groupInvitation.processingAccept && !groupInvitation.processingDeny) || groupInvitation.processingDeny'></loading-button>
 
-          <!-- shows at page load and if processing a accepting -->
-          <loading-button
-                  normal-text='Join Group'
-                  loading-text='Joining Group...'
-                  loading='groupInvitation.processingAccept'
-                  loading-class='disabled'
-                  input-classes='btn btn-primary'
-                  ng-click='groupInvitation.accept()'
-                  ng-if='(!groupInvitation.processingAccept && !groupInvitation.processingDeny) || groupInvitation.processingAccept'></loading-button>
-          
-          <!-- shows when processing a deny request -->
-          <loading-button
-                  normal-text='Join Group'
-                  loading-text='Join Group'
-                  loading='groupInvitation.processingDeny'
-                  loading-class='disabled'
-                  input-classes='btn btn-primary'
-                  ng-click='groupInvitation.accept()'
-                  ng-if='!groupInvitation.processingAccept && groupInvitation.processingDeny'></loading-button>
-        </p>
-      </div>
+      <!-- shows when processing a accept request -->
+      <loading-button
+              normal-text='No Thanks'
+              loading-text='No Thanks'
+              loading='groupInvitation.processingAccept'
+              loading-class='disabled'
+              input-classes='btn btn-standard btn-block-mobile mobile-push-half-bottom'
+              ng-click='groupInvitation.deny()'
+              ng-if='groupInvitation.processingAccept && !groupInvitation.processingDeny'></loading-button>
+
+      <!-- shows at page load and if processing a accepting -->
+      <loading-button
+              normal-text='Join Group'
+              loading-text='Joining Group...'
+              loading='groupInvitation.processingAccept'
+              loading-class='disabled'
+              input-classes='btn btn-primary btn-block-mobile mobile-push-half-bottom'
+              ng-click='groupInvitation.accept()'
+              ng-if='(!groupInvitation.processingAccept && !groupInvitation.processingDeny) || groupInvitation.processingAccept'></loading-button>
+
+      <!-- shows when processing a deny request -->
+      <loading-button
+              normal-text='Join Group'
+              loading-text='Join Group'
+              loading='groupInvitation.processingDeny'
+              loading-class='disabled'
+              input-classes='btn btn-primary btn-block-mobile mobile-push-half-bottom'
+              ng-click='groupInvitation.accept()'
+              ng-if='!groupInvitation.processingAccept && groupInvitation.processingDeny'></loading-button>
     </div>
   </div>
 </div>

--- a/crossroads.net/app/group_tool/group_message/groupMessage.html
+++ b/crossroads.net/app/group_tool/group_message/groupMessage.html
@@ -36,15 +36,15 @@
       
       <div class='row'>
         <div class='col-md-12'>
-          <p class='text-center'>
-            <a type='button' class='btn btn-standard' href='#' ng-click='groupMessage.cancel()'>Cancel</a>
+          <p class='text-center sm-text-right'>
+            <a type='button' class='btn btn-standard btn-block-mobile mobile-push-half-bottom' href='#' ng-click='groupMessage.cancel()'>Cancel</a>
             <loading-button 
               input-type='submit'
               normal-text='{{ groupMessage.normalLoadingText }}'
               loading-text='{{ groupMessage.loadingLoadingText }}'
               loading='groupMessage.processing'
               loading-class='disabled'
-              input-classes='btn btn-primary'/>
+              input-classes='btn btn-primary btn-block-mobile mobile-push-half-bottom'/>
           </p>
         </div>
       </div>


### PR DESCRIPTION
* Right align any button that was still centered
* Make sure buttons are full-width and stack vertically with a small margin on mobile
* Change some buttons to `btn-standard` so there is only one "primary" button per page/form