### PR TITLE
DE1808 - Fix for participant layout issue

### DIFF
--- a/crossroads.net/styles/modules/group-participants-cards.scss
+++ b/crossroads.net/styles/modules/group-participants-cards.scss
@@ -10,11 +10,15 @@
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
+    justify-content: flex-start;
   }
 
   .group-detail-participant-item {
     @media (min-width: $screen-md) {
-      flex: 1 1 auto;
+      flex: none;
+
+      // Safari is wrapping when it shouldn't, reduce the right margin by -1px to fix
+      margin-right: -1px;
     }
   }
 }


### PR DESCRIPTION
Set the flex: css style to `non` so that the participant items will honor the bootstrap widths
Adjust margin-left by -1px because Safari is wrapping for some reason when it shouldn't