### PR TITLE
Fix test that would occasionally fail due to DateTime mismatch

### DIFF
--- a/Gateway/MinistryPlatform.Translation.Test/Services/CommunicationServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/CommunicationServiceTest.cs
@@ -183,7 +183,12 @@ namespace MinistryPlatform.Translation.Test.Services
             _ministryPlatformService.Setup(mock => mock.CreateSubRecord(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<Dictionary<string, object>>(), It.IsAny<string>(), false))
                 .Returns(1);
             _fixture.SendMessage(comm);
-            Assert.AreEqual(DateTime.Now, spiedDict["Start_Date"]);
+
+            // Verify that the dictionary contains a Start_Date, that it is a DateTime, 
+            // and that is reasonably close to DateTime.Now
+            Assert.IsTrue(spiedDict.ContainsKey("Start_Date"));
+            Assert.IsInstanceOf<DateTime>(spiedDict["Start_Date"]);
+            Assert.IsTrue(DateTime.Now.Subtract((DateTime)spiedDict["Start_Date"]).TotalSeconds < 30);
         }
     }
 }


### PR DESCRIPTION
* Previously was comparing a DateTime in dictionary to DateTime.Now, but those were sometimes not exactly equal, causing test failure.  Now we just make sure the value in the dictionary is relatively close to DateTime.Now.
* No associated defect or user story to approve for this PR
