### PR TITLE
US4782 - Add cancel link to Create and Edit groups pages

### DIFF
--- a/crossroads.net/app/group_tool/create_group/createGroup.controller.js
+++ b/crossroads.net/app/group_tool/create_group/createGroup.controller.js
@@ -3,7 +3,7 @@ import SmallGroup from '../model/smallGroup';
 
 export default class CreateGroupController {
     /*@ngInject*/
-    constructor(ParticipantService, $state, $log, CreateGroupService, GroupService, $rootScope, $window) {
+    constructor(ParticipantService, $state, $stateParams, $log, CreateGroupService, GroupService, $rootScope, $window) {
         this.log = $log;
         this.state = $state;
         this.participantService = ParticipantService;
@@ -16,6 +16,10 @@ export default class CreateGroupController {
         this.createGroupForm = {};
         this.options = {};
         this.window = $window;
+
+        // If the state that called this component has a specific state route for the Cancel button set it now
+        // The cancel button will be hidden if there isn't a cancelSref
+        this.cancelSref = $stateParams.cancelSref;
     }
 
     $onInit() {

--- a/crossroads.net/app/group_tool/create_group/createGroup.html
+++ b/crossroads.net/app/group_tool/create_group/createGroup.html
@@ -4,7 +4,8 @@
   <form ng-submit="createGroup.previewGroup()" novalidate name="createGroup.createGroupForm">
     <formly-form model="createGroup.createGroupService.model" fields="createGroup.fields" form="createGroup.createGroupForm" options="createGroup.options" ng-cloak>
       <div class="col-md-12 push-top text-center sm-text-right">
-        <button type="submit" class="btn btn-primary btn-block-mobile submit-button">Preview Group</button>
+        <button ng-if="createGroup.cancelSref" ui-sref="{{createGroup.cancelSref}}" type="button" class="btn btn-standard btn-block-mobile mobile-push-half-bottom">Cancel</button>
+        <button type="submit" class="btn btn-primary btn-block-mobile submit-button mobile-push-half-bottom">Preview Group</button>
       </div>
     </formly-form>
   </form>

--- a/crossroads.net/app/group_tool/edit_group/editGroup.html
+++ b/crossroads.net/app/group_tool/edit_group/editGroup.html
@@ -7,6 +7,7 @@
   <form ng-submit="editGroup.previewGroup()" novalidate name="editGroup.editGroupForm">
     <formly-form model="editGroup.createGroupService.model" fields="editGroup.fields" form="editGroup.editGroupForm" options="editGroup.options" ng-cloak>
       <div class="col-md-12 push-top text-center sm-text-right">
+        <button ui-sref='grouptool.detail({groupId: editGroup.stateParams.groupId})' type="button" class="btn btn-standard btn-block-mobile mobile-push-half-bottom">Cancel</button>
         <button type="submit" class="btn btn-primary submit-button btn-block-mobile">Preview Group</button>
       </div>
     </formly-form>

--- a/crossroads.net/app/group_tool/groupTool.routes.js
+++ b/crossroads.net/app/group_tool/groupTool.routes.js
@@ -26,6 +26,9 @@ export default function GroupToolRouter($httpProvider, $stateProvider) {
     .state('grouptool.create', {
       parent: 'noSideBar',
       url: '/groups/create',
+      params: {
+        cancelSref: null
+      },
       template: '<create-group></create-group>',
       resolve:{
         stateList: (CreateGroupService, GroupService) =>{

--- a/crossroads.net/app/group_tool/my_groups/myGroups.html
+++ b/crossroads.net/app/group_tool/my_groups/myGroups.html
@@ -23,7 +23,7 @@
 
             <!-- Lead a Group -->
             <div ng-class="{ 'col-md-6 col-sm-12': myGroups.groupsEven() }">
-              <div class="my-groups-static panel panel-default text-center pointer" ui-sref="grouptool.create">
+              <div class="my-groups-static panel panel-default text-center pointer" ui-sref="grouptool.create({ cancelSref: 'grouptool.mygroups' })">
                 <div class="my-groups-static-vert">
                   <div class="push-half-bottom">Lead a Group</div>
                   <svg viewBox="0 0 32 32" class="icon icon-xxxlarge plus4 text-primary">


### PR DESCRIPTION
### UX Details
#### Start a Group
* Cancel button only visible if linked from My Groups dashboard and will take you back to My Groups (the ui-router state that calls to `grouptool.create` must provide a state param `cancelSref` with the state the cancel button should return to.  IF there is no `cancelSref` the Cancel button will not be visible
* If clicked from leader approval email to Start a Group, there should be no Cancel button

![create - desktop](https://cloud.githubusercontent.com/assets/2341619/18016105/8ba86ae8-6b98-11e6-9816-b03ab5895247.png)
![create - mobile](https://cloud.githubusercontent.com/assets/2341619/18016103/8ba5c20c-6b98-11e6-9c2e-6dd340d59550.png)

#### Edit Group
* Cancel button always visible and takes me back to Group Detail About tab

![edit - desktop](https://cloud.githubusercontent.com/assets/2341619/18016104/8ba674c2-6b98-11e6-9883-7e65ba7aab79.png)
![edit - mobile](https://cloud.githubusercontent.com/assets/2341619/18016106/8bb1e4ba-6b98-11e6-92e7-c4ad2a65e9c9.png)


