### PR TITLE
DE1866 - Fix mobile link for Back to My Groups

### DIFF
--- a/crossroads.net/app/group_tool/group_detail/participants/groupDetail.participants.html
+++ b/crossroads.net/app/group_tool/group_detail/participants/groupDetail.participants.html
@@ -18,19 +18,21 @@
 
   <div ng-if="groupDetailParticipants.isListView() && groupDetailParticipants.isLeader" dynamic-content="$root.MESSAGES.groupToolDetailParticipantsHelpText.content | html" class="text-center"></div>
 
-  <div class="text-center sm-text-right clearfix">
-    <div ng-if='groupDetailParticipants.data.length > 1 && groupDetailParticipants.isListView()' class="inline-block">
+  <div class="row mobile-push-half-top">
+    <div ng-if='groupDetailParticipants.data.length > 1 && groupDetailParticipants.isListView()' class="col-sm-6 col-sm-push-6 sm-text-right">
       <a type='button' class='btn btn-standard btn-block-mobile push-half-bottom' href='#' ng-click='groupDetailParticipants.setEditView()' ng-if='groupDetailParticipants.isLeader'>Edit</a>
       <a type='button' class='btn btn-primary btn-block-mobile push-half-bottom' href="mailto:?bcc={{groupDetailParticipants.emailList()}}" target="_top">Email Group</a>
     </div>
-    <a ui-sref="grouptool.mygroups" ng-if="groupDetailParticipants.isListView()" class="sm-pull-left">
-      <svg viewBox="0 0 32 32" class="icon icon-large arrow-circle-o-left">
-        <use xlink:href="#arrow-circle-o-left"></use>
-      </svg>
-      Back to My Groups
-    </a>
-    <div ng-if='groupDetailParticipants.isEditView()' class="inline">
+    <div ng-if='groupDetailParticipants.isEditView()' class="col-sm-6 col-sm-offset-6">
       <a type='button' class='btn btn-primary btn-block-mobile push-half-bottom' href='#' ng-click='groupDetailParticipants.setListView()' ng-if='groupDetailParticipants.isLeader'>Cancel</a>
+    </div>
+    <div class="col-sm-6 col-sm-pull-6 text-center sm-text-left mobile-push-half-top">
+      <a ui-sref="grouptool.mygroups" ng-if="groupDetailParticipants.isListView()">
+        <svg viewBox="0 0 32 32" class="icon icon-large arrow-circle-o-left">
+          <use xlink:href="#arrow-circle-o-left"></use>
+        </svg>
+        Back to My Groups
+      </a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
 needs to be handled as a bootstrap column so that on mobile the inline-block and the pull left will not cause the buttons and link to be in the same row

![mobile view](https://cloud.githubusercontent.com/assets/2341619/18100203/f92bbb34-6eb7-11e6-8b11-7bc3a1cc5d0f.png)