### PR TITLE
US4806 - Switch button order on mobile so that primary buttons are on top

### DIFF
--- a/crossroads.net/app/group_tool/confirm_request/confirmRequest.html
+++ b/crossroads.net/app/group_tool/confirm_request/confirmRequest.html
@@ -6,7 +6,6 @@
     <group-detail-about data="confirmRequest.group"></group-detail-about>
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-standard btn-block-mobile mobile-push-half-bottom" ng-click="confirmRequest.cancel()">Back to Search Results</button>
     <loading-button
       ng-click="confirmRequest.submit()"
       input-type='button'
@@ -14,7 +13,8 @@
       loading-text='Sending...'
       loading='confirmRequest.processing'
       loading-class='disabled'
-      input-classes='btn btn-primary btn-block-mobile mobile-push-half-bottom'></loading-button>
+      input-classes='sm-pull-right btn btn-primary btn-block-mobile mobile-push-half-bottom'></loading-button>
+    <button type="button" class="btn btn-standard btn-block-mobile mobile-push-half-bottom" ng-click="confirmRequest.cancel()">Back to Search Results</button>
   </div>
 </div>
 
@@ -32,7 +32,6 @@
       <group-email message='confirmRequest.groupMessage' allow-subject='true'/>
     </div>
     <div class="modal-footer">
-      <button type="button" class="btn btn-standard btn-block-mobile mobile-push-half-bottom" ng-click="confirmRequest.cancel()">Back to Search Results</button>
       <loading-button
         ng-click="confirmRequest.sendEmail(groupEmailForm)"
         input-type='button'
@@ -40,7 +39,8 @@
         loading-text='Sending...'
         loading='confirmRequest.processing'
         loading-class='disabled'
-        input-classes='btn btn-primary btn-block-mobile mobile-push-half-bottom'></loading-button>
+        input-classes='sm-pull-right btn btn-primary btn-block-mobile mobile-push-half-bottom'></loading-button>
+      <button type="button" class="btn btn-standard btn-block-mobile mobile-push-half-bottom" ng-click="confirmRequest.cancel()">Back to Search Results</button>
     </div>
   </form>
 </div>

--- a/crossroads.net/app/group_tool/create_group/createGroup.html
+++ b/crossroads.net/app/group_tool/create_group/createGroup.html
@@ -3,9 +3,9 @@
   <div dynamic-content="$root.MESSAGES.groupToolCreateGroupHeading.content | html"></div>
   <form ng-submit="createGroup.previewGroup()" novalidate name="createGroup.createGroupForm">
     <formly-form model="createGroup.createGroupService.model" fields="createGroup.fields" form="createGroup.createGroupForm" options="createGroup.options" ng-cloak>
-      <div class="col-md-12 push-top text-center sm-text-right">
+      <div class="clearfix push-top text-center sm-text-right">
+        <button type="submit" class="sm-pull-right btn btn-primary btn-block-mobile submit-button mobile-push-half-bottom">Preview Group</button>
         <button ng-if="createGroup.cancelSref" ui-sref="{{createGroup.cancelSref}}" type="button" class="btn btn-standard btn-block-mobile mobile-push-half-bottom">Cancel</button>
-        <button type="submit" class="btn btn-primary btn-block-mobile submit-button mobile-push-half-bottom">Preview Group</button>
       </div>
     </formly-form>
   </form>

--- a/crossroads.net/app/group_tool/create_group/preview/createGroup.preview.html
+++ b/crossroads.net/app/group_tool/create_group/preview/createGroup.preview.html
@@ -1,13 +1,13 @@
 <group-detail-about data="createGroupPreview.groupData"> </group-detail-about>
-<div class="text-center sm-text-right">
-  <button ng-if="!createGroupPreview.edit" type="submit" class="btn btn-standard btn-block-mobile mobile-push-half-bottom" ui-sref='grouptool.create'>Edit</button>
-  <button ng-if="createGroupPreview.edit" type="submit" class="btn btn-standard btn-block-mobile mobile-push-half-bottom" ui-sref='grouptool.edit({ groupId: createGroupPreview.groupData.groupId })'>Edit</button>
+<div class="clearfix push-top text-center sm-text-right">
   <loading-button
     normal-text='Submit Group'
     loading-text='Submitting...'
     loading='createGroupPreview.saving'
     loading-class='disabled'
-    input-classes='btn btn-primary btn-block-mobile mobile-push-half-bottom'
+    input-classes='sm-pull-right btn btn-primary btn-block-mobile mobile-push-half-bottom'
     type="submit"
     ng-click='createGroupPreview.submit()'></loading-button>
+  <button ng-if="!createGroupPreview.edit" type="submit" class="btn btn-standard btn-block-mobile mobile-push-half-bottom" ui-sref='grouptool.create'>Edit</button>
+  <button ng-if="createGroupPreview.edit" type="submit" class="btn btn-standard btn-block-mobile mobile-push-half-bottom" ui-sref='grouptool.edit({ groupId: createGroupPreview.groupData.groupId })'>Edit</button>
 </div>

--- a/crossroads.net/app/group_tool/edit_group/editGroup.html
+++ b/crossroads.net/app/group_tool/edit_group/editGroup.html
@@ -6,9 +6,9 @@
   <p>Hi leader! </p>
   <form ng-submit="editGroup.previewGroup()" novalidate name="editGroup.editGroupForm">
     <formly-form model="editGroup.createGroupService.model" fields="editGroup.fields" form="editGroup.editGroupForm" options="editGroup.options" ng-cloak>
-      <div class="col-md-12 push-top text-center sm-text-right">
+      <div class="clearfix col-md-12 push-top text-center sm-text-right">
+        <button type="submit" class="sm-pull-right btn btn-primary submit-button btn-block-mobile mobile-push-half-bottom">Preview Group</button>
         <button ui-sref='grouptool.detail({groupId: editGroup.stateParams.groupId})' type="button" class="btn btn-standard btn-block-mobile mobile-push-half-bottom">Cancel</button>
-        <button type="submit" class="btn btn-primary submit-button btn-block-mobile">Preview Group</button>
       </div>
     </formly-form>
   </form>

--- a/crossroads.net/app/group_tool/end_group/endGroup.html
+++ b/crossroads.net/app/group_tool/end_group/endGroup.html
@@ -7,15 +7,15 @@
       <formly-form model="endGroup.model" fields="endGroup.fields" form="endGroup.endGroupForm"
         options="createGroup.options" ng-cloak>
         <div class="col-md-12 push-top text-center sm-text-right">
-          <button type="submit" class="btn btn-standard btn-block-mobile mobile-push-half-bottom" ng-click="endGroup.cancel()">Cancel</button>
           <loading-button
               normal-text='Submit'
               loading-text='Submitting...'
               loading='endGroup.saving'
               loading-class='disabled'
-              input-classes='btn btn-primary submit-button btn-block-mobile mobile-push-half-bottom'
+              input-classes='sm-pull-right btn btn-primary submit-button btn-block-mobile mobile-push-half-bottom'
               type="submit"
               ng-click='endGroup.submit()'></loading-button>
+          <button type="submit" class="btn btn-standard btn-block-mobile mobile-push-half-bottom" ng-click="endGroup.cancel()">Cancel</button>
         </div>
       </formly-form>
     </form>

--- a/crossroads.net/app/group_tool/group_detail/about/groupDetail.about.html
+++ b/crossroads.net/app/group_tool/group_detail/about/groupDetail.about.html
@@ -73,9 +73,9 @@
 
     </div>
   </div>
-  <div class='push-top text-center sm-text-right' ng-if='groupDetailAbout.showFooter'>
+  <div class='push-top text-center sm-text-right clearfix' ng-if='groupDetailAbout.showFooter'>
+    <button type='button' ng-if='groupDetailAbout.isLeader' ng-click='groupDetailAbout.goToEdit()' class='sm-pull-right push-half-bottom btn btn-primary btn-block-mobile'>Edit</button>
     <button type='button' ng-if='groupDetailAbout.isLeader' ng-click="groupDetailAbout.goToEnd()" class='push-half-bottom btn btn-standard btn-block-mobile'>End Group</button>
-    <button type='button' ng-if='groupDetailAbout.isLeader' ng-click='groupDetailAbout.goToEdit()' class='push-half-bottom btn btn-primary btn-block-mobile'>Edit</button>
     <a ui-sref="grouptool.mygroups" class="sm-pull-left">
       <svg viewBox="0 0 32 32" class="icon icon-large arrow-circle-o-left">
         <use xlink:href="#arrow-circle-o-left"></use>

--- a/crossroads.net/app/group_tool/group_detail/participants/change_participant_role/changeParticipantRole.html
+++ b/crossroads.net/app/group_tool/group_detail/participants/change_participant_role/changeParticipantRole.html
@@ -57,14 +57,16 @@
       </div>
 
       <div class='text-right push-ends'>
-        <a type='button' class='btn btn-standard btn-block-mobile mobile-push-half-bottom' href='#' ng-click='changeParticipantRole.cancel(changeParticipantForm)'>Cancel</a>
         <loading-button
           input-type='submit'
           normal-text='Change Role'
           loading-text='Changing...'
           loading='changeParticipantRole.processing'
           loading-class='disabled'
-          input-classes='btn btn-primary btn-block-mobile mobile-push-half-bottom'/>
+          input-classes='sm-pull-right btn btn-primary btn-block-mobile mobile-push-half-bottom'></loading-button>
+
+        <a type='button' class='btn btn-standard btn-block-mobile mobile-push-half-bottom' href='#' ng-click='changeParticipantRole.cancel(changeParticipantForm)'>Cancel</a>
+
       </div>
     </div>
   </div>

--- a/crossroads.net/app/group_tool/group_detail/participants/groupDetail.participants.html
+++ b/crossroads.net/app/group_tool/group_detail/participants/groupDetail.participants.html
@@ -20,8 +20,8 @@
 
   <div class="row mobile-push-half-top">
     <div ng-if='groupDetailParticipants.data.length > 1 && groupDetailParticipants.isListView()' class="col-sm-6 col-sm-push-6 sm-text-right">
+      <a type='button' class='btn btn-primary btn-block-mobile push-half-bottom sm-pull-right' href="mailto:?bcc={{groupDetailParticipants.emailList()}}" target="_top">Email Group</a>
       <a type='button' class='btn btn-standard btn-block-mobile push-half-bottom' href='#' ng-click='groupDetailParticipants.setEditView()' ng-if='groupDetailParticipants.isLeader'>Edit</a>
-      <a type='button' class='btn btn-primary btn-block-mobile push-half-bottom' href="mailto:?bcc={{groupDetailParticipants.emailList()}}" target="_top">Email Group</a>
     </div>
     <div ng-if='groupDetailParticipants.isEditView()' class="col-sm-6 col-sm-offset-6">
       <a type='button' class='btn btn-primary btn-block-mobile push-half-bottom' href='#' ng-click='groupDetailParticipants.setListView()' ng-if='groupDetailParticipants.isLeader'>Cancel</a>

--- a/crossroads.net/app/group_tool/group_detail/requests/invite/groupDetail.invite.html
+++ b/crossroads.net/app/group_tool/group_detail/requests/invite/groupDetail.invite.html
@@ -57,14 +57,14 @@
         <div class='row'>&nbsp;</div>
 
         <div class='text-center sm-text-right'>
-          <button type='button' class='btn btn-standard btn-block-mobile mobile-push-half-bottom' ng-click='groupDetailInvite.cancel()'>Cancel</button>
           <loading-button
             input-type='submit'
             normal-text='Send'
             loading-text='Sending...'
             loading='groupDetailInvite.processing'
             loading-class='disabled'
-            input-classes='btn btn-primary btn-block-mobile mobile-push-half-bottom'/>
+            input-classes='sm-pull-right btn btn-primary btn-block-mobile mobile-push-half-bottom'></loading-button>
+          <button type='button' class='btn btn-standard btn-block-mobile mobile-push-half-bottom' ng-click='groupDetailInvite.cancel()'>Cancel</button>
         </div>
       </div>
     </div>

--- a/crossroads.net/app/group_tool/group_invitation/groupInvitation.html
+++ b/crossroads.net/app/group_tool/group_invitation/groupInvitation.html
@@ -23,6 +23,26 @@
       </div>
     </div>
     <div class='push-top text-center sm-text-right'>
+      <!-- shows at page load and if processing a accepting -->
+      <loading-button
+        normal-text='Join Group'
+        loading-text='Joining...'
+        loading='groupInvitation.processingAccept'
+        loading-class='disabled'
+        input-classes='sm-pull-right btn btn-primary btn-block-mobile mobile-push-half-bottom'
+        ng-click='groupInvitation.accept()'
+        ng-if='(!groupInvitation.processingAccept && !groupInvitation.processingDeny) || groupInvitation.processingAccept'></loading-button>
+
+      <!-- shows when processing a deny request -->
+      <loading-button
+        normal-text='Join Group'
+        loading-text='Join Group'
+        loading='groupInvitation.processingDeny'
+        loading-class='disabled'
+        input-classes='sm-pull-right btn btn-primary btn-block-mobile mobile-push-half-bottom'
+        ng-click='groupInvitation.accept()'
+        ng-if='!groupInvitation.processingAccept && groupInvitation.processingDeny'></loading-button>
+
       <!-- shows at page load and if processing a deny -->
       <loading-button
               normal-text='No Thanks'
@@ -42,26 +62,6 @@
               input-classes='btn btn-standard btn-block-mobile mobile-push-half-bottom'
               ng-click='groupInvitation.deny()'
               ng-if='groupInvitation.processingAccept && !groupInvitation.processingDeny'></loading-button>
-
-      <!-- shows at page load and if processing a accepting -->
-      <loading-button
-              normal-text='Join Group'
-              loading-text='Joining...'
-              loading='groupInvitation.processingAccept'
-              loading-class='disabled'
-              input-classes='btn btn-primary btn-block-mobile mobile-push-half-bottom'
-              ng-click='groupInvitation.accept()'
-              ng-if='(!groupInvitation.processingAccept && !groupInvitation.processingDeny) || groupInvitation.processingAccept'></loading-button>
-
-      <!-- shows when processing a deny request -->
-      <loading-button
-              normal-text='Join Group'
-              loading-text='Join Group'
-              loading='groupInvitation.processingDeny'
-              loading-class='disabled'
-              input-classes='btn btn-primary btn-block-mobile mobile-push-half-bottom'
-              ng-click='groupInvitation.accept()'
-              ng-if='!groupInvitation.processingAccept && groupInvitation.processingDeny'></loading-button>
     </div>
   </div>
 </div>

--- a/crossroads.net/app/group_tool/group_message/groupMessage.html
+++ b/crossroads.net/app/group_tool/group_message/groupMessage.html
@@ -37,14 +37,16 @@
       <div class='row'>
         <div class='col-md-12'>
           <p class='text-center sm-text-right'>
-            <a type='button' class='btn btn-standard btn-block-mobile mobile-push-half-bottom' href='#' ng-click='groupMessage.cancel()'>Cancel</a>
-            <loading-button 
+            <loading-button
               input-type='submit'
               normal-text='{{ groupMessage.normalLoadingText }}'
               loading-text='{{ groupMessage.loadingLoadingText }}'
               loading='groupMessage.processing'
               loading-class='disabled'
-              input-classes='btn btn-primary btn-block-mobile mobile-push-half-bottom'/>
+              input-classes='sm-pull-right btn btn-primary btn-block-mobile mobile-push-half-bottom'></loading-button>
+
+            <a type='button' class='btn btn-standard btn-block-mobile mobile-push-half-bottom' href='#' ng-click='groupMessage.cancel()'>Cancel</a>
+
           </p>
         </div>
       </div>

--- a/crossroads.net/app/group_tool/group_search_filter/groupSearchFilter.html
+++ b/crossroads.net/app/group_tool/group_search_filter/groupSearchFilter.html
@@ -31,10 +31,10 @@
       </div>
     </div>
     <div class="text-right push-half-bottom">
+      <button type='submit' class='sm-pull-right btn btn-primary btn-sm btn-block-mobile mobile-push-half-bottom'>Update Filters</button>
       <button type="button" class="btn btn-standard btn-sm btn-block-mobile mobile-push-half-bottom"
               ng-click="groupSearchFilter.closeFilters(filterForm)">Cancel
       </button>
-      <button type='submit' class='btn btn-primary btn-sm btn-block-mobile mobile-push-half-bottom'>Update Filters</button>
     </div>
   </div>
   <div ng-if="!groupSearchFilter.expanded" class="push-ends mobile-push-half-top">


### PR DESCRIPTION
## Changes to button order
### Desktop
#### Create and Edit
Create Group (linked from My Groups) - Cancel / Preview Group
Create Group Preview -  Edit / Submit Group
Edit Group - Cancel / Preview Group

#### Group Details
Group Detail About tab - End Group / Edit 
End Group - Cancel / Submit
Participants - Edit / Email Group
Change Participant Role - Cancel / Change Role
Invite Someone - Cancel / Send
Deny Request - Cancel / Deny
Accept Request - Cancel / Deny

#### Search
Search Filters - Cancel / Update Filters
Confirm Request - Back to Search Results / Send Request
Contact Group Leader - Back to Search Results / Send

#### Join Group Preview
Join a Group invitation preview - No Thanks / Join Group

### Mobile
#### Create and Edit
Create Group (linked from My Groups)
* Preview Group
* Cancel

Create Group Preview
* Submit Group
* Edit

Edit Group
* Preview Group
* Cancel

#### Group Details
Group Detail About tab
* Edit 
* End Group

End Group
* Submit
* Cancel

Participants
* Email Group
* Edit

Change Participant Role
* Change Role
* Cancel

Invite Someone
* Send
* Cancel

Deny Request
* Cancel
* Deny

Accept Request
* Cancel
* Deny

#### Search
Search Filters
* Cancel
* Update Filters

Confirm Request
  * Send Request 
  * Back to Search Results

Contact Group Leader
  * Send
  * Back to Search Results

#### Join Group Preview
Join a Group invitation preview
* Join Group
* No Thanks


