### PR TITLE
DE1879 - Date Selector Default

### DIFF
--- a/crossroads.net/app/streaming/reminder-modal.component.ts
+++ b/crossroads.net/app/streaming/reminder-modal.component.ts
@@ -24,7 +24,7 @@ export class ReminderModalComponent {
   upcoming: any = [];
   loading: boolean = false;
   formSuccess: boolean = false;
-  isSelectingDates: boolean = true;
+  isSelectingDates: boolean = false;
   isDayValid: boolean = false;
   isTimeValid: boolean = false;
   isEmailValid: boolean = true;
@@ -39,6 +39,7 @@ export class ReminderModalComponent {
     this.model = new Reminder();
     streamspotService.events.then(response => {
       this.upcoming = response;
+      this.model.day = this.nextDate();
     })
   }
 
@@ -82,6 +83,14 @@ export class ReminderModalComponent {
       ;
   }
 
+  nextDate() {
+    return _.
+      head(this.uniqueDates()).
+      start.
+      format(this.dateFormats.key)
+      ;
+  }
+
   selectedDate(date) {
     if(_.isEmpty(this.upcoming)) {
       return this.upcoming;
@@ -98,8 +107,6 @@ export class ReminderModalComponent {
   }
 
   public open(size) {
-    this.isSelectingDates = true;
-    this.model = new Reminder();
     this.modal.open(size)
   }
 }

--- a/crossroads.net/app/streaming/streaming.ng2component.html
+++ b/crossroads.net/app/streaming/streaming.ng2component.html
@@ -8,7 +8,7 @@
         </svg>
       </pageScroll>
       <countdown (watchNowClick)="watchNowClicked()"></countdown>
-      <button type="button" class="btn btn-sm btn-reminder" (click)="modal.open('lg')">Remind Me</button>
+      <button type="button" class="btn btn-sm btn-reminder" (click)="modal.open('lg')" *ngIf="!inProgress">Remind Me</button>
     </div>
   </section>
 


### PR DESCRIPTION
This PR updates the reminder-modal to default to the next available stream date, per [DE1879](https://rally1.rallydev.com/#/41662702253d/detail/defect/62120424516?fdp=true). Users should still be required to select a time but by default, they should not have to choose a day (unless they want to). 