### PR TITLE
DE1882 - White Page Transition to Watch Now Stream

### DIFF
--- a/crossroads.net/styles/pages/streaming.scss
+++ b/crossroads.net/styles/pages/streaming.scss
@@ -1080,6 +1080,7 @@ modal.watch-now {
   }
 
   .modal-body {
+    background: #000;
     height: 100%;
     padding: 0;
 


### PR DESCRIPTION
This PR ensures that the modal transition after clicking the watch now button is black, not white. For more details, please review [DE1882](https://rally1.rallydev.com/#/41662702253d/detail/defect/62122537439). 