### PR TITLE
US4786 - Participant tab and Request tab emails should be mailto links

### DIFF
--- a/crossroads.net/app/group_tool/group_detail/participants/participant_card/groupDetail.participant.card.html
+++ b/crossroads.net/app/group_tool/group_detail/participants/participant_card/groupDetail.participant.card.html
@@ -10,7 +10,7 @@
     </div>
     <div>
       <span class='group-participant-name'>
-        {{groupDetailParticipantCard.participant.email}}
+        <a href="mailto:{{groupDetailParticipantCard.participant.email}}">{{groupDetailParticipantCard.participant.email}}</a>
       </span>
     </div>
     <div class="push-half-top push-bottom">

--- a/crossroads.net/app/group_tool/group_detail/requests/groupDetail.requests.html
+++ b/crossroads.net/app/group_tool/group_detail/requests/groupDetail.requests.html
@@ -49,7 +49,7 @@
             Requested to Join
           </div>
           <div class="col-sm-3 ellipsis">
-            {{inquiry.emailAddress}}
+            <a href="mailto:{{inquiry.emailAddress}}">{{inquiry.emailAddress}}</a>
           </div>
           <div class="col-sm-3 ellipsis">
             {{inquiry.requestDate | date: 'MM/dd/yyyy'}}
@@ -80,7 +80,7 @@
             Invite Sent
           </div>
           <div class="col-sm-3 ellipsis">
-            {{invite.emailAddress}}
+            <a href="mailto:{{invite.emailAddress}}">{{invite.emailAddress}}</a>
           </div>
           <div class="col-sm-3 ellipsis">
             {{invite.requestDate | date: 'MM/dd/yyyy'}}


### PR DESCRIPTION
![participants - desktop](https://cloud.githubusercontent.com/assets/2341619/18359130/817bf6e2-75c6-11e6-886f-5b2455f3e57b.png)
![participants - mobile](https://cloud.githubusercontent.com/assets/2341619/18359132/817e9884-75c6-11e6-9c7d-19d86fede49f.png)
![requests - desktop](https://cloud.githubusercontent.com/assets/2341619/18359131/817de4c0-75c6-11e6-9029-50466f08cbc0.png)
![requests - mobile](https://cloud.githubusercontent.com/assets/2341619/18359133/8180a0d4-75c6-11e6-923d-38ffcc6c4d86.png)
