### PR TITLE
make validDropdown check for valid value

### DIFF
--- a/crossroads.net/app/common/profile/household/profileHousehold.template.html
+++ b/crossroads.net/app/common/profile/household/profileHousehold.template.html
@@ -145,12 +145,12 @@
                     <div id="Site"
                          class="form-group col-sm-6"
                          ng-class="{'has-error': household.validation.showErrors(household.householdForm, 'crLocation')}">
-                      <label for="provider" class="required">Crossroads Site</label>
+                      <label for="crLocation" class="required">Crossroads Site</label>
                       <select class="form-control col-sm-12"
                               name="crLocation"
-                              valid-dropdown-value="household.validLocations"
                               ng-model="household.householdInfo.congregationId"
-                              ng-options="location.dp_RecordID as location.dp_RecordName for location in household.locations | orderBy: ['OnlineSortOrder', 'name']">
+                              ng-options="location.dp_RecordID as location.dp_RecordName for location in household.locations | orderBy: ['OnlineSortOrder', 'name']"
+                              valid-dropdown-value="household.validLocations">
                         <option value="" disabled="disabled" selected="selected" style="display:none"> -- Choose One -- </option>
                       </select>
                       <ng-messages for="household.householdForm.crLocation.$error" ng-if="household.validation.showErrors(household.householdForm, 'crLocation')">

--- a/crossroads.net/core/validators/validDropdownValue.directive.js
+++ b/crossroads.net/core/validators/validDropdownValue.directive.js
@@ -22,6 +22,12 @@
             return false;
           }
 
+          // Sometimes the validDropdownValue list comes in empty
+          // in these cases, we just need to validate that the value
+          // is not undefined, null or 0.
+          if (scope.validDropdownValue.length < 1) {
+            return val !== undefined && val !== null && val !== 0;
+          }
           return _.includes(scope.validDropdownValue, val);
         };
       }


### PR DESCRIPTION
[DE1916](https://rally1.rallydev.com/#/27593501023d/detail/defect/62612530680)

Sometimes the value passed in to the validDropdown validator is an
unresolved promise. In those cases, we need to assume that any value
outside of `null`, `undefined` or `0`.

* add condintional to `validDropdown` validator to look for non-empty list

:tongue: 