### PR TITLE
DE1894 - Refactor Content Cards for Background Images

### DIFF
--- a/crossroads.net/app/streaming/content-card.ng2component.html
+++ b/crossroads.net/app/streaming/content-card.ng2component.html
@@ -1,8 +1,6 @@
 <article class="crds-card fadeInUp" [attr.data-wow-delay]="content.delay" [ngClass]="{ wow: animate }">
   <figure>
-    <linked-content href="{{ content.url }}" target="{{ content.target }}">
-      <img alt="" class="content img-responsive imgix-fluid" [attr.data-src]="content.imageSrc" src="{{ content.image }}" title="{{ content.title }}">
-    </linked-content>
+    <linked-content target="{{ content.target }}" href="{{ content.url }}" class="imgix-fluid-bg img-full-width" background="{{ content.image }}"></linked-content>
     <figcaption>
       <linked-content target="{{ content.target }}" href="{{ content.url }}" *ngIf="content.title" title="{{ content.title }}">{{ content.title | truncate: 38 }}</linked-content>
     </figcaption>

--- a/crossroads.net/app/streaming/streaming.component.ts
+++ b/crossroads.net/app/streaming/streaming.component.ts
@@ -106,9 +106,7 @@ export class StreamingComponent {
               if (typeof event.messageVideo !== "undefined" && typeof event.messageVideo.still !== 'undefined') {
                 event.image = event.messageVideo.still.filename
               } 
-              event.imageSrc = event.image.replace(/https*:/, '')
-
-              }
+            }
           })
         });
   }

--- a/crossroads.net/app/streaming/video.component.ts
+++ b/crossroads.net/app/streaming/video.component.ts
@@ -81,9 +81,9 @@ export class VideoComponent implements OnInit {
   }
 
   ngOnInit() {
-    if (this.inModal) {
-      this.redirectText = 'Close Modal';
-    } 
+    setTimeout(function() {
+      window.dispatchEvent(new Event('resize'));
+    }, 1000);
   }
 
   redirect() {

--- a/crossroads.net/core/linked_content/linked-content-ng2.component.ts
+++ b/crossroads.net/core/linked_content/linked-content-ng2.component.ts
@@ -5,7 +5,7 @@ import { NgClass } from '@angular/common';
   selector: 'linked-content',
   directives: [NgClass],
   template: `
-    <a href="{{href}}" (click)="onClick($event)" [ngClass]="{ unclickable: !isLinked() }" class="linked-content {{class}}" title="{{title}}" target="{{target}}">
+    <a href="{{href}}" (click)="onClick($event)" [ngClass]="{ unclickable: !isLinked() }" class="linked-content {{class}}" title="{{title}}" target="{{target}}" [attr.data-src]="background">
       <ng-content></ng-content>
     </a>
   `,
@@ -23,7 +23,8 @@ export class LinkedContentNg2Component {
   @Input() target = '_self';  
   @Input() title = '';
   @Input() class = '';
-  
+  @Input() background;
+
   onClick(event) {
     if(!this.isLinked()) {
       event.preventDefault();
@@ -32,10 +33,16 @@ export class LinkedContentNg2Component {
 
   ngOnInit() {
     this.href = this.isLinked() ? this.href : '#';
+    this.parseBackground();
   }
 
   isLinked() {
     return (this.href !== undefined && this.href !== '' && this.href !== '#' && this.href !== 'javascript:;');
   }
 
+  parseBackground() {
+    if(this.background != undefined) {
+      this.background = this.background.replace(/https?:\/\/[^/]*\/(crds-cms-uploads\/)?/, "//crds-cms-uploads.imgix.net/");
+    }
+  }
 }

--- a/crossroads.net/styles/modules/crds-card.scss
+++ b/crossroads.net/styles/modules/crds-card.scss
@@ -1,3 +1,20 @@
+@mixin aspect-ratio($width, $height) {
+  position: relative;
+  &:before{
+      display: block;
+      content: " ";
+      width: 100%;
+      padding-top: ($height / $width) * 100%;
+  }
+  > .content {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+  }
+}
+
 .crds-card {
   section, figcaption {
     position: relative;
@@ -27,6 +44,15 @@
   a {
     color: $gray;
   }
+  figure > linked-content > a {
+    @include aspect-ratio(16,9);
+    overflow: hidden;
+    display: block;
+    width: 100%;
+    margin-bottom: 2%;
+  }
+
+
   h3 {
     font-size: 110%;
     margin: 0.3em 0 0.3em;

--- a/crossroads.net/styles/pages/streaming.scss
+++ b/crossroads.net/styles/pages/streaming.scss
@@ -1,21 +1,3 @@
-@mixin aspect-ratio($width, $height) {
-  position: relative;
-  &:before{
-      display: block;
-      content: " ";
-      width: 100%;
-      padding-top: ($height / $width) * 100%;
-  }
-
-  > .content {
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-  }
-}
-
 @mixin crds-make-condensed {
   font-family: $cr-streaming-font-extra-cond;
   font-size: 170%;
@@ -433,14 +415,6 @@ streaming {
 
     section {
       top: -1em;
-    }
-
-    figure > linked-content > a {
-      @include aspect-ratio(16,9);
-      overflow: hidden;
-      display: block;
-      width: 100%;
-      margin-bottom: 2%;
     }
 
     @media (max-width: $screen-xs-max) { 


### PR DESCRIPTION
This PR updates the content-card directive to use background images instead of inline images so that the image area is covered, even in the case of images that are smaller than the content-area. 