### PR TITLE
Save current answer to Spiritual Life Question

### DIFF
--- a/crossroads.net/app/trips/signup/signupStep.controller.js
+++ b/crossroads.net/app/trips/signup/signupStep.controller.js
@@ -65,6 +65,7 @@ var attributes = require('crds-constants').ATTRIBUTE_IDS;
         case '2':
           evaluateAllergies();
           evaluateSpiritualLife();
+          vm.signupService.spiritualLifeShown = true;
           break;
         case '3':
           evaluateMedicationsTaking();
@@ -133,12 +134,14 @@ var attributes = require('crds-constants').ATTRIBUTE_IDS;
     }
 
     function evaluateSpiritualLife() {
-      _.forEach(vm.spiritualLife, function(spirit) {
-        if (spirit.selected) {
-          spirit.selected = false;
-          spirit.endDate = new Date();
-        }
-      });
+      if (!vm.signupService.spiritualLifeShown) {
+        _.forEach(vm.spiritualLife, function(spirit) {
+          if (spirit.selected) {
+            spirit.selected = false;
+            spirit.endDate = new Date();
+          }
+        });
+      }
     }
 
   }

--- a/crossroads.net/app/trips/signup/tripsSignup.service.js
+++ b/crossroads.net/app/trips/signup/tripsSignup.service.js
@@ -69,6 +69,8 @@
       signupService.page5 = page5();
       signupService.page6 = page6();
       signupService.depositInfo = depositInfo();
+
+      signupService.spiritualLifeShown = false;
     }
 
     function depositInfo() {


### PR DESCRIPTION
[DE1921](https://rally1.rallydev.com/#/27593501023d/detail/defect/62690564891)

Choosing a spiritual life option and then progressing through the
application and then coming back to the question should not wipe out
previous answer.

* keep track in the tripsSignupService that the page was initially loaded
* reset flag on reset call