### PR TITLE
Feature/us4895 group preview visibility

### DIFF
--- a/crossroads.net/app/group_tool/groupTool.routes.js
+++ b/crossroads.net/app/group_tool/groupTool.routes.js
@@ -67,6 +67,9 @@ export default function GroupToolRouter($httpProvider, $stateProvider) {
           description: ''
         },
         isCreate: true
+      },
+      params: {
+        showVisibility: true
       }
     })
     .state('grouptool.edit.preview', {
@@ -79,6 +82,9 @@ export default function GroupToolRouter($httpProvider, $stateProvider) {
           description: ''
         },
         isCreate: false
+      },
+      params: {
+        showVisibility: true
       }
     })
     .state('grouptool.edit', {
@@ -137,7 +143,10 @@ export default function GroupToolRouter($httpProvider, $stateProvider) {
     })
     .state('grouptool.detail.about', {
       url: '/about',
-      template: '<group-detail-about></group-detail-about>'
+      template: '<group-detail-about></group-detail-about>',
+      params: {
+        showVisibility: true
+      }
     })
     .state('grouptool.detail.participants', {
       url: '/participants',

--- a/crossroads.net/app/group_tool/group_detail/about/groupDetail.about.controller.js
+++ b/crossroads.net/app/group_tool/group_detail/about/groupDetail.about.controller.js
@@ -1,10 +1,11 @@
 
 export default class GroupDetailAboutController {
   /*@ngInject*/
-  constructor(GroupService, ImageService, $state, $log, $cookies) {
+  constructor(GroupService, ImageService, $state, $stateParams, $log, $cookies) {
     this.groupService = GroupService;
     this.imageService = ImageService;
     this.state = $state;
+    this.stateParams = $stateParams;
     this.log = $log;
     this.cookies = $cookies;
 
@@ -44,6 +45,11 @@ export default class GroupDetailAboutController {
       //this.setGroupImageUrl();
       this.ready = true;
     }
+
+
+    // Set show visibility flag
+    this.showVisibility = !!this.stateParams.showVisibility;
+
   }
 
   setGroupImageUrl() {

--- a/crossroads.net/app/group_tool/group_detail/about/groupDetail.about.controller.js
+++ b/crossroads.net/app/group_tool/group_detail/about/groupDetail.about.controller.js
@@ -27,9 +27,6 @@ export default class GroupDetailAboutController {
       this.groupService.getGroup(this.groupId).then((data) => {
         this.data = data;
         this.setGroupImageUrl();
-        this.groupService.getIsLeader(this.groupId).then((isLeader) => {
-          this.isLeader = isLeader;
-        });        
       },
       (err) => {
         this.log.error(`Unable to get group details: ${err.status} - ${err.statusText}`);
@@ -46,10 +43,16 @@ export default class GroupDetailAboutController {
       this.ready = true;
     }
 
-
     // Set show visibility flag
     this.showVisibility = !!this.stateParams.showVisibility;
 
+    // If the component is allowed to show visibility or the footer will be rendered with Leader buttons,
+    // Determine if the logged in user is the leader of this group
+    if (this.showFooter || this.showVisibility) {
+      this.groupService.getIsLeader(this.groupId).then((isLeader) => {
+        this.isLeader = isLeader;
+      });
+    }
   }
 
   setGroupImageUrl() {

--- a/crossroads.net/spec-es6/group_tool/group_detail/about/groupDetail.about.controller.spec.js
+++ b/crossroads.net/spec-es6/group_tool/group_detail/about/groupDetail.about.controller.spec.js
@@ -8,6 +8,7 @@ describe('GroupDetailAboutController', () => {
         groupService,
         imageService,
         state,
+        stateParams,
         rootScope,
         log,
         qApi,
@@ -26,6 +27,7 @@ describe('GroupDetailAboutController', () => {
         groupService = $injector.get('GroupService');
         imageService = $injector.get('ImageService');
         state = $injector.get('$state');
+        stateParams = $injector.get('$stateParams');
         rootScope = $injector.get('$rootScope');
         log = $injector.get('$log');
         qApi = $injector.get('$q');
@@ -35,7 +37,7 @@ describe('GroupDetailAboutController', () => {
           groupId: 123
         };
 
-        fixture = new GroupDetailAboutController(groupService, imageService, state, log, cookies);
+        fixture = new GroupDetailAboutController(groupService, imageService, state, stateParams, log, cookies);
     }));
 
     describe('groupExists() function', () => {


### PR DESCRIPTION
### Leader sees visibility on Group Detail About tab
![detail about tab](https://cloud.githubusercontent.com/assets/2341619/18478525/9a30ae8a-799f-11e6-8a60-fde313488307.png)

### Leader sees visibility on Create/Edit Preview screen
![preview](https://cloud.githubusercontent.com/assets/2341619/18478524/9a11db40-799f-11e6-86e3-0bf1fb618dcf.png)

### Leader does *not* see visibility on search results
![search results](https://cloud.githubusercontent.com/assets/2341619/18478523/99edb8f0-799f-11e6-9603-2f703899802d.png)
