### PR TITLE
US4897 -  Participant & Request tab headings on Mobile

### DIFF
--- a/crossroads.net/app/group_tool/group_detail/participants/groupDetail.participants.html
+++ b/crossroads.net/app/group_tool/group_detail/participants/groupDetail.participants.html
@@ -5,7 +5,7 @@
   ng-show='groupDetailParticipants.ready'
   ng-if='groupDetailParticipants.isListView() || groupDetailParticipants.isEditView()'>
 
-  <h4 ng-if="groupDetailParticipants.data.length > 1" class="visible-xs group-detail-title-mobile push-top soft-half-bottom">Participants</h4>
+  <h4 ng-if="groupDetailParticipants.data.length > 1" class="visible-xs group-detail-title-mobile push-top soft-half-bottom border-bottom">Participants</h4>
 
   <div class='group-detail-participant-list row push-top'>
     <div ng-repeat='participant in groupDetailParticipants.data' class="group-detail-participant-item col-xs-12 col-sm-6 col-lg-4 push-bottom">

--- a/crossroads.net/app/group_tool/group_detail/participants/groupDetail.participants.html
+++ b/crossroads.net/app/group_tool/group_detail/participants/groupDetail.participants.html
@@ -4,6 +4,9 @@
 <div
   ng-show='groupDetailParticipants.ready'
   ng-if='groupDetailParticipants.isListView() || groupDetailParticipants.isEditView()'>
+
+  <h4 ng-if="groupDetailParticipants.data.length > 1" class="visible-xs group-detail-title-mobile push-top soft-half-bottom">Participants</h4>
+
   <div class='group-detail-participant-list row push-top'>
     <div ng-repeat='participant in groupDetailParticipants.data' class="group-detail-participant-item col-xs-12 col-sm-6 col-lg-4 push-bottom">
       <group-detail-participant-card

--- a/crossroads.net/app/group_tool/group_detail/requests/groupDetail.requests.html
+++ b/crossroads.net/app/group_tool/group_detail/requests/groupDetail.requests.html
@@ -12,7 +12,7 @@
 
     <p class='text-center'><button type='button' class='btn btn-primary btn-block-mobile' ng-click="groupDetailRequests.setView('Invite', false)">Invite Someone</button></p>
 
-    <h4 ng-if="groupDetailRequests.hasRequestsOrInvites()" class="group-detail-title-mobile push-top soft-half-bottom">Requests</h4>
+    <h4 ng-if="groupDetailRequests.hasRequestsOrInvites()" class="group-detail-title-mobile push-top soft-half-bottom border-bottom">Requests</h4>
   </div>
 
   <!-- Requests Table -->

--- a/crossroads.net/app/group_tool/group_detail/requests/groupDetail.requests.html
+++ b/crossroads.net/app/group_tool/group_detail/requests/groupDetail.requests.html
@@ -12,7 +12,7 @@
 
     <p class='text-center'><button type='button' class='btn btn-primary btn-block-mobile' ng-click="groupDetailRequests.setView('Invite', false)">Invite Someone</button></p>
 
-    <h4 class="group-detail-title-mobile push-top soft-half-bottom">Requests</h4>
+    <h4 ng-if="groupDetailRequests.hasRequestsOrInvites()" class="group-detail-title-mobile push-top soft-half-bottom">Requests</h4>
   </div>
 
   <!-- Requests Table -->


### PR DESCRIPTION
### Mobile Participants tab *always* shows heading
![participants heading](https://cloud.githubusercontent.com/assets/2341619/18479362/ae9bf908-79a2-11e6-96ce-41f3a92506ff.png)

### Mobile Requests tab shows heading *IF* there are Invites or Inquiries
![requests heading visible](https://cloud.githubusercontent.com/assets/2341619/18479361/ae954c70-79a2-11e6-9905-a05d8b496d55.png)

### Mobile Requests tab hides heading *IF* there are zero invites or inquiries
![requests heading hidden](https://cloud.githubusercontent.com/assets/2341619/18479360/ae94d8da-79a2-11e6-95a0-784a167cd89c.png)