### PR TITLE
DE1922 - Selected Time Reminder

### DIFF
--- a/crossroads.net/app/streaming/reminder-modal.component.ts
+++ b/crossroads.net/app/streaming/reminder-modal.component.ts
@@ -140,7 +140,6 @@ export class ReminderModalComponent {
   }
 
   public open(size) {
-    this.resetForm()
     this.modal.open(size)
   }
 }


### PR DESCRIPTION
This PR delivers [DE1922](https://rally1.rallydev.com/#/41662702253d/detail/defect/62759497742) by updating the streaming reminder component so that selections for date/time and phone/email persist after the modal has been closed and then reopened. 

Note– after discussing this with Isaac, we agreed that this defect really only applies to the persistence of previously selected values, with sole regard to field validation following a close/reopen event. Let me know if you have any questions about this distinction. 

