### PR TITLE
DE1894 - Digital Program Images

### DIFF
--- a/crossroads.net/app/streaming/content-card.ng2component.html
+++ b/crossroads.net/app/streaming/content-card.ng2component.html
@@ -1,6 +1,6 @@
 <article class="crds-card fadeInUp" [attr.data-wow-delay]="content.delay" [ngClass]="{ wow: animate }">
   <figure>
-    <linked-content target="{{ content.target }}" href="{{ content.url }}" class="imgix-fluid-bg img-full-width" background="{{ content.image }}"></linked-content>
+    <linked-content target="{{ content.target }}" href="{{ content.url }}" class="imgix-fluid-bg img-background" background="{{ content.image }}"></linked-content>
     <figcaption>
       <linked-content target="{{ content.target }}" href="{{ content.url }}" *ngIf="content.title" title="{{ content.title }}">{{ content.title | truncate: 38 }}</linked-content>
     </figcaption>


### PR DESCRIPTION
Apply `img-background` selector to content cards for better image handling for Retina screens. See the discussion on [DE1894](https://rally1.rallydev.com/#/41662702253d/detail/defect/62186866087/discussion) for more information.