### PR TITLE
DE1894 - Digital Program Images

### DIFF
--- a/crossroads.net/styles/pages/streaming.scss
+++ b/crossroads.net/styles/pages/streaming.scss
@@ -628,7 +628,7 @@ streaming, landing {
       font-size: 210%;
       top: -0.5em;
       word-wrap: break-word;
-      
+      -webkit-transform: translateZ(0);
     }
 
     section {


### PR DESCRIPTION
This PR resolves a rendering bug on retina screens, where the `<figcaption>` elements within the streaming digital program are obscured on-hover, within a modal window. 

Related to [DE1894](https://rally1.rallydev.com/#/41662702253d/detail/defect/62186866087), let me know if you have any questions. 