### PR TITLE
DE1936 - Add a Group Detail about component isLeader input binding

### DIFF
--- a/crossroads.net/app/group_tool/create_group/preview/createGroup.preview.html
+++ b/crossroads.net/app/group_tool/create_group/preview/createGroup.preview.html
@@ -1,4 +1,4 @@
-<group-detail-about data="createGroupPreview.groupData"> </group-detail-about>
+<group-detail-about data="createGroupPreview.groupData" is-leader="true"> </group-detail-about>
 <div class="clearfix push-top text-center sm-text-right">
   <loading-button
     normal-text='Submit Group'

--- a/crossroads.net/app/group_tool/group_detail/about/groupDetail.about.component.js
+++ b/crossroads.net/app/group_tool/group_detail/about/groupDetail.about.component.js
@@ -9,7 +9,8 @@ export default function GroupDetailAboutComponent() {
       data: '<',
       edit: '<',
       forInvitation: '<',
-      forSearch: '<'
+      forSearch: '<',
+      isLeader: '<'
     },
     restrict: 'E',
     templateUrl: 'about/groupDetail.about.html',

--- a/crossroads.net/app/group_tool/group_detail/about/groupDetail.about.controller.js
+++ b/crossroads.net/app/group_tool/group_detail/about/groupDetail.about.controller.js
@@ -12,7 +12,6 @@ export default class GroupDetailAboutController {
     this.defaultProfileImageUrl = this.imageService.DefaultProfileImage;
     this.ready = false;
     this.error = false;
-    this.isLeader = false;
     this.showFooter = false;
 
     this.forInvitation = (this.forInvitation === undefined || this.forInvitation === null) ? false : this.forInvitation;
@@ -47,8 +46,8 @@ export default class GroupDetailAboutController {
     this.showVisibility = !!this.stateParams.showVisibility;
 
     // If the component is allowed to show visibility or the footer will be rendered with Leader buttons,
-    // Determine if the logged in user is the leader of this group
-    if (this.showFooter || this.showVisibility) {
+    // Determine if the logged in user is the leader of this group IF not already set as an input binding
+    if (this.isLeader === undefined && (this.showFooter || this.showVisibility)) {
       this.groupService.getIsLeader(this.groupId).then((isLeader) => {
         this.isLeader = isLeader;
       });


### PR DESCRIPTION
The `isLeader` flag was being set using the result from a `this.groupService.getIsLeader()` call, however in the Create Group Preview process, the group hasn't been added to the database yet and so the API call is returning a 404 and the isLeader flag isn't being set true.  

The new input binding allows the Create Preview component to explicitly set `is-leader=true`