### PR TITLE
DE1894 - Digital Program Images

### DIFF
--- a/crossroads.net/app/streaming/video.component.ts
+++ b/crossroads.net/app/streaming/video.component.ts
@@ -1,5 +1,5 @@
 // angular imports
-import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, Output, AfterViewInit } from '@angular/core';
 
 // streaming imports
 import { StreamspotIframeComponent } from './streamspot-iframe.component';
@@ -24,7 +24,7 @@ var WOW = require('wow.js/dist/wow.min.js');
   pipes: [TruncatePipe]
 })
 
-export class VideoComponent implements OnInit {
+export class VideoComponent {
   @Input() inModal: boolean = false;
   @Output('close') _close = new EventEmitter();
 
@@ -80,10 +80,21 @@ export class VideoComponent implements OnInit {
     }).init();
   }
 
-  ngOnInit() {
+  ngAfterViewInit() {
+    // Trigger a window.resize() event so imgix will
+    // reevaluate background images in modal context
     setTimeout(function() {
-      window.dispatchEvent(new Event('resize'));
+      var event;
+      if ("createEvent" in document) {
+        // initUIEvent() is deprecated but IE11 doesn't support UIEvent()
+        event = document.createEvent('UIEvents');
+        event.initUIEvent('resize', true, false, window, 0);
+      } else {
+        event = new UIEvent('resize');
+      }
+      window.dispatchEvent(event);
     }, 1000);
+
   }
 
   redirect() {


### PR DESCRIPTION
This PR resolves another defect related to [DE1894](https://rally1.rallydev.com/#/41662702253d/detail/defect/62186866087) – background images within the live stream's digital-progam content are not rendering in IE11. 

This update refactors the triggered window.resize() event specifically for IE11 – after the view has been initialized, the resize event forces Imgix to re-render the background images. 

Let me know if you have any questions or concerns. 