### PR TITLE
US4709 - Edit Group title should be a content block

### DIFF
--- a/crossroads.net/app/group_tool/edit_group/editGroup.html
+++ b/crossroads.net/app/group_tool/edit_group/editGroup.html
@@ -1,9 +1,6 @@
 <preloader full-screen='false' ng-show='!editGroup.ready'> </preloader>
 <div ng-show='editGroup.ready'>
-  <h1>
-    Edit Your Group
-  </h1>
-  <p>Hi leader! </p>
+  <div dynamic-content="$root.MESSAGES.groupToolEditGroupHeading.content | html"></div>
   <form ng-submit="editGroup.previewGroup()" novalidate name="editGroup.editGroupForm">
     <formly-form model="editGroup.createGroupService.model" fields="editGroup.fields" form="editGroup.editGroupForm" options="editGroup.options" ng-cloak>
       <div class="clearfix col-md-12 push-top text-center sm-text-right">


### PR DESCRIPTION
The title and description paragraph are now a content block matching the structure of the Create Group html page

![edit group content block](https://cloud.githubusercontent.com/assets/2341619/18761106/a43ed8c8-80d1-11e6-9848-3d5bc75acb46.png)
