### PR TITLE
DE1989: Get digital program titles displaying correctly when truncated.

### DIFF
--- a/crossroads.net/app/live_stream/content_card/contentCard.html
+++ b/crossroads.net/app/live_stream/content_card/contentCard.html
@@ -2,7 +2,7 @@
   <figure>
     <linked-content target="{{ contentCard.content.target }}" href="{{ contentCard.content.url }}" class="imgix-fluid-bg img-background" background="{{ contentCard.content.image }}"></linked-content>
     <figcaption>
-      <linked-content  target="{{ contentCard.content.target }}" href="{{ contentCard.content.url }}" ng-if="contentCard.content.title" title="{{ contentCard.content.title }}">{{ contentCard.content.title | truncate: 38 }}</linked-content>
+      <linked-content  target="{{ contentCard.content.target }}" href="{{ contentCard.content.url }}" ng-if="contentCard.content.title" title="{{ contentCard.content.title }}" ng-bind-html="contentCard.content.title | truncate: 38"></linked-content>
     </figcaption>
   </figure>
   <section>

--- a/crossroads.net/app/live_stream/stream/stream.html
+++ b/crossroads.net/app/live_stream/stream/stream.html
@@ -48,7 +48,7 @@
             </linked-content>
           </figure>
           <section>
-            <h3 title="{{ promo.title }}"><linked-content href="{{ promo.url }}" target="_blank">{{ promo.title | truncate: 38 }}</linked-content></h3>
+            <h3 title="{{ promo.title }}"><linked-content href="{{ promo.url }}" target="_blank" ng-bind-html="promo.title | truncate: 38"></linked-content></h3>
             <div ng-bind-html="promo.description"></div>
           </section>
         </article>


### PR DESCRIPTION
Digital program titles were not getting truncated correctly. This is a bug fix for that issue.