### PR TITLE
Feature/us5367 serve style tweaks

### DIFF
--- a/crossroads.net/app/my_serve/index.js
+++ b/crossroads.net/app/my_serve/index.js
@@ -1,6 +1,7 @@
 import CONSTANTS from 'crds-constants';
 
 import './myserve.html';
+import './myserve_icon_key.html';
 import './one_time_serve_mockup.html';
 import './event_registration_mockup.html';
 import './event_registration_mockup_desired.html';

--- a/crossroads.net/app/my_serve/myserve.html
+++ b/crossroads.net/app/my_serve/myserve.html
@@ -2,21 +2,13 @@
   <h1 class="page-header">Sign Up To Serve </h1>
 
   <div class="clearfix" data-ng-show="!serve.showNoOpportunitiesMsg() || !serve.showNoOpportunitiesMsg()">
-    <button type="button" class="btn btn-primary btn-block-mobile mobile-push-bottom sm-pull-right" ui-sref="serve-signup.message">Send Message </button>
-    <div>
-      <svg viewBox="0 0 32 32" class="icon icon-check-circle">
-        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#check-circle">
-        </use>
-      </svg>Signed Up Yes &nbsp;&nbsp;
-      <svg viewBox="0 0 32 32" class="icon icon-minus-circle">
-        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#minus-circle">
-        </use>
-      </svg>Signed Up No
-    </div>
+    <button type="button" class="btn btn-primary btn-block-mobile  mobile-flush-bottom sm-pull-right" ui-sref="serve-signup.message">Send Message </button>
+    <div ng-include="'my_serve/myserve_icon_key.html'" class="hidden-xs"></div>
   </div>
 
   <div>
     <serve-team-refine-list last-date="serve.lastDate" serving-days="serve.groups" original="serve.original"> </serve-team-refine-list>
+    <div ng-include="'my_serve/myserve_icon_key.html'" class="visible-xs"></div>
 
     <div class="serve-signup-cont clearfix col-sm-9 col-sm-pull-3 soft-ends">
 

--- a/crossroads.net/app/my_serve/myserve_icon_key.html
+++ b/crossroads.net/app/my_serve/myserve_icon_key.html
@@ -1,0 +1,10 @@
+<div>
+  <svg viewBox="0 0 32 32" class="icon icon-check-circle">
+    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#check-circle">
+    </use>
+  </svg>Signed Up Yes &nbsp;&nbsp;
+  <svg viewBox="0 0 32 32" class="icon icon-minus-circle">
+    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#minus-circle">
+    </use>
+  </svg>Signed Up No
+</div>

--- a/crossroads.net/app/my_serve/refine/refineList.html
+++ b/crossroads.net/app/my_serve/refine/refineList.html
@@ -1,4 +1,4 @@
-<div class="col-sm-3 col-sm-push-9 clearfix serve-filter mobile-hard-left mobile-hard-right soft-top">
+<div class="col-sm-3 col-sm-push-9 clearfix serve-filter mobile-hard-left mobile-hard-right mobile-flush-top mobile-soft-half-ends soft-top">
 
   <div ng-click="toggleFilterCollapse()">
 
@@ -15,17 +15,16 @@
     </div>
   </div>
 
-  <!--DATE DESIGN WITH MODAL-->
-  <div class="push-bottom soft-half-top" >
-    <button type="button" class="btn btn-default btn-block push-bottom" ng-click="open()">
-      <span>{{filterFromDate | date:'M/dd/yyyy' }}</span>
-      <span> - </span>
-      <span>{{lastDate | date:'M/dd/yyyy' }}</span>
-    </button>
-  </div>
-
-
   <div collapse="isFilterCollapsed">
+
+    <!--DATE DESIGN WITH MODAL-->
+    <div class="push-bottom filter-group soft-half-top" >
+      <button type="button" class="btn btn-default btn-block push-bottom" ng-click="open()">
+        <span>{{filterFromDate | date:'M/dd/yyyy' }}</span>
+        <span> - </span>
+        <span>{{lastDate | date:'M/dd/yyyy' }}</span>
+      </button>
+    </div>
 
     <div class="push-half-bottom filter-group" ng-if="uniqueMembers.length > 1">
       <div class="checkbox" data-ng-repeat="member in uniqueMembers">

--- a/crossroads.net/app/my_serve/serve_team_members/serveTeamMembers.html
+++ b/crossroads.net/app/my_serve/serve_team_members/serveTeamMembers.html
@@ -1,9 +1,9 @@
 <h4 class="">Confirmed Team Members</h4>
 <div ng-repeat="role in serveTeamMembers.allMembers" class="row serve-role-members">
-  <div class="col-sm-3 soft-half-top">
+  <div class="col-sm-3 serve-team-confirm-role">
     <strong>{{role.name}}</strong>
   </div>
-  <div class="col-sm-9 soft-half-top">
+  <div class="col-sm-9">
     <closable-tag ng-repeat="member in role.members"
                   name="member.name"
                   on-click="serveTeamMembers.memberClick(member)"

--- a/crossroads.net/app/my_serve/serve_team_message/serveTeamMessage.html
+++ b/crossroads.net/app/my_serve/serve_team_message/serveTeamMessage.html
@@ -73,6 +73,14 @@
            ng-click='serveTeamMessage.cancel()'>Cancel</a>
 
       </div>
+
+      <a ui-sref="serve-signup" class="push-top">
+        <svg viewBox="0 0 32 32" class="icon icon-large arrow-circle-o-left">
+          <use xlink:href="#arrow-circle-o-left"></use>
+        </svg>
+        Back to Sign Up to Serve
+      </a>
+
     </div>
   </div>
 </form>

--- a/crossroads.net/styles/helpers/utilities.scss
+++ b/crossroads.net/styles/helpers/utilities.scss
@@ -459,6 +459,16 @@ a.underline,
         padding-right: $line-height-computed;
         padding-left: $line-height-computed;
     }
+
+    .mobile-soft-half-top {
+        padding-top: $line-height-computed / 2;
+    }
+
+    .mobile-soft-half-ends {
+        padding-top: $line-height-computed / 2;
+        padding-bottom: $line-height-computed / 2;
+    }
+
     .mobile-soft-half-sides {
         padding-right: $line-height-computed / 2;
         padding-left: $line-height-computed / 2;

--- a/crossroads.net/styles/modules/closable-tags.scss
+++ b/crossroads.net/styles/modules/closable-tags.scss
@@ -1,11 +1,13 @@
 closable-tag {
   display: inline-block;
+  font-size: 85%;
+  font-weight: 400;
 
   background-color: $gray-lighter;
   padding: $padding-small-vertical $padding-small-horizontal;
   border-radius: 10px;
 
-  svg {
+  svg.icon {
     width: 10px;
     margin-left: 5px;
     margin-bottom: 3px;

--- a/crossroads.net/styles/modules/ng-tags-input.scss
+++ b/crossroads.net/styles/modules/ng-tags-input.scss
@@ -18,12 +18,14 @@ tags-input {
     }
 
     .tag-item {
-      background: $brand-primary;
+      color: $black;
+      background: $gray-lighter;
+      border-color: $gray-lighter;
       margin-top: 0;
       margin-bottom: 0;
 
       .remove-button {
-        color: $white;
+        color: $black;
       }
 
       &.selected {

--- a/crossroads.net/styles/pages/serve.scss
+++ b/crossroads.net/styles/pages/serve.scss
@@ -172,5 +172,10 @@
 }
 
 .serve-role-members {
-  min-height: 62px;
+  min-height: 45px;
+  font-weight: 400;
+}
+
+.serve-team-confirm-role {
+  line-height: 1.2;
 }


### PR DESCRIPTION
## Selected Member tags are Gray
<img width="513" alt="gray tags" src="https://cloud.githubusercontent.com/assets/2341619/19320569/cf68bf6a-907f-11e6-9f97-2c7f16bcac63.png">


## Confirmed Team Member tags are smaller with less space between sections
<img width="752" alt="tag size" src="https://cloud.githubusercontent.com/assets/2341619/19320577/d21626b2-907f-11e6-8b9a-f868a6fae364.png">


## Changed Green/Red icon key location on mobile
<img width="398" alt="icon key location" src="https://cloud.githubusercontent.com/assets/2341619/19320580/d45b9bfa-907f-11e6-9d04-de7550f2974d.png">


## Send Message back link
<img width="818" alt="back link" src="https://cloud.githubusercontent.com/assets/2341619/19320583/d7017ee2-907f-11e6-8ffc-d4a75642dc0a.png">
