### PR TITLE
defect/DE2010

### DIFF
--- a/crossroads.net/app/live_stream/streaming_reminder/streamingReminder.controller.js
+++ b/crossroads.net/app/live_stream/streaming_reminder/streamingReminder.controller.js
@@ -107,7 +107,7 @@ export default class StreamingReminderController {
   groupedDates() {
     return _
       .chain(this.upcoming)
-      .groupBy((event) => event.start.format(this.dateFormats.key))
+      .groupBy((event) => Event.formatGeneralDateTimeToLocalDate(event.start))
       .value()
     ;
   }


### PR DESCRIPTION
This bug fix changes the logic with which events are grouped by. Previously they were getting grouped by their GMT time, but have been changed to get grouped by their local timezone time.