### PR TITLE
DE2154 - Validation error if Waiver selection not made

### DIFF
--- a/Gateway/MinistryPlatform.Translation/Repositories/EventRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/EventRepository.cs
@@ -31,17 +31,20 @@ namespace MinistryPlatform.Translation.Repositories
         private readonly IMinistryPlatformService _ministryPlatformService;
         private readonly IMinistryPlatformRestRepository _ministryPlatformRestRepository;
         private readonly IGroupRepository _groupService;
+        private readonly IEventParticipantRepository _eventParticipantRepository;
 
         public EventRepository(IMinistryPlatformService ministryPlatformService,
                             IAuthenticationRepository authenticationService,
                             IConfigurationWrapper configurationWrapper,
                             IGroupRepository groupService,
-                            IMinistryPlatformRestRepository ministryPlatformRestRepository)
+                            IMinistryPlatformRestRepository ministryPlatformRestRepository,
+                            IEventParticipantRepository eventParticipantRepository)
             : base(authenticationService, configurationWrapper)
         {
             _ministryPlatformService = ministryPlatformService;
             _ministryPlatformRestRepository = ministryPlatformRestRepository;
             _groupService = groupService;
+            _eventParticipantRepository = eventParticipantRepository;
         }
 
         public int CreateEvent(MpEventReservationDto eventReservationReservation)
@@ -527,6 +530,12 @@ namespace MinistryPlatform.Translation.Repositories
         public List<MpWaivers> GetWaivers(int eventId, int contactId)
         {
             var apiToken = ApiLogin();
+            var eventParticipantId = _eventParticipantRepository.GetEventParticipantByContactId(eventId, contactId);
+            if (eventParticipantId == 0)
+            {
+                throw new ApplicationException("Event Participant not found for Contact");
+            }
+
             const string columnList = "Waiver_ID_Table.[Waiver_ID], Waiver_ID_Table.[Waiver_Name], Waiver_ID_Table.[Waiver_Text], cr_Event_Waivers.[Required]";
             var campWaivers = _ministryPlatformRestRepository.UsingAuthenticationToken(apiToken).Search<MpWaivers>($"Event_ID = {eventId} AND Active=1", columnList).ToList();
             
@@ -534,7 +543,7 @@ namespace MinistryPlatform.Translation.Repositories
             const string columns = "cr_Event_Participant_Waivers.Waiver_ID, cr_Event_Participant_Waivers.Event_Participant_ID, Accepted, Signee_Contact_ID";
             foreach (var waiver in campWaivers)
             {
-                var searchString = $"Waiver_ID_Table.Waiver_ID = {waiver.WaiverId} AND Event_Participant_ID_Table_Event_ID_Table.Event_ID = {eventId}";
+                var searchString = $"Waiver_ID_Table.Waiver_ID = {waiver.WaiverId} AND Event_Participant_ID_Table_Event_ID_Table.Event_ID = {eventId} AND cr_Event_Participant_Waivers.Event_Participant_ID = {eventParticipantId}";
                 var response = _ministryPlatformRestRepository.UsingAuthenticationToken(apiToken).Search<MpWaiverResponse>(searchString, columns).FirstOrDefault();
                 if (response != null)
                 {

--- a/crossroads.net/app/camps/camp_waivers/camp_waivers.controller.js
+++ b/crossroads.net/app/camps/camp_waivers/camp_waivers.controller.js
@@ -61,6 +61,7 @@ export default class CampWaiversController {
 
   submitWaivers() {
     if (this.form.$invalid) {
+      this.rootScope.$emit('notify', this.rootScope.MESSAGES.generalError);
       return;
     }
 


### PR DESCRIPTION
Fixed bug with REST call to get Waivers to ensure only records for the specified contact are returned.

Display a growl error if Next button is clicked without selecting a radio button

![image](https://cloud.githubusercontent.com/assets/2341619/19941173/75b879ba-a105-11e6-80b6-bff89b6b970b.png)
