### PR TITLE
fix for nuget packages in api versioning

### DIFF
--- a/Gateway/crds-angular/packages.config
+++ b/Gateway/crds-angular/packages.config
@@ -44,8 +44,8 @@
   <package id="SlowCheetah" version="2.5.14" targetFramework="net45" />
   <package id="Swashbuckle" version="5.2.1" targetFramework="net45" />
   <package id="Swashbuckle.Core" version="5.2.1" targetFramework="net45" />
-  <package id="System.Net.Http" version="4.1.0" targetFramework="net45" />
-  <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.0.0" targetFramework="net45" />
+  <package id="System.Text.RegularExpressions" version="4.0.0" targetFramework="net45" />
   <package id="Twilio" version="4.7.2" targetFramework="net45" />
   <package id="Unity" version="3.5.1404.0" targetFramework="net45" />
   <package id="Unity.WebAPI" version="5.1" targetFramework="net45" />


### PR DESCRIPTION
* Nuget was unable to pull in version 4.1.0 of
	* System.text.RegularExpressions
	* System.net.http
* This rolls back to 4.0.0