### PR TITLE
DE2185 - Clear Camper Data

### DIFF
--- a/Gateway/crds-angular/Controllers/API/CampController.cs
+++ b/Gateway/crds-angular/Controllers/API/CampController.cs
@@ -104,8 +104,8 @@ namespace crds_angular.Controllers.API
         }
 
         [ResponseType(typeof(CampReservationDTO))]
-        [VersionedRoute(template: "camps/{eventId}/{contactId}", minimumVersion: "1.0.0")]
-        [Route("camps/{eventId}/{contactId}")]
+        [VersionedRoute(template: "camps/{eventId}/campers/{contactId}", minimumVersion: "1.0.0")]
+        [Route("camps/{eventId}/campers/{contactId}")]
         [HttpGet]
         public IHttpActionResult GetCamperInfo(int eventId, int contactId)
         {
@@ -152,8 +152,8 @@ namespace crds_angular.Controllers.API
             });
         }
 
-        [VersionedRoute(template: "camps/{eventId}", minimumVersion: "1.0.0")]
-        [Route("camps/{eventid}")]
+        [VersionedRoute(template: "camps/{eventId}/campers", minimumVersion: "1.0.0")]
+        [Route("camps/{eventid}/campers")]
         [HttpPost]
         public IHttpActionResult SaveCampReservation([FromBody] CampReservationDTO campReservation, int eventId)
         {

--- a/crossroads.net/app/camps/application_page/camper_info/camper_info.controller.js
+++ b/crossroads.net/app/camps/application_page/camper_info/camper_info.controller.js
@@ -1,7 +1,7 @@
-/* @ngInject */
 class CamperInfoController {
+  /* @ngInject */
   constructor(LookupService, CamperInfoForm, $rootScope, $stateParams) {
-    this.camperInfoForm = CamperInfoForm;
+    this.camperInfoForm = CamperInfoForm.createForm();
     this.lookupService = LookupService;
     this.rootScope = $rootScope;
     this.stateParams = $stateParams;

--- a/crossroads.net/app/camps/application_page/camper_info/camper_info_form.service.js
+++ b/crossroads.net/app/camps/application_page/camper_info/camper_info_form.service.js
@@ -1,6 +1,21 @@
-/* ngInject */
+class CamperInfoFormFactory {
+  /* ngInject */
+  constructor(CampsService, LookupService) {
+    console.debug('CamperInfoFormFactory - constructor');
+    this.campsService = CampsService;
+    this.lookupService = LookupService;
+  }
+
+  createForm() {
+    return new CamperInfoForm(this.campsService, this.lookupService);
+  }
+}
+
+export default CamperInfoFormFactory;
+
 class CamperInfoForm {
   constructor(CampsService, LookupService) {
+    console.debug('CamperInfoForm - constructor');
     this.campsService = CampsService;
     this.lookupService = LookupService;
 
@@ -21,7 +36,7 @@ class CamperInfoForm {
   }
 
   save(campId) {
-    return this.campsService.campResource.save({ campId }, this.formModel).$promise;
+    return this.campsService.camperResource.save({ campId }, this.formModel).$promise;
   }
 
   getModel() {
@@ -196,5 +211,3 @@ class CamperInfoForm {
     ];
   }
 }
-
-export default CamperInfoForm;

--- a/crossroads.net/app/camps/application_page/camper_info/camper_info_form.service.js
+++ b/crossroads.net/app/camps/application_page/camper_info/camper_info_form.service.js
@@ -1,7 +1,6 @@
 class CamperInfoFormFactory {
   /* ngInject */
   constructor(CampsService, LookupService) {
-    console.debug('CamperInfoFormFactory - constructor');
     this.campsService = CampsService;
     this.lookupService = LookupService;
   }
@@ -15,7 +14,6 @@ export default CamperInfoFormFactory;
 
 class CamperInfoForm {
   constructor(CampsService, LookupService) {
-    console.debug('CamperInfoForm - constructor');
     this.campsService = CampsService;
     this.lookupService = LookupService;
 

--- a/crossroads.net/app/camps/application_page/emergency_contact_info/emergency_contact.controller.js
+++ b/crossroads.net/app/camps/application_page/emergency_contact_info/emergency_contact.controller.js
@@ -1,7 +1,7 @@
 class EmergencyContactController {
   /* @ngInject */
   constructor(EmergencyContactForm, $rootScope, $state, $stateParams) {
-    this.emergencyContactForm = EmergencyContactForm;
+    this.emergencyContactForm = EmergencyContactForm.createForm();
     this.rootScope = $rootScope;
     this.state = $state;
     this.stateParams = $stateParams;

--- a/crossroads.net/app/camps/application_page/emergency_contact_info/emergency_contact_form.service.js
+++ b/crossroads.net/app/camps/application_page/emergency_contact_info/emergency_contact_form.service.js
@@ -1,6 +1,18 @@
-class EmergencyContactForm {
+class EmergencyContactFormFactory {
   /* ngInject */
-  constructor($resource, CampsService) {
+  constructor(CampsService) {
+    this.campsService = CampsService;
+  }
+
+  createForm() {
+    return new EmergencyContactForm(this.campsService);
+  }
+}
+
+export default EmergencyContactFormFactory;
+
+class EmergencyContactForm {
+  constructor(CampsService) {
     this.campsService = CampsService;
     this.formModel = {};
   }
@@ -201,5 +213,3 @@ class EmergencyContactForm {
   }
 
 }
-
-export default EmergencyContactForm;

--- a/crossroads.net/app/camps/application_page/medical_info/medical_info.controller.js
+++ b/crossroads.net/app/camps/application_page/medical_info/medical_info.controller.js
@@ -1,7 +1,7 @@
 /* @ngInject */
 class MedicalInfoController {
   constructor(MedicalInfoForm, $rootScope, $state) {
-    this.medicalInfoForm = MedicalInfoForm;
+    this.medicalInfoForm = MedicalInfoForm.createForm();
     this.rootScope = $rootScope;
     this.go = $state.go;
     this.stateParams = $state.params;

--- a/crossroads.net/app/camps/application_page/medical_info/medical_info_form.service.js
+++ b/crossroads.net/app/camps/application_page/medical_info/medical_info_form.service.js
@@ -1,6 +1,18 @@
-/* ngInject */
-class MedicalInfoForm {
+class MedicalInfoFormFactory {
+  /* ngInject */
+  constructor(CampsService, $resource) {
+    this.campsService = CampsService;
+    this.$resource = $resource;
+  }
 
+  createForm() {
+    return new MedicalInfoForm(this.campsService, this.$resource);
+  }
+}
+
+export default MedicalInfoFormFactory;
+
+class MedicalInfoForm {
   constructor(CampsService, $resource) {
     this.campsService = CampsService;
     this.allergies = [];
@@ -238,5 +250,3 @@ class MedicalInfoForm {
     return this.formModel;
   }
 }
-
-export default MedicalInfoForm;

--- a/crossroads.net/app/camps/application_page/product_summary/product_summary.controller.js
+++ b/crossroads.net/app/camps/application_page/product_summary/product_summary.controller.js
@@ -4,7 +4,7 @@ import moment from 'moment';
 class ProductSummaryController {
   /* @ngInject */
   constructor(ProductSummaryForm, CampsService, $rootScope, $stateParams) {
-    this.productSummaryForm = ProductSummaryForm;
+    this.productSummaryForm = ProductSummaryForm.createForm();
     this.campsService = CampsService;
     this.rootScope = $rootScope;
     this.stateParams = $stateParams;

--- a/crossroads.net/app/camps/application_page/product_summary/product_summary_form.service.js
+++ b/crossroads.net/app/camps/application_page/product_summary/product_summary_form.service.js
@@ -1,6 +1,17 @@
-/* ngInject */
-class ProductSummaryForm {
+class ProductSummaryFormFactory {
+  /* ngInject */
+  constructor($resource) {
+    this.$resource = $resource;
+  }
 
+  createForm() {
+    return new ProductSummaryForm(this.$resource);
+  }
+}
+
+export default ProductSummaryFormFactory;
+
+class ProductSummaryForm {
   constructor($resource) {
     this.formModel = {
       financialAssistance: false
@@ -23,5 +34,3 @@ class ProductSummaryForm {
     return this.formModel;
   }
 }
-
-export default ProductSummaryForm;

--- a/crossroads.net/app/camps/camps.service.js
+++ b/crossroads.net/app/camps/camps.service.js
@@ -7,9 +7,7 @@ class CampsService {
     // eslint-disable-next-line prefer-template
     this.campResource = $resource(__API_ENDPOINT__ + 'api/camps/:campId');
     // eslint-disable-next-line prefer-template
-    this.camperResource = $resource(__API_ENDPOINT__ + 'api/camps/:campId/:camperId');
-    // eslint-disable-next-line prefer-template
-    this.camperResource = $resource(__API_ENDPOINT__ + 'api/camps/:campId/:camperId');
+    this.camperResource = $resource(__API_ENDPOINT__ + 'api/camps/:campId/campers/:camperId');
     // eslint-disable-next-line prefer-template
     this.campDashboard = $resource(__API_ENDPOINT__ + 'api/my-camp');
     // eslint-disable-next-line prefer-template
@@ -26,9 +24,25 @@ class CampsService {
     // eslint-disable-next-line prefer-template
     this.paymentResource = $resource(__API_ENDPOINT__ + 'api/v1.0.0/invoice/:invoiceId/payment/:paymentId');
 
+    this.campInfo = null;
+    this.campTitle = null;
+    this.camperInfo = null;
+    this.waivers = null;
+    this.productInfo = null;
+    this.payment = null;
+    this.campMedical = null;
+
+    this.initializeCampData();
+    this.initializeCamperData();
+  }
+
+  initializeCampData() {
     this.campInfo = {};
-    this.camperInfo = {};
     this.campTitle = '';
+  }
+
+  initializeCamperData() {
+    this.camperInfo = {};
     this.waivers = [];
     this.productInfo = {};
     this.payment = {};

--- a/crossroads.net/app/camps/camps_family/camp_household_members/camp_household_members.controller.js
+++ b/crossroads.net/app/camps/camps_family/camp_household_members/camp_household_members.controller.js
@@ -1,12 +1,20 @@
 export default class CampHouseholdMembersController {
   /* @ngInject */
-  constructor(CampsService) {
+  constructor(CampsService, $state) {
     this.campsService = CampsService;
+    this.state = $state;
   }
 
   // eslint-disable-next-line class-methods-use-this
   isSignedUp(member) {
     return member.signedUpDate !== null;
+  }
+
+  signUp(member) {
+    // Since we might be selected a new camper, ensure that the CampService does not have cached data
+    // from the prior camper
+    this.campsService.initializeCamperData();
+    this.state.go('campsignup.application', { page: 'camper-info', contactId: member.contactId });
   }
 
   divClass(member) {

--- a/crossroads.net/app/camps/camps_family/camp_household_members/camp_household_members.html
+++ b/crossroads.net/app/camps/camps_family/camp_household_members/camp_household_members.html
@@ -11,7 +11,7 @@
           <div class="col-xs-12 col-sm-3 col-md-2 hard-sides mobile-soft-half-sides mobile-push-half-ends">
             <a href="#" data-ng-if="$ctrl.isSignedUp(member)" disabled class="table-btn btn-standard disabled">Sign Up </a>
             <a href="#" ng-if="!member.isEligible && !$ctrl.isSignedUp(member)" disabled class="table-btn btn-standard disabled">Sign Up</a>
-            <a ui-sref="campsignup.camper({camperId: member.contactId})" ng-if="!$ctrl.isSignedUp(member) && member.isEligible" class="table-btn btn-standard">Sign Up</a>
+            <a ng-click="$ctrl.signUp(member)" ng-if="!$ctrl.isSignedUp(member) && member.isEligible" class="table-btn btn-standard">Sign Up</a>
           </div>
         </div>
       </li>

--- a/crossroads.net/spec/camps/application_page/camps_medical_info/camps_medical_info.component.spec.js
+++ b/crossroads.net/spec/camps/application_page/camps_medical_info/camps_medical_info.component.spec.js
@@ -20,13 +20,16 @@ describe('Camps Medical Info Component', () => {
   beforeEach(inject((_$componentController_, _MedicalInfoForm_, _$log_, _$rootScope_, _$state_, _$q_) => {
     $componentController = _$componentController_;
     // log = _$log_;
-    medicalInfoForm = _MedicalInfoForm_;
     stateParams = _$state_.params;
     rootScope = _$rootScope_;
     q = _$q_;
 
     stateParams.campId = campId;
     stateParams.contactId = contactId;
+
+    // Set up the form
+    medicalInfoForm = _MedicalInfoForm_.createForm();
+    spyOn(_MedicalInfoForm_, 'createForm').and.callFake(() => medicalInfoForm);
 
     spyOn(medicalInfoForm, 'getModel').and.callThrough();
     spyOn(medicalInfoForm, 'getFields').and.callThrough();

--- a/crossroads.net/spec/camps/application_page/camps_medical_info/medical_info_form.service.spec.js
+++ b/crossroads.net/spec/camps/application_page/camps_medical_info/medical_info_form.service.spec.js
@@ -15,7 +15,7 @@ describe('Camps Medical Info Form', () => {
   beforeEach(angular.mock.module(campsModule));
 
   beforeEach(inject((_MedicalInfoForm_, _$httpBackend_) => {
-    fixture = _MedicalInfoForm_;
+    fixture = _MedicalInfoForm_.createForm();
     httpBackend = _$httpBackend_;
   }));
 

--- a/crossroads.net/spec/camps/application_page/emergency_contact_info/emergency_contact.component.spec.js
+++ b/crossroads.net/spec/camps/application_page/emergency_contact_info/emergency_contact.component.spec.js
@@ -21,7 +21,6 @@ describe('Camps Emergency Contact Component', () => {
   beforeEach(inject((_$componentController_, _EmergencyContactForm_, _CampsService_, _$log_, _$rootScope_, _$stateParams_, _$q_) => {
     $componentController = _$componentController_;
     // log = _$log_;
-    emergencyContactForm = _EmergencyContactForm_;
     campsService = _CampsService_;
     stateParams = _$stateParams_;
     rootScope = _$rootScope_;
@@ -29,6 +28,10 @@ describe('Camps Emergency Contact Component', () => {
 
     stateParams.campId = campId;
     stateParams.contactId = contactId;
+
+    // Set up the form instance
+    emergencyContactForm = _EmergencyContactForm_.createForm();
+    spyOn(_EmergencyContactForm_, 'createForm').and.callFake(() => emergencyContactForm);
 
     spyOn(emergencyContactForm, 'getModel').and.callThrough();
     spyOn(emergencyContactForm, 'getFields').and.callThrough();

--- a/crossroads.net/spec/camps/application_page/emergency_contact_info/emergency_contact_form.service.spec.js
+++ b/crossroads.net/spec/camps/application_page/emergency_contact_info/emergency_contact_form.service.spec.js
@@ -20,7 +20,7 @@ describe('Camps Emergency Contact Form', () => {
   beforeEach(angular.mock.module(applicationmodule));
 
   beforeEach(inject((_EmergencyContactForm_, _CampsService_, _$httpBackend_) => {
-    fixture = _EmergencyContactForm_;
+    fixture = _EmergencyContactForm_.createForm();
     campsService = _CampsService_;
     httpBackend = _$httpBackend_;
 

--- a/crossroads.net/spec/camps/application_page/product_summary/product_summary.component.spec.js
+++ b/crossroads.net/spec/camps/application_page/product_summary/product_summary.component.spec.js
@@ -21,7 +21,6 @@ describe('Camp Product Summary Component', () => {
 
   beforeEach(inject((_$componentController_, _ProductSummaryForm_, _CampsService_, _$rootScope_, _$stateParams_, _$q_) => {
     $componentController = _$componentController_;
-    productSummaryForm = _ProductSummaryForm_;
     campsService = _CampsService_;
     stateParams = _$stateParams_;
     rootScope = _$rootScope_;
@@ -32,8 +31,12 @@ describe('Camp Product Summary Component', () => {
     stateParams.campId = campId;
     stateParams.contactId = contactId;
 
+    // Set up the form instance
+    productSummaryForm = _ProductSummaryForm_.createForm();
+    spyOn(_ProductSummaryForm_, 'createForm').and.callFake(() => productSummaryForm);
     spyOn(productSummaryForm, 'getModel').and.callThrough();
 
+    // Create the component to test
     const bindings = {};
     productSummaryController = $componentController('productSummary', null, bindings);
     productSummaryController.$onInit();

--- a/crossroads.net/spec/camps/application_page/product_summary/product_summary_form.service.spec.js
+++ b/crossroads.net/spec/camps/application_page/product_summary/product_summary_form.service.spec.js
@@ -14,7 +14,7 @@ describe('Camp Product Summary Form', () => {
   beforeEach(angular.mock.module(applicationModule));
 
   beforeEach(inject((_ProductSummaryForm_, _$httpBackend_) => {
-    fixture = _ProductSummaryForm_;
+    fixture = _ProductSummaryForm_.createForm();
     httpBackend = _$httpBackend_;
   }));
 

--- a/crossroads.net/spec/camps/camper_info/camper_info.component.spec.js
+++ b/crossroads.net/spec/camps/camper_info/camper_info.component.spec.js
@@ -19,7 +19,6 @@ describe('Camper Info Component', () => {
 
   beforeEach(inject((_$componentController_, _$httpBackend_, _CamperInfoForm_, _$q_, _$stateParams_, _$rootScope_) => {
     $componentController = _$componentController_;
-    camperInfoForm = _CamperInfoForm_;
     $httpBackend = _$httpBackend_;
     q = _$q_;
     stateParams = _$stateParams_;
@@ -28,6 +27,10 @@ describe('Camper Info Component', () => {
       successfullRegistration: { content: 'success' },
       generalError: { content: 'error' }
     };
+
+    // Set up the camper info form instance that will be returned by the CamperInfoForm.createForm() factory function
+    camperInfoForm = _CamperInfoForm_.createForm();
+    spyOn(_CamperInfoForm_, 'createForm').and.callFake(() => camperInfoForm);
 
     spyOn(camperInfoForm, 'getFields').and.callThrough();
     spyOn(camperInfoForm, 'getModel').and.callThrough();
@@ -87,4 +90,8 @@ describe('Camper Info Component', () => {
     rootScope.$apply(); // must be called to resolve the promise
     expect(camperInfo.submitting).toBeFalsy();
   });
+
+  it('should get new data when selecting another family member', () => {
+
+  })
 });

--- a/crossroads.net/spec/camps/camper_info/camper_info_form.service.spec.js
+++ b/crossroads.net/spec/camps/camper_info/camper_info_form.service.spec.js
@@ -11,7 +11,7 @@ describe('Camper Info Form Service', () => {
   beforeEach(angular.mock.module(campsModule));
 
   beforeEach(inject((_LookupService_, _CamperInfoForm_, _$httpBackend_) => {
-    camperInfoForm = _CamperInfoForm_;
+    camperInfoForm = _CamperInfoForm_.createForm();
     httpBackend = _$httpBackend_;
   }));
 
@@ -34,7 +34,7 @@ describe('Camper Info Form Service', () => {
     camperInfoForm.formModel.middleName = 'M';
     camperInfoForm.formModel.preferredName = 'Matt';
 
-    httpBackend.expectPOST(`${endpoint}/camps/${campId}`, camperInfoForm.formModel).respond(200);
+    httpBackend.expectPOST(`${endpoint}/camps/${campId}/campers`, camperInfoForm.formModel).respond(200);
     camperInfoForm.save(campId);
     httpBackend.flush();
   });

--- a/crossroads.net/spec/camps/camps.service.spec.js
+++ b/crossroads.net/spec/camps/camps.service.spec.js
@@ -22,6 +22,16 @@ describe('Camp Service', () => {
     httpBackend.flush();
   });
 
+  it('Should make the API call to get a Camper', () => {
+    const eventId = 4525285;
+    const camperId = 1234;
+    httpBackend.expectGET(`${endpoint}/camps/${eventId}/campers/${camperId}`)
+      .respond(200, {});
+    campsService.getCamperInfo(eventId, camperId);
+
+    httpBackend.flush();
+  });
+
   it('should make the API call to get my dashboard', () => {
     httpBackend.expectGET(`${endpoint}/my-camp`).respond(200, []);
     campsService.getCampDashboard();


### PR DESCRIPTION
I've added two approaches for ensuring we aren't getting the wrong camper data.  

1.  Added CampsService.initializeCampData() and CampsService.initializerCamperData()... the initializeCamperData() function will be called when you click on a family member on the /family page.  That way we ensure that we're starting fresh for a second family member

2. Each of our "Form Services" e.g. CamperInfoForm now has a pair of classes.  The actual injected service is a factory that you must call .createForm() on.  e.g. CamperInfoForm.createForm().  This gives you an individual instance of the current form class which will only be used for the current page controller.  That way when a user revisits the page, potentially for a different camper, all new data will be retrieved from the CampsService cache