### PR TITLE
DE2216 - Change the formly phone number validator

### DIFF
--- a/crossroads.net/app/camps/application_page/medical_info/medical_info_form.service.js
+++ b/crossroads.net/app/camps/application_page/medical_info/medical_info_form.service.js
@@ -52,34 +52,34 @@ class MedicalInfoForm {
     const dto = {
       contactId: this.formModel.contactId,
       medicalInformationId: this.campsService.campMedical.medicalInformationId,
-      insuranceCompany: this.formModel.insuranceCompany,
-      policyHolder: this.formModel.policyHolder,
-      physicianName: this.formModel.physicianName,
-      physicianPhone: this.formModel.physicianPhone,
+      insuranceCompany: this.formModel.insuranceCompany || undefined,
+      policyHolder: this.formModel.policyHolder || undefined,
+      physicianName: this.formModel.physicianName || undefined,
+      physicianPhone: this.formModel.physicianPhone || undefined,
       allergies: [
         { allergyType: 'Medicine',
-          allergyId: this.medicineAllergyId,
-          allergyDescription: this.formModel.medicineAllergies,
-          medicalInformationAllergyId: this.medicineMedAllergyId,
-          allergyTypeId: this.medicineAllergyTypeId
+          allergyId: this.medicineAllergyId || undefined,
+          allergyDescription: this.formModel.medicineAllergies || undefined,
+          medicalInformationAllergyId: this.medicineMedAllergyId || undefined,
+          allergyTypeId: this.medicineAllergyTypeId || undefined
         },
         { allergyType: 'Food',
-          allergyId: this.foodAllergyId,
-          allergyDescription: this.formModel.foodAllergies,
-          medicalInformationAllergyId: this.foodMedAllergyId,
-          allergyTypeId: this.foodAllergyTypeId
+          allergyId: this.foodAllergyId || undefined,
+          allergyDescription: this.formModel.foodAllergies || undefined,
+          medicalInformationAllergyId: this.foodMedAllergyId || undefined,
+          allergyTypeId: this.foodAllergyTypeId || undefined
         },
         { allergyType: 'Environmental',
-          allergyId: this.environmentalAllergyId,
-          allergyDescription: this.formModel.environmentalAllergies,
-          medicalInformationAllergyId: this.environmentalMedAllergyId,
-          allergyTypeId: this.environmentAllergyTypeId
+          allergyId: this.environmentalAllergyId || undefined,
+          allergyDescription: this.formModel.environmentalAllergies || undefined,
+          medicalInformationAllergyId: this.environmentalMedAllergyId || undefined,
+          allergyTypeId: this.environmentAllergyTypeId || undefined
         },
         { allergyType: 'Other',
-          allergyId: this.otherAllergyId,
-          allergyDescription: this.formModel.otherAllergies,
-          medicalInformationAllergyId: this.otherMedAllergyId,
-          allergyTypeId: this.otherAllergyTypeId
+          allergyId: this.otherAllergyId || undefined,
+          allergyDescription: this.formModel.otherAllergies || undefined,
+          medicalInformationAllergyId: this.otherMedAllergyId || undefined,
+          allergyTypeId: this.otherAllergyTypeId || undefined
         }]
     };
     return dto;

--- a/crossroads.net/app/formlyBuilder/formlyConfig/types/phoneNumberValidator.js
+++ b/crossroads.net/app/formlyBuilder/formlyConfig/types/phoneNumberValidator.js
@@ -5,7 +5,7 @@ function addPhoneNumberValidator(formlyConfig) {
       validators: {
         phoneNumber: {
           expression: (value) => {
-            if (value == null) {
+            if (value == null || value === '') {
               return true;
             }
             const regex = /^\(?(\d{3})\)?[\s.-]?(\d{3})[\s.-]?(\d{4})$/;


### PR DESCRIPTION
... to ignore empty strings as well as null.  Note that this also required a change to the medical info form service to pass undefined for any value that was delete and is now an empty string.  This fix does *not* handle the N/A values which are part of DE2210