### PR TITLE
DE2313 Forced the iframe resize to use interval

### DIFF
--- a/crossroads.net/app/camps/application_page/camps_payment/camps_payment.controller.js
+++ b/crossroads.net/app/camps/application_page/camps_payment/camps_payment.controller.js
@@ -22,9 +22,9 @@ export default class CampPaymentController {
     this.iFrameResizer = require('iframe-resizer/js/iframeResizer.min.js');
 
     this.iFrames = this.iFrameResizer({
-      heightCalculationMethod: 'max',
+      heightCalculationMethod: 'taggedElement',
       checkOrigin: false,
-      resizeFrom: 'child'
+      interval: -16
     }, this.iframeSelector);
 
     // eslint-disable-next-line no-undef


### PR DESCRIPTION
By making the iframe resizer use an interval it forces a check on every
page refresh rather than when it thinks it needs to check. This makes
the animation look very smooth.