### PR TITLE
Feature/us5870 handle accounting company in online giving history

### DIFF
--- a/CI/SQL/20161206_092600_US5870-AddAccountingCompanyToDonationDistributionsPage.sql
+++ b/CI/SQL/20161206_092600_US5870-AddAccountingCompanyToDonationDistributionsPage.sql
@@ -1,0 +1,124 @@
+USE [MinistryPlatform]
+GO
+
+DECLARE @EXISTING_PAGE_ID int = 0
+DECLARE @PAGE_ID int = 516
+DECLARE @PAGE_SECTION_ID int = 17 -- "My Records" page
+DECLARE @DISPLAY_NAME nvarchar(50) = N'My Household Donation Distributions'
+DECLARE @SINGULAR_NAME nvarchar(50) = N'My Household Donation Distribution'
+DECLARE @DESCRIPTION nvarchar(255) = N'Distributions of the donation amount to programs, event projects, or pledges.  This is used by the Giving History page in CR.net'
+DECLARE @VIEW_ORDER smallint = 20
+DECLARE @TABLE_NAME nvarchar(50) = 'Donation_Distributions'
+DECLARE @PRIMARY_KEY nvarchar(50) = 'Donation_Distribution_ID'
+DECLARE @DEFAULT_FIELD_LIST nvarchar(2000) = N'Donation_ID_Table.Donation_Date
+,CASE WHEN (Donation_Distributions.Soft_Credit_Donor IS NULL) THEN ''False'' ELSE ''True'' END AS [Soft_Credit_Donation]
+,ISNULL(Donation_ID_Table_Donor_ID_Table_Contact_ID_Table.Last_Name,Donation_ID_Table_Donor_ID_Table_Contact_ID_Table.Display_Name) AS [Last_Name]
+,Donation_ID_Table_Donor_ID_Table_Contact_ID_Table.First_Name
+,Donation_Distributions.Amount
+,Donation_ID_Table_Payment_Type_ID_Table.Payment_Type
+,Donation_ID_Table.Item_Number
+,Program_ID_Table.Program_Name
+,Program_ID_Table.Statement_Title
+,Pledge_ID_Table_Pledge_Campaign_ID_Table.Campaign_Name
+,Donation_Distributions.Donation_ID
+,Donation_ID_Table.Donor_ID
+,Donation_ID_Table_Batch_ID_Table.Batch_ID
+,Pledge_ID_Table.Pledge_ID
+,Target_Event_Table.Event_Title AS [Target_Event]
+,Donation_ID_Table.Donation_Status_Date ,Donation_ID_Table.Donation_Status_ID ,Donation_ID_Table.Transaction_Code ,Donation_ID_Table.Payment_Type_ID ,Soft_Credit_Donor_Table.Donor_ID AS [Soft_Credit_Donor_ID] ,Donation_ID_Table_Donor_ID_Table_Contact_ID_Table.[Display_Name] AS [Donor_Display_Name]
+,Donation_ID_Table.Is_Recurring_Gift
+,Congregation_ID_Table_Accounting_Company_ID_Table.[Company_Name]
+,Congregation_ID_Table_Accounting_Company_ID_Table.[Show_Online]'
+DECLARE @SELECTED_RECORD_EXPRESSION nvarchar(255) = 'Program_ID_Table.Program_Name'
+DECLARE @DISPLAY_COPY bit = 0
+DECLARE @DISPLAY_SEARCH bit = 1
+DECLARE @FILTER_CLAUSE NVARCHAR(500) = 'Donation_Distributions.Donation_Distribution_ID IN (
+SELECT * FROM [dbo].[crds_udfGetDonationDistributionIdsForUser](dp_UserID)
+)
+'
+DECLARE @CONTACT_ID_FIELD NVARCHAR(100) = 'Donation_ID_Table_Donor_ID_Table.Contact_ID'
+
+SELECT @EXISTING_PAGE_ID = [Page_ID] FROM [dbo].[dp_Pages] WHERE [Page_ID] = @PAGE_ID;
+
+IF @EXISTING_PAGE_ID = 0
+BEGIN
+    SET IDENTITY_INSERT [dbo].[dp_Pages] ON
+    PRINT 'Inserting new page ' + Convert(varchar, @PAGE_ID)
+    INSERT INTO [dbo].[dp_Pages] (
+		[Page_ID]
+		,[Display_Name]
+		,[Singular_Name]
+		,[Description]
+		,[View_Order]
+		,[Table_Name]
+		,[Primary_Key]
+		,[Display_Search]
+		,[Default_Field_List]
+		,[Selected_Record_Expression]
+		,[Filter_Clause]
+		,[Start_Date_Field]
+		,[End_Date_Field]
+		,[Contact_ID_Field]
+		,[Default_View]
+		,[Pick_List_View]
+		,[Image_Name]
+		,[Direct_Delete_Only]
+		,[System_Name]
+		,[Date_Pivot_Field]
+		,[Custom_Form_Name]
+		,[Display_Copy])
+	VALUES (
+		@PAGE_ID
+		,@DISPLAY_NAME
+		,@SINGULAR_NAME
+		,@DESCRIPTION
+		,@VIEW_ORDER
+		,@TABLE_NAME
+		,@PRIMARY_KEY
+		,@DISPLAY_SEARCH
+		,@DEFAULT_FIELD_LIST
+		,@SELECTED_RECORD_EXPRESSION
+		,@FILTER_CLAUSE
+		,NULL -- Start_Date_Field
+		,NULL -- End_Date_Field
+		,@CONTACT_ID_FIELD
+		,NULL -- Default_View
+		,NULL -- Pick_List_View
+		,NULL -- Image_Name
+		,NULL -- Direct_Delete_Only
+		,NULL -- System_Name
+		,NULL -- Date_Pivot_Field
+		,NULL -- Custom_Form_Name
+		,@DISPLAY_COPY
+	);
+    SET IDENTITY_INSERT [dbo].[dp_Pages] OFF
+END
+ELSE
+BEGIN
+	PRINT 'Update existing page ' + Convert(varchar, @PAGE_ID)
+	UPDATE [dbo].[dp_Pages] SET
+		[Display_Name] = @DISPLAY_NAME
+		,[Singular_Name] = @SINGULAR_NAME
+		,[Description] = @DESCRIPTION
+		,[View_Order] = @VIEW_ORDER
+		,[Table_Name] = @TABLE_NAME
+		,[Primary_Key] = @PRIMARY_KEY
+		,[Default_Field_List] = @DEFAULT_FIELD_LIST
+		,[Selected_Record_Expression] = @SELECTED_RECORD_EXPRESSION
+		,[Display_Copy] = @DISPLAY_COPY
+    ,[Display_Search] = @DISPLAY_SEARCH
+    ,[Filter_Clause] = @FILTER_CLAUSE
+    ,[Contact_ID_Field] = @CONTACT_ID_FIELD
+	WHERE [Page_ID] = @PAGE_ID
+END
+
+SELECT @EXISTING_PAGE_ID = [Page_ID] FROM [dbo].[dp_Page_Section_Pages] WHERE [Page_ID] = @PAGE_ID AND [Page_Section_ID] = @PAGE_SECTION_ID;
+IF @EXISTING_PAGE_ID = 0
+BEGIN
+  PRINT 'Adding page ' + Convert(varchar, @PAGE_ID) + ' to page section ' + Convert(varchar, @PAGE_SECTION_ID);
+  INSERT INTO [dbo].[dp_Page_Section_Pages] (Page_ID, Page_Section_ID) VALUES (@PAGE_ID, @PAGE_SECTION_ID);
+END
+ELSE
+BEGIN
+  PRINT 'Page ' + Convert(varchar, @PAGE_ID) + ' is already in page section ' + Convert(varchar, @PAGE_SECTION_ID);
+END;

--- a/Gateway/Crossroads.AsyncJobs/App_Start/AutoMapperConfig.cs
+++ b/Gateway/Crossroads.AsyncJobs/App_Start/AutoMapperConfig.cs
@@ -102,6 +102,8 @@ namespace Crossroads.AsyncJobs
                 .ForMember(dest => dest.Distributions, opts => opts.MapFrom(src => src.Distributions))
                 .ForMember(dest => dest.IncludeOnGivingHistory, opts => opts.MapFrom(src => src.IncludeOnGivingHistory))
                 .ForMember(dest => dest.IncludeOnPrintedStatement, opts => opts.MapFrom(src => src.IncludeOnPrintedStatement))
+                .ForMember(dest => dest.AccountingCompanyName, opts => opts.MapFrom(src => src.AccountingCompanyName))
+                .ForMember(dest => dest.AccountingCompanyIncludeOnPrintedStatement, opts => opts.MapFrom(src => src.AccountingCompanyIncludeOnPrintedStatement))
                 .AfterMap((src, dest) =>
                 {
                     dest.Source = new DonationSourceDTO

--- a/Gateway/MinistryPlatform.Translation.Test/Services/DonorServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/DonorServiceTest.cs
@@ -1156,7 +1156,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Item_Number", null},
                     {"Is_Recurring_Gift", false },
                     {"Company_Name", "Company Name" },
-                    {"Show_Online", 1 }
+                    {"Show_Online", true }
                 },
                 new Dictionary<string, object>
                 {
@@ -1174,7 +1174,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Item_Number", null},
                     {"Is_Recurring_Gift", false },
                     {"Company_Name", "Company Name" },
-                    {"Show_Online", 1 }
+                    {"Show_Online", true }
                 },
                 new Dictionary<string, object>
                 {
@@ -1192,7 +1192,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Item_Number", null},
                     {"Is_Recurring_Gift", false },
                     {"Company_Name", "Company Name" },
-                    {"Show_Online", 1 }
+                    {"Show_Online", true }
                 }
             };
 
@@ -1267,7 +1267,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Item_Number", null},
                     {"Is_Recurring_Gift", false },
                     {"Company_Name", "Company Name" },
-                    {"Show_Online", 1 }
+                    {"Show_Online", true }
                 },
                 new Dictionary<string, object>
                 {
@@ -1285,7 +1285,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Item_Number", ""},
                     {"Is_Recurring_Gift", false },
                     {"Company_Name", "Company Name" },
-                    {"Show_Online", 1 }
+                    {"Show_Online", true }
                 },
                 new Dictionary<string, object>
                 {
@@ -1302,7 +1302,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Donor_Display_Name", "Test Name"},
                     {"Is_Recurring_Gift", false },
                     {"Company_Name", "Company Name" },
-                    {"Show_Online", 1 }
+                    {"Show_Online", true }
                 },
                 new Dictionary<string, object>
                 {
@@ -1320,7 +1320,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Item_Number", "1234"},
                     {"Is_Recurring_Gift", false },
                     {"Company_Name", "Company Name" },
-                    {"Show_Online", 1 }
+                    {"Show_Online", true }
                 },
             };
 
@@ -1398,7 +1398,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Item_Number", null},
                     {"Is_Recurring_Gift", false },
                     {"Company_Name", "Company Name3" },
-                    {"Show_Online", 0 }
+                    {"Show_Online", false }
                 },
                 new Dictionary<string, object>
                 {
@@ -1416,7 +1416,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Item_Number", ""},
                     {"Is_Recurring_Gift", false },
                     {"Company_Name", "Company Name2" },
-                    {"Show_Online", 1 }
+                    {"Show_Online", true }
                 },
                 new Dictionary<string, object>
                 {
@@ -1433,7 +1433,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Donor_Display_Name", "Test Name"},
                     {"Is_Recurring_Gift", false },
                     {"Company_Name", "Company Name3" },
-                    {"Show_Online", 0 }
+                    {"Show_Online", false }
                 },
                 new Dictionary<string, object>
                 {
@@ -1451,7 +1451,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Item_Number", "1234"},
                     {"Is_Recurring_Gift", false },
                     {"Company_Name", "Company Name4" },
-                    {"Show_Online", 1 }
+                    {"Show_Online", true }
                 },
             };
 
@@ -1502,7 +1502,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Item_Number", null},
                     {"Is_Recurring_Gift", true },
                     {"Company_Name", "Company Name" },
-                    {"Show_Online", 1 }
+                    {"Show_Online", true }
                 },
                 new Dictionary<string, object>
                 {
@@ -1520,7 +1520,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Item_Number", ""},
                     {"Is_Recurring_Gift", true },
                     {"Company_Name", "Company Name" },
-                    {"Show_Online", 1 }
+                    {"Show_Online", true }
                 },
                 new Dictionary<string, object>
                 {
@@ -1537,7 +1537,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Donor_Display_Name", "Test Name"},
                     {"Is_Recurring_Gift", false },
                     {"Company_Name", "Company Name" },
-                    {"Show_Online", 1 }
+                    {"Show_Online", true }
                 },
                 new Dictionary<string, object>
                 {
@@ -1555,7 +1555,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Item_Number", "1234"},
                     {"Is_Recurring_Gift", false },
                     {"Company_Name", "Company Name" },
-                    {"Show_Online", 1 }
+                    {"Show_Online", true }
                 },
             };
 
@@ -1612,7 +1612,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Item_Number", null},
                     {"Is_Recurring_Gift", false },
                     {"Company_Name", "Company Name" },
-                    {"Show_Online", 1 }
+                    {"Show_Online", true }
                 },
                 new Dictionary<string, object>
                 {
@@ -1630,7 +1630,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Item_Number", null},
                     {"Is_Recurring_Gift", false },
                     {"Company_Name", "Company Name" },
-                    {"Show_Online", 1 }
+                    {"Show_Online", true }
                 },
                 new Dictionary<string, object>
                 {
@@ -1648,7 +1648,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Item_Number", null},
                     {"Is_Recurring_Gift", false },
                     {"Company_Name", "Company Name" },
-                    {"Show_Online", 1 }
+                    {"Show_Online", true }
                 }
             };
 
@@ -1716,7 +1716,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Item_Number", null},
                     {"Is_Recurring_Gift", false },
                     {"Company_Name", "Company Name" },
-                    {"Show_Online", 1 }
+                    {"Show_Online", true }
                 },
                 new Dictionary<string, object>
                 {
@@ -1734,7 +1734,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Item_Number", null},
                     {"Is_Recurring_Gift", false },
                     {"Company_Name", "Company Name" },
-                    {"Show_Online", 1 }
+                    {"Show_Online", true }
                 },
                 new Dictionary<string, object>
                 {
@@ -1751,7 +1751,7 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Donor_Display_Name", "Test Name"},
                     {"Is_Recurring_Gift", false },
                     {"Company_Name", "Company Name" },
-                    {"Show_Online", 1 }
+                    {"Show_Online", true }
                 }
             };
 

--- a/Gateway/MinistryPlatform.Translation.Test/Services/DonorServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/DonorServiceTest.cs
@@ -1154,7 +1154,9 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"dp_RecordName", "Program 1"},
                     {"Donor_Display_Name", "Test Name"},
                     {"Item_Number", null},
-                    {"Is_Recurring_Gift", false }
+                    {"Is_Recurring_Gift", false },
+                    {"Company_Name", "Company Name" },
+                    {"Show_Online", 1 }
                 },
                 new Dictionary<string, object>
                 {
@@ -1170,7 +1172,9 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"dp_RecordName", "Program 2"},
                     {"Donor_Display_Name", "Test Name"},
                     {"Item_Number", null},
-                    {"Is_Recurring_Gift", false }
+                    {"Is_Recurring_Gift", false },
+                    {"Company_Name", "Company Name" },
+                    {"Show_Online", 1 }
                 },
                 new Dictionary<string, object>
                 {
@@ -1186,7 +1190,9 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"dp_RecordName", "Program 9"},
                     {"Donor_Display_Name", "Test Name"},
                     {"Item_Number", null},
-                    {"Is_Recurring_Gift", false }
+                    {"Is_Recurring_Gift", false },
+                    {"Company_Name", "Company Name" },
+                    {"Show_Online", 1 }
                 }
             };
 
@@ -1259,7 +1265,9 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"dp_RecordName", "Program 1"},
                     {"Donor_Display_Name", "Test Name"},
                     {"Item_Number", null},
-                    {"Is_Recurring_Gift", false }
+                    {"Is_Recurring_Gift", false },
+                    {"Company_Name", "Company Name" },
+                    {"Show_Online", 1 }
                 },
                 new Dictionary<string, object>
                 {
@@ -1275,7 +1283,9 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"dp_RecordName", "Program 2"},
                     {"Donor_Display_Name", "Test Name"},
                     {"Item_Number", ""},
-                    {"Is_Recurring_Gift", false }
+                    {"Is_Recurring_Gift", false },
+                    {"Company_Name", "Company Name" },
+                    {"Show_Online", 1 }
                 },
                 new Dictionary<string, object>
                 {
@@ -1290,7 +1300,9 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Amount", 9000.00M},
                     {"dp_RecordName", "Program 9"},
                     {"Donor_Display_Name", "Test Name"},
-                    {"Is_Recurring_Gift", false }
+                    {"Is_Recurring_Gift", false },
+                    {"Company_Name", "Company Name" },
+                    {"Show_Online", 1 }
                 },
                 new Dictionary<string, object>
                 {
@@ -1306,7 +1318,9 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"dp_RecordName", "Program 9"},
                     {"Donor_Display_Name", "Test Name"},
                     {"Item_Number", "1234"},
-                    {"Is_Recurring_Gift", false }
+                    {"Is_Recurring_Gift", false },
+                    {"Company_Name", "Company Name" },
+                    {"Show_Online", 1 }
                 },
             };
 
@@ -1336,6 +1350,138 @@ namespace MinistryPlatform.Translation.Test.Services
         }
 
         [Test]
+        public void TestGetDonationsWithMultipleAccountingCompanies()
+        {
+            var statuses = new List<Dictionary<string, object>>
+            {
+                new Dictionary<string, object>
+                {
+                    {"dp_RecordID", 1},
+                    {"Display_On_Giving_History", true},
+                    {"Display_On_Statements", true},
+                    {"Display_On_MyTrips", true},
+                    {"Donation_Status", "Pending"}
+                },
+                new Dictionary<string, object>
+                {
+                    {"dp_RecordID", 2},
+                    {"Display_On_Giving_History", false},
+                    {"Display_On_Statements", false},
+                    {"Display_On_MyTrips", false},
+                    {"Donation_Status", "Succeeded"}
+                },
+                new Dictionary<string, object>
+                {
+                    {"dp_RecordID", 3},
+                    {"Display_On_Giving_History", false},
+                    {"Display_On_Statements", false},
+                    {"Display_On_MyTrips", false},
+                    {"Donation_Status", "Succeeded"}
+                }
+            };
+
+            var records = new List<Dictionary<string, object>>
+            {
+                new Dictionary<string, object>
+                {
+                    {"Donation_Date", DateTime.Now},
+                    {"Donation_ID", 1000},
+                    {"Soft_Credit_Donor_ID", null},
+                    {"Donation_Status_ID", 1},
+                    {"Donation_Status_Date", DateTime.Now},
+                    {"Donor_ID", 1100},
+                    {"Payment_Type_ID", 1110},
+                    {"Transaction_Code", "tx_1000"},
+                    {"Amount", 1000.00M},
+                    {"dp_RecordName", "Program 1"},
+                    {"Donor_Display_Name", "Test Name"},
+                    {"Item_Number", null},
+                    {"Is_Recurring_Gift", false },
+                    {"Company_Name", "Company Name3" },
+                    {"Show_Online", 0 }
+                },
+                new Dictionary<string, object>
+                {
+                    {"Donation_Date", DateTime.Now},
+                    {"Donation_ID", 2000},
+                    {"Soft_Credit_Donor_ID", null},
+                    {"Donation_Status_ID", 2},
+                    {"Donation_Status_Date", DateTime.Now},
+                    {"Donor_ID", 2200},
+                    {"Payment_Type_ID", 2220},
+                    {"Transaction_Code", "tx_2000"},
+                    {"Amount", 2000.00M},
+                    {"dp_RecordName", "Program 2"},
+                    {"Donor_Display_Name", "Test Name"},
+                    {"Item_Number", ""},
+                    {"Is_Recurring_Gift", false },
+                    {"Company_Name", "Company Name2" },
+                    {"Show_Online", 1 }
+                },
+                new Dictionary<string, object>
+                {
+                    {"Donation_Date", DateTime.Now},
+                    {"Donation_ID", 1000},
+                    {"Soft_Credit_Donor_ID", null},
+                    {"Donation_Status_ID", 1},
+                    {"Donation_Status_Date", DateTime.Now},
+                    {"Donor_ID", 1100},
+                    {"Payment_Type_ID", 1110},
+                    {"Transaction_Code", "tx_1000"},
+                    {"Amount", 9000.00M},
+                    {"dp_RecordName", "Program 9"},
+                    {"Donor_Display_Name", "Test Name"},
+                    {"Is_Recurring_Gift", false },
+                    {"Company_Name", "Company Name3" },
+                    {"Show_Online", 0 }
+                },
+                new Dictionary<string, object>
+                {
+                    {"Donation_Date", DateTime.Now},
+                    {"Donation_ID", 3000},
+                    {"Soft_Credit_Donor_ID", null},
+                    {"Donation_Status_ID", 1},
+                    {"Donation_Status_Date", DateTime.Now},
+                    {"Donor_ID", 1100},
+                    {"Payment_Type_ID", 1110},
+                    {"Transaction_Code", "tx_1000"},
+                    {"Amount", 9000.00M},
+                    {"dp_RecordName", "Program 9"},
+                    {"Donor_Display_Name", "Test Name"},
+                    {"Item_Number", "1234"},
+                    {"Is_Recurring_Gift", false },
+                    {"Company_Name", "Company Name4" },
+                    {"Show_Online", 1 }
+                },
+            };
+
+            var searchString = "\"*/2015*\",True";
+            _ministryPlatformService.Setup(mocked => mocked.GetRecordsDict(516, "auth token", searchString, It.IsAny<string>())).Returns(records);
+            _ministryPlatformService.Setup(mocked => mocked.GetRecordsDict(90210, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(statuses);
+            var result = _fixture.GetDonationsForAuthenticatedUser("auth token", true, "2015");
+
+            _ministryPlatformService.VerifyAll();
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(3, result.Count);
+            Assert.AreEqual(2, result[0].Distributions.Count);
+            Assert.AreEqual(1000000, result[0].donationAmt);
+            Assert.AreEqual("Program 1", result[0].Distributions[0].donationDistributionProgram);
+            Assert.AreEqual(100000, result[0].Distributions[0].donationDistributionAmt);
+            Assert.AreEqual("Program 9", result[0].Distributions[1].donationDistributionProgram);
+            Assert.AreEqual(900000, result[0].Distributions[1].donationDistributionAmt);
+            Assert.IsFalse(result[0].AccountingCompanyIncludeOnPrintedStatement);
+
+            Assert.AreEqual(1, result[1].Distributions.Count);
+            Assert.AreEqual(200000, result[1].donationAmt);
+            Assert.AreEqual("Program 2", result[1].Distributions[0].donationDistributionProgram);
+            Assert.AreEqual(200000, result[1].Distributions[0].donationDistributionAmt);
+
+            Assert.AreEqual("1234", result[2].itemNumber);
+
+        }
+
+        [Test]
         public void TestGetLastDonationForAuthenticatedUser()
         {
             var records = new List<Dictionary<string, object>>
@@ -1354,7 +1500,9 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"dp_RecordName", "Program 1"},
                     {"Donor_Display_Name", "Test Name"},
                     {"Item_Number", null},
-                    {"Is_Recurring_Gift", true }
+                    {"Is_Recurring_Gift", true },
+                    {"Company_Name", "Company Name" },
+                    {"Show_Online", 1 }
                 },
                 new Dictionary<string, object>
                 {
@@ -1370,7 +1518,9 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"dp_RecordName", "Program 2"},
                     {"Donor_Display_Name", "Test Name"},
                     {"Item_Number", ""},
-                    {"Is_Recurring_Gift", true }
+                    {"Is_Recurring_Gift", true },
+                    {"Company_Name", "Company Name" },
+                    {"Show_Online", 1 }
                 },
                 new Dictionary<string, object>
                 {
@@ -1385,7 +1535,9 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Amount", 5000.00M},
                     {"dp_RecordName", "Program 9"},
                     {"Donor_Display_Name", "Test Name"},
-                    {"Is_Recurring_Gift", false }
+                    {"Is_Recurring_Gift", false },
+                    {"Company_Name", "Company Name" },
+                    {"Show_Online", 1 }
                 },
                 new Dictionary<string, object>
                 {
@@ -1401,7 +1553,9 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"dp_RecordName", "Program 9"},
                     {"Donor_Display_Name", "Test Name"},
                     {"Item_Number", "1234"},
-                    {"Is_Recurring_Gift", false }
+                    {"Is_Recurring_Gift", false },
+                    {"Company_Name", "Company Name" },
+                    {"Show_Online", 1 }
                 },
             };
 
@@ -1456,7 +1610,9 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"dp_RecordName", "Program 1"},
                     {"Donor_Display_Name", "Test Name"},
                     {"Item_Number", null},
-                    {"Is_Recurring_Gift", false }
+                    {"Is_Recurring_Gift", false },
+                    {"Company_Name", "Company Name" },
+                    {"Show_Online", 1 }
                 },
                 new Dictionary<string, object>
                 {
@@ -1472,7 +1628,9 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"dp_RecordName", "Program 2"},
                     {"Donor_Display_Name", "Test Name"},
                     {"Item_Number", null},
-                    {"Is_Recurring_Gift", false }
+                    {"Is_Recurring_Gift", false },
+                    {"Company_Name", "Company Name" },
+                    {"Show_Online", 1 }
                 },
                 new Dictionary<string, object>
                 {
@@ -1488,7 +1646,9 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"dp_RecordName", "Program 9"},
                     {"Donor_Display_Name", "Test Name"},
                     {"Item_Number", null},
-                    {"Is_Recurring_Gift", false }
+                    {"Is_Recurring_Gift", false },
+                    {"Company_Name", "Company Name" },
+                    {"Show_Online", 1 }
                 }
             };
 
@@ -1554,7 +1714,9 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"dp_RecordName", "Program 1"},
                     {"Donor_Display_Name", "Test Name"},
                     {"Item_Number", null},
-                    {"Is_Recurring_Gift", false }
+                    {"Is_Recurring_Gift", false },
+                    {"Company_Name", "Company Name" },
+                    {"Show_Online", 1 }
                 },
                 new Dictionary<string, object>
                 {
@@ -1570,7 +1732,9 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"dp_RecordName", "Program 2"},
                     {"Donor_Display_Name", "Test Name"},
                     {"Item_Number", null},
-                    {"Is_Recurring_Gift", false }
+                    {"Is_Recurring_Gift", false },
+                    {"Company_Name", "Company Name" },
+                    {"Show_Online", 1 }
                 },
                 new Dictionary<string, object>
                 {
@@ -1585,7 +1749,9 @@ namespace MinistryPlatform.Translation.Test.Services
                     {"Amount", 9000.00M},
                     {"dp_RecordName", "Program 9"},
                     {"Donor_Display_Name", "Test Name"},
-                    {"Item_Number", null}
+                    {"Is_Recurring_Gift", false },
+                    {"Company_Name", "Company Name" },
+                    {"Show_Online", 1 }
                 }
             };
 

--- a/Gateway/MinistryPlatform.Translation/Models/MpDonation.cs
+++ b/Gateway/MinistryPlatform.Translation/Models/MpDonation.cs
@@ -21,6 +21,8 @@ namespace MinistryPlatform.Translation.Models
         public bool IncludeOnGivingHistory { get; set; }
         public bool IncludeOnPrintedStatement { get; set; }
         public bool recurringGift { get; set; }
+        public string AccountingCompanyName {get; set; }
+        public bool AccountingCompanyIncludeOnPrintedStatement { get; set; }
 
         #region Distributions property
         private readonly List<MpDonationDistribution> _distributions = new List<MpDonationDistribution>();

--- a/Gateway/MinistryPlatform.Translation/Repositories/DonorRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/DonorRepository.cs
@@ -790,7 +790,7 @@ namespace MinistryPlatform.Translation.Repositories
             {
                 return donationMap[donationId];
             }
-            
+
             var donation = new MpDonation
             {
                 donationDate = record["Donation_Date"] as DateTime? ?? DateTime.Now,
@@ -805,12 +805,14 @@ namespace MinistryPlatform.Translation.Repositories
                 softCreditDonorId = record["Soft_Credit_Donor_ID"] as int? ?? 0,
                 donorDisplayName = record["Donor_Display_Name"] as string,
                 itemNumber = record["Item_Number"] as string,
-                recurringGift = record["Is_Recurring_Gift"] as bool? ?? false
+                recurringGift = record["Is_Recurring_Gift"] as bool? ?? false,
+                AccountingCompanyName = record["Company_Name"] as string,
+                AccountingCompanyIncludeOnPrintedStatement = (record["Show_Online"] as int? ?? 0) > 0
             };
 
             var status = statuses.Find(x => x.Id == donation.donationStatus) ?? new MpDonationStatus();
             donation.IncludeOnGivingHistory = status.DisplayOnGivingHistory;
-            donation.IncludeOnPrintedStatement = status.DisplayOnStatement;
+            donation.IncludeOnPrintedStatement = status.DisplayOnStatement && donation.AccountingCompanyIncludeOnPrintedStatement;
 
             return donation;
         }

--- a/Gateway/MinistryPlatform.Translation/Repositories/DonorRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/DonorRepository.cs
@@ -807,7 +807,7 @@ namespace MinistryPlatform.Translation.Repositories
                 itemNumber = record["Item_Number"] as string,
                 recurringGift = record["Is_Recurring_Gift"] as bool? ?? false,
                 AccountingCompanyName = record["Company_Name"] as string,
-                AccountingCompanyIncludeOnPrintedStatement = (record["Show_Online"] as int? ?? 0) > 0
+                AccountingCompanyIncludeOnPrintedStatement = record["Show_Online"] as bool? ?? false
             };
 
             var status = statuses.Find(x => x.Id == donation.donationStatus) ?? new MpDonationStatus();

--- a/Gateway/crds-angular/App_Start/AutoMapperConfig.cs
+++ b/Gateway/crds-angular/App_Start/AutoMapperConfig.cs
@@ -138,6 +138,8 @@ namespace crds_angular.App_Start
                 .ForMember(dest => dest.Distributions, opts => opts.MapFrom(src => src.Distributions))
                 .ForMember(dest => dest.IncludeOnGivingHistory, opts => opts.MapFrom(src => src.IncludeOnGivingHistory))
                 .ForMember(dest => dest.IncludeOnPrintedStatement, opts => opts.MapFrom(src => src.IncludeOnPrintedStatement))
+                .ForMember(dest => dest.AccountingCompanyName, opts => opts.MapFrom(src => src.AccountingCompanyName))
+                .ForMember(dest => dest.AccountingCompanyIncludeOnPrintedStatement, opts => opts.MapFrom(src => src.AccountingCompanyIncludeOnPrintedStatement))
                 .AfterMap((src, dest) =>
                 {
                     dest.Source = new DonationSourceDTO

--- a/Gateway/crds-angular/Models/Crossroads/Stewardship/DonationDTO .cs
+++ b/Gateway/crds-angular/Models/Crossroads/Stewardship/DonationDTO .cs
@@ -38,6 +38,12 @@ namespace crds_angular.Models.Crossroads.Stewardship
         [JsonProperty("payment_id")]
         public int PaymentId { get; set; }
 
+        [JsonProperty("accounting_company_name")]
+        public string AccountingCompanyName { get; set; }
+
+        [JsonProperty("accounting_company_include_on_printed_statement")]
+        public bool AccountingCompanyIncludeOnPrintedStatement { get; set; }
+
         [JsonProperty(PropertyName = "source", NullValueHandling = NullValueHandling.Ignore)]
         public DonationSourceDTO Source { get; set; }
 

--- a/crossroads.net/app/giving_history/templates/donation_list.html
+++ b/crossroads.net/app/giving_history/templates/donation_list.html
@@ -8,12 +8,13 @@
   <tbody>
     <tr ng-repeat-start="donation in donations track by $index"></tr>
     <tr ng-repeat-start="distribution in donation.distributions track by $index"></tr>
-    <tr ng-repeat-end ng-class="{'hidden-print' : donation.status == 'Pending'}">
+    <tr ng-repeat-end ng-class="{'hidden-print' : donation.status == 'Pending' || !donation.accounting_company_include_on_printed_statement}">
       <td>
         {{distribution.program_name}}
         <span ng-if="donation.status == 'Pending'" class="label label-default" tooltip-placement="right" tooltip="This payment is still in the process of being cleared by our accounting team.">Pending</span>
         <span ng-if="donation.status == 'Declined'" class="label label-danger" tooltip-placement="right" tooltip="This payment has been declined.">Declined</span>
         <span ng-if="donation.status == 'Refunded'" class="label label-info" tooltip-placement="right" tooltip="This is a refund that has been issued to you.">Refund</span>
+        <span ng-if="!donation.accounting_company_include_on_printed_statement" class="label label-secondary" tooltip-placement="right" tooltip="This is a gift made to {{donation.accounting_company_name}}, not to be included in tax statements from Crossroads.">{{donation.accounting_company_name}}</span>
         <div class="text-muted">
             <small>
               <span ng-show="donation.source.icon">

--- a/crossroads.net/app/giving_history/templates/donation_list.html
+++ b/crossroads.net/app/giving_history/templates/donation_list.html
@@ -14,7 +14,7 @@
         <span ng-if="donation.status == 'Pending'" class="label label-default" tooltip-placement="right" tooltip="This payment is still in the process of being cleared by our accounting team.">Pending</span>
         <span ng-if="donation.status == 'Declined'" class="label label-danger" tooltip-placement="right" tooltip="This payment has been declined.">Declined</span>
         <span ng-if="donation.status == 'Refunded'" class="label label-info" tooltip-placement="right" tooltip="This is a refund that has been issued to you.">Refund</span>
-        <span ng-if="!donation.accounting_company_include_on_printed_statement" class="label label-secondary" tooltip-placement="right" tooltip="This is a gift made to {{donation.accounting_company_name}}, not to be included in tax statements from Crossroads.">{{donation.accounting_company_name}}</span>
+        <span ng-if="!donation.accounting_company_include_on_printed_statement" class="label label-secondary" tooltip-placement="right" tooltip="{{$root.MESSAGES.givingHistoryGiftNotOnPrintedStatement.content | htmlToPlainText}}">{{donation.accounting_company_name}}</span>
         <div class="text-muted">
             <small>
               <span ng-show="donation.source.icon">


### PR DESCRIPTION
* [US5870 - Handle Accounting Company on Giving History](https://rally1.rallydev.com/#/38108142417d/detail/userstory/78184047960)
* Also review [PR 202](https://github.com/crdschurch/SS-CMS/pull/202) on SS-CMS
* Gifts to Accounting_Company with Show_Online set to false will...
  * Have a badge next to them, indicating the name of the Accounting_Company
  * Have a tooltip on the badge, indicating that they will not be included on printed statements

![image](https://cloud.githubusercontent.com/assets/11178122/20944713/82eb5a66-bbd2-11e6-9e84-f8c92c0f9d92.png)
