### PR TITLE
Defect/de2431 vertical movement with dont miss cards

### DIFF
--- a/crossroads.net/styles/pages/streaming.scss
+++ b/crossroads.net/styles/pages/streaming.scss
@@ -1076,11 +1076,8 @@ streaming, landing {
         .crds-carousel {
           &__controls {
             float: right;
+            margin-right: 20px;
             margin-top: 1.5em;
-
-            @media (min-width: $screen-md) {
-              margin-right: 20px;
-            }
           }
 
           &__control {
@@ -1459,6 +1456,7 @@ geolocation {
   footer {
     .btn-standard {
       background: rgba(77,77,77,0.75);
+      border: none;
       color: #FFF;
       font-size: 16px;
       padding: 8px 14px;

--- a/crossroads.net/styles/pages/streaming.scss
+++ b/crossroads.net/styles/pages/streaming.scss
@@ -1063,12 +1063,14 @@ streaming, landing {
           margin-bottom: 2em;
           margin-top: 1em;
           overflow-x: scroll;
+          overflow-y: hidden;
           position: relative;
           white-space: nowrap;
           width: 100%;
           &::-webkit-scrollbar {
             display: none;
           }
+          overflow: -moz-scrollbars-none;
         }
 
         .crds-carousel {


### PR DESCRIPTION
> I'm able to move the don't miss cards vertically (just a few pixels). In Firefox, I also see scroll bars around that section's content.

*** **BONUS FIX: Removed an ugly button border on the geolocation section and fixed the right margin on the horizontal slider controls** ***