### PR TITLE
DE2440 Missing CMS Message

### DIFF
--- a/crossroads.net/app/camps/camps_family/camps_family.controller.js
+++ b/crossroads.net/app/camps/camps_family/camps_family.controller.js
@@ -8,7 +8,9 @@ class CampsFamilyController {
 
   $onInit() {
     this.log.debug('Camps Family Controller Initialized!');
-    this.cmsMessage = this.rootScope.MESSAGES[`camps_intro_${this.state.toParams.campId}`].content || this.rootScope.MESSAGES.summercampIntro.content;
+    this.cmsMessage = (this.rootScope.MESSAGES[`campIntro_${this.state.toParams.campId}`]) ?
+      this.rootScope.MESSAGES[`campIntro_${this.state.toParams.campId}`].content :
+      this.rootScope.MESSAGES.summercampIntro.content;
   }
 }
 

--- a/crossroads.net/spec/camps/camper_info/camper_info.component.spec.js
+++ b/crossroads.net/spec/camps/camper_info/camper_info.component.spec.js
@@ -1,26 +1,20 @@
-import constants from 'crds-constants';
-
-/* jshint unused: false */
 import campsModule from '../../../app/camps/camps.module';
 
 describe('Camper Info Component', () => {
-  let $componentController,
-      $httpBackend,
-      camperInfo,
-      camperInfoForm,
-      q,
-      stateParams,
-      rootScope,
-      state;
+  let $componentController;
+  let camperInfo;
+  let camperInfoForm;
+  let q;
+  let stateParams;
+  let rootScope;
+  let state;
 
-  const endpoint = window.__env__['CRDS_API_ENDPOINT'] + 'api';
   const eventId = 12323;
 
-  beforeEach(angular.mock.module(constants.MODULES.CAMPS));
+  beforeEach(angular.mock.module(campsModule));
 
   beforeEach(inject((_$state_, _$componentController_, _$httpBackend_, _CamperInfoForm_, _$q_, _$stateParams_, _$rootScope_) => {
     $componentController = _$componentController_;
-    $httpBackend = _$httpBackend_;
     state = _$state_;
     q = _$q_;
     stateParams = _$stateParams_;
@@ -67,8 +61,7 @@ describe('Camper Info Component', () => {
   it('should successfully save the form', () => {
     camperInfo.infoForm = { $valid: true };
 
-    spyOn(camperInfoForm, 'save').and.callFake((data) => {
-      console.log('called faked with', data);
+    spyOn(camperInfoForm, 'save').and.callFake(() => {
       const deferred = q.defer();
       deferred.resolve('success!');
       return deferred.promise;
@@ -85,8 +78,7 @@ describe('Camper Info Component', () => {
     // allow for the submit fuctionality to called
     camperInfo.infoForm = { $valid: true };
 
-    spyOn(camperInfoForm, 'save').and.callFake((data) => {
-      console.log('called faked with', data);
+    spyOn(camperInfoForm, 'save').and.callFake(() => {
       const deferred = q.defer();
       deferred.resolve('success!');
       return deferred.promise;

--- a/crossroads.net/spec/camps/camps_family/camps_family.component.spec.js
+++ b/crossroads.net/spec/camps/camps_family/camps_family.component.spec.js
@@ -27,7 +27,7 @@ describe('Camps Family Select Tool', () => {
     spyOn(log, 'debug').and.callThrough();
 
     rootScope.MESSAGES = {
-      camps_intro_123: { content: 'success' },
+      campIntro_123: { content: 'success' },
       summercampIntro: {
         content: 'summer camp intro text'
       }
@@ -35,10 +35,26 @@ describe('Camps Family Select Tool', () => {
 
     const bindings = { };
     familySelectController = $componentController('campsFamily', null, bindings);
-    familySelectController.$onInit();
   }));
 
   it('should initialize the component', () => {
+    familySelectController.$onInit();
     expect(log.debug).toHaveBeenCalled();
+  });
+
+  it('should get the default cms block if no specific cms block exists', () => {
+    state.toParams = {
+      campId: 12
+    };
+    familySelectController.$onInit();
+    expect(familySelectController.cmsMessage).toBe('summer camp intro text');
+  });
+
+  it('should get the camp specific content block', () => {
+    state.toParams = {
+      campId: 123
+    };
+    familySelectController.$onInit();
+    expect(familySelectController.cmsMessage).toBe('success');
   });
 });


### PR DESCRIPTION
* The logic when determining whether or not to show a generic cms
message failed when the specific cms message was empty.