### PR TITLE
Defect/de2439 combined horizontal slider issues

### DIFF
--- a/crossroads.net/app/live_stream/stream/stream.html
+++ b/crossroads.net/app/live_stream/stream/stream.html
@@ -26,12 +26,12 @@
             <h2>don't miss</h2>
 
             <div class="crds-carousel__controls">
-              <a href="#prev" ng-click="stream.carouselPrev()" class="crds-carousel__control crds-carousel__control--prev">
+              <a href="" ng-click="stream.carouselPrev()" class="crds-carousel__control crds-carousel__control--prev">
                 <svg viewBox="0 0 32 32" class="icon-medium icon-arrow-left9">
                   <use xlink:href="#arrow-left9"></use>
                 </svg>
               </a>
-              <a href="#next" ng-click="stream.carouselNext()" class="crds-carousel__control crds-carousel__control--next">
+              <a href="" ng-click="stream.carouselNext()" class="crds-carousel__control crds-carousel__control--next">
                 <svg viewBox="0 0 32 32" class="icon-medium icon-arrow-right9">
                   <use xlink:href="#arrow-right9"></use>
                 </svg>

--- a/crossroads.net/styles/pages/streaming.scss
+++ b/crossroads.net/styles/pages/streaming.scss
@@ -1071,6 +1071,7 @@ streaming, landing {
             display: none;
           }
           overflow: -moz-scrollbars-none;
+          -ms-overflow-style: -ms-autohiding-scrollbar;
         }
 
         .crds-carousel {

--- a/crossroads.net/styles/pages/streaming.scss
+++ b/crossroads.net/styles/pages/streaming.scss
@@ -1090,8 +1090,7 @@ streaming, landing {
             text-align: center;
             vertical-align: middle;
 
-            &:hover,
-            &:focus {
+            &:hover {
               background: lighten(rgba(77,77,77,0.75), 10);
               border: none;
               text-decoration: none;

--- a/crossroads.net/styles/pages/streaming.scss
+++ b/crossroads.net/styles/pages/streaming.scss
@@ -1072,6 +1072,7 @@ streaming, landing {
           }
           overflow: -moz-scrollbars-none;
           -ms-overflow-style: -ms-autohiding-scrollbar;
+          -webkit-overflow-scrolling: touch;
         }
 
         .crds-carousel {


### PR DESCRIPTION
1. In most (all?) browsers, when I click the arrow buttons on the don't miss section slider, they stay selected (highlighted).  Seems like they should only "highlight" until the unclick event.
2. There's a horizontal scroll bar present on Edge (not present on any other browser)
3. When I use the horizontal slider left/right buttons in the don't miss section, #prev or #next is appended to the url.  Is this ideal behavior?
4. @bmiller - Momentum scroll not supported
5. @bmiller - Mobile experience is less than ideal