### PR TITLE
DE2503 Styles Broken

### DIFF
--- a/crossroads.net/app/live_stream/stream/stream.controller.js
+++ b/crossroads.net/app/live_stream/stream/stream.controller.js
@@ -1,5 +1,5 @@
 export default class StreamingController {
-  constructor(CMSService, StreamspotService, GeolocationService, $rootScope, $modal, $location, $timeout, $sce, $document, $interval) {
+  constructor(CMSService, StreamspotService, GeolocationService, $rootScope, $modal, $location, $timeout, $sce, $document) {
     this.cmsService = CMSService;
     this.streamspotService = StreamspotService;
     this.geolocationService = GeolocationService;
@@ -14,7 +14,6 @@ export default class StreamingController {
     this.dontMiss = [];
     this.beTheChurch = [];
     this.inlineGiving = [];
-    this.interval = $interval;
 
     this.sce = $sce;
     let debug = false;
@@ -42,29 +41,6 @@ export default class StreamingController {
         });
 
     this.openGeolocationModal();
-    this.timeout(this.afterViewInit.bind(this), 500);
-  }
-
-  afterViewInit() {
-    this.iframeInterval = this.interval(this.resizeIframe.bind(this), 100);
-  }
-
-  resizeIframe() {
-    if (this.inlineGiving.length < 1) {
-      const el = document.querySelector('.digital-program__giving iframe');
-      this.inlineGiving = iFrameResizer({
-        heightCalculationMethod: 'taggedElement',
-        minHeight: 350,
-        checkOrigin: false,
-        interval: 32
-      }, el);
-      this.interval.cancel(this.iframeInterval);
-    }
-  }
-
-  buildUrl() {
-    const params = this.queryStringParams || 'type=donation&theme=dark';
-    return this.sce.trustAsResourceUrl(`${this.baseUrl}?${params}`);
   }
 
   sortDigitalProgram(data) {


### PR DESCRIPTION
This PR removes a method reintroduced via 9b68f471b8582e1d1e6b3384c4baaa72a57d2b9d that refers to iFrameResizer – since this dependency was moved out of stream.controller a few commits ago, it was throwing an error. My best guess is that this is result of borked merge that took place yesterday. 

Let me know if you have any questions. 