### PR TITLE
DE2504 - Stream Broken on iOS9

### DIFF
--- a/crossroads.net/app/live_stream/stream/stream.controller.js
+++ b/crossroads.net/app/live_stream/stream/stream.controller.js
@@ -88,11 +88,4 @@ export default class StreamingController {
     }
   }
 
-  static getMargins(el) {
-    return {
-      marginRight: parseInt(window.getComputedStyle(el).marginRight, 0),
-      marginLeft: parseInt(window.getComputedStyle(el).marginLeft, 0)
-    };
-  }
-
 }

--- a/crossroads.net/app/live_stream/stream/stream.html
+++ b/crossroads.net/app/live_stream/stream/stream.html
@@ -13,7 +13,7 @@
       this.carouselWrapper = bind(this.carouselWrapper, this);
       this.carousel = bind(this.carousel, this);
       this.carouselElement = bind(this.carouselElement, this);
-      this.run = false;
+      this.init = false;
     }
 
     Carousel.prototype.setup = function() {
@@ -25,8 +25,9 @@
     };
 
     Carousel.prototype.getCarouselCardWidth = function() {
-      if (!this.run) {
+      if (!this.init) {
         this.setup();
+        this.init = true;
       }
       var marginRight = parseInt(window.getComputedStyle(this.carouselCard).marginRight, 0); // eslint-disable-line prefer-const
       return this.carouselCard.offsetWidth + marginRight;

--- a/crossroads.net/app/live_stream/stream/stream.html
+++ b/crossroads.net/app/live_stream/stream/stream.html
@@ -13,7 +13,7 @@
       this.carouselWrapper = bind(this.carouselWrapper, this);
       this.carousel = bind(this.carousel, this);
       this.carouselElement = bind(this.carouselElement, this);
-      this.run = false
+      this.run = false;
     }
 
     Carousel.prototype.setup = function() {
@@ -28,7 +28,7 @@
       if (!this.run) {
         this.setup();
       }
-      let marginRight = parseInt(window.getComputedStyle(this.carouselCard).marginRight, 0); // eslint-disable-line prefer-const
+      var marginRight = parseInt(window.getComputedStyle(this.carouselCard).marginRight, 0); // eslint-disable-line prefer-const
       return this.carouselCard.offsetWidth + marginRight;
     }
 
@@ -38,26 +38,28 @@
 
     Carousel.prototype.carouselNext = function() {
       /* eslint-disable prefer-const */
-      let cardWidth = this.getCarouselCardWidth();
-      let n = Math.floor(this.getCurrentScrollPosition() / cardWidth);
-      let scrollLeft = (n + 1) * cardWidth;
+      var cardWidth = this.getCarouselCardWidth();
+      var n = Math.floor(this.getCurrentScrollPosition() / cardWidth);
+      var scrollLeft = (n + 1) * cardWidth;
       /* eslint-enable prefer-const */
       this.scrollTo(scrollLeft);
     }
 
     Carousel.prototype.carouselPrev = function() {
-      let cardWidth = this.getCarouselCardWidth(); // eslint-disable-line prefer-const
-      let scrollPos = this.getCurrentScrollPosition(); // eslint-disable-line prefer-const
-      let n = 0;
+      var cardWidth = this.getCarouselCardWidth(); // eslint-disable-line prefer-const
+      var scrollPos = this.getCurrentScrollPosition(); // eslint-disable-line prefer-const
+      var n = 0;
       if (scrollPos > cardWidth) {
         n = Math.round(scrollPos / cardWidth) - 1;
       }
-      let scrollLeft = n * cardWidth; // eslint-disable-line prefer-const
+      var scrollLeft = n * cardWidth; // eslint-disable-line prefer-const
       this.scrollTo(scrollLeft);
     }
 
-    Carousel.prototype.scrollTo = function(x, duration = 250) {
-
+    Carousel.prototype.scrollTo = function(x, duration) {
+      if(duration === undefined) {
+        duration = 250;
+      }
       this.carouselElement.scrollLeftAnimated(x, duration);
     }
 


### PR DESCRIPTION
This PR refactors an inline script on /live/stream to remove ES6 references which are creating problems in iOS9. 

To be clear, the nature of this script and its location inline within the template is debatable and may need to be removed entirely. I'm going to discuss this situation with @bzmillerboy this afternoon  - considering this code has already been merged into development, I am simply fixing the bug vs. refactoring the inline script. 

Let me know if you have any questions.  