### PR TITLE
DE2535 - Left margin on embed not the same

### DIFF
--- a/crossroads.net/styles/pages/streaming.scss
+++ b/crossroads.net/styles/pages/streaming.scss
@@ -1024,6 +1024,7 @@ streaming, landing {
 
         margin-bottom: 0;
         padding-right: 0;
+        padding-left: 0;
       }
 
       iframe {


### PR DESCRIPTION
Remove left-padding from inline giving widget so padding matches.