### PR TITLE
US6152 - Revise mobile stack on stream page

### DIFF
--- a/crossroads.net/app/live_stream/stream/stream.html
+++ b/crossroads.net/app/live_stream/stream/stream.html
@@ -98,7 +98,6 @@
   <div class="digital-program-container">
     <div class="container">
       <div class="row">
-        <div class="digital-program__giving" dynamic-content="$root.MESSAGES.streamingInlineGivingEmbed.content | html"></div>
         <div class="digital-program__articles">
           <section class="digital-program__slider" ng-show="stream.dontMiss.length">
             <header class="clearfix">
@@ -125,6 +124,8 @@
             </div>
           </section>
         </div>
+
+        <div class="digital-program__giving" dynamic-content="$root.MESSAGES.streamingInlineGivingEmbed.content | html"></div>
       </div>
     </div>
 

--- a/crossroads.net/styles/pages/streaming.scss
+++ b/crossroads.net/styles/pages/streaming.scss
@@ -1015,14 +1015,10 @@ streaming, landing {
 
     .digital-program__giving {
       background-color: #171717;
-      margin-bottom: 2em;
       padding: 0;
 
       @media (min-width: $screen-md) {
         @include make-md-column(4);
-        @include make-md-column-push(8);
-
-        margin-bottom: 0;
         padding-right: 0;
         padding-left: 0;
       }
@@ -1041,10 +1037,11 @@ streaming, landing {
     }
 
     .digital-program__articles {
+      margin-bottom: 2em;
+
       @media (min-width: $screen-md) {
         @include make-md-column(8);
-        @include make-md-column-pull(4);
-
+        margin-bottom: 0;
         padding-left: 0;
       }
 


### PR DESCRIPTION
Change layout so horizontal slider loads before the inline giving widget on mobile devices.

> On the /live/stream page, need to revise the order of elements on mobile such that the horizontal slider appears above the inline giving iframe on mobile. 