### PR TITLE
DE2576 - Two give widgets on stream page

### DIFF
--- a/crossroads.net/app/live_stream/stream/stream.html
+++ b/crossroads.net/app/live_stream/stream/stream.html
@@ -93,7 +93,6 @@
   <div class="digital-program-container">
     <div class="container">
       <div class="row">
-        <div class="digital-program__giving" dynamic-content="$root.MESSAGES.streamingInlineGivingEmbed.content | html"></div>
         <div class="digital-program__articles">
           <section class="digital-program__slider" ng-show="stream.dontMiss.length">
             <header class="clearfix">


### PR DESCRIPTION
https://www.dropbox.com/s/62fwjp3a6r1znwy/live-bug.png?dl=0
Please make sure that Give Widget goes back to the right side of the "do not miss" (it was originally designed this way and currently it's on the left side).