### PR TITLE
DE2582 added logic to buildUrl function

### DIFF
--- a/crossroads.net/app/camps/application_page/camps_payment/camps_payment.controller.js
+++ b/crossroads.net/app/camps/application_page/camps_payment/camps_payment.controller.js
@@ -84,6 +84,8 @@ export default class CampPaymentController {
       url = encodeURIComponent(`${returnUrl}/${this.redirectTo}`);
     } else if (this.redirectTo) {
       url = encodeURIComponent(`${this.returnUrl}/${campId}/${this.redirectTo}/${contactId}`);
+    } else if (this.update) {
+      url = encodeURIComponent(`${this.returnUrl}/${campId}/payment-confirmation/${contactId}`);
     } else {
       url = encodeURIComponent(`${this.returnUrl}/${campId}/confirmation/${contactId}`);
     }

--- a/crossroads.net/spec/camps/application_page/camps_payment/camps_payment.component.spec.js
+++ b/crossroads.net/spec/camps/application_page/camps_payment/camps_payment.component.spec.js
@@ -68,6 +68,17 @@ describe('Camps Payment Component', () => {
 
       expect(sce.trustAsResourceUrl).toHaveBeenCalledWith(`${fixture.baseUrl}?type=payment&min_payment=${fixture.depositPrice}&invoice_id=${invoiceId}&total_cost=${fixture.totalPrice}&title=${fixture.campsService.campTitle}&url=${url}`);
     });
+
+    it('should redirect correctly to a the payment-confirmation page', () => {
+      fixture.campsService.productInfo.invoiceId = invoiceId;
+      state.toParams.redirectTo = undefined;
+      fixture.$onInit();
+      fixture.buildUrl();
+
+      const url = `https%3A%2F%2Fcrossroads.net%2Fcamps%2F${state.toParams.campId}%2Fpayment-confirmation%2F${state.toParams.contactId}`;
+
+      expect(sce.trustAsResourceUrl).toHaveBeenCalledWith(`${fixture.baseUrl}?type=payment&min_payment=${fixture.depositPrice}&invoice_id=${invoiceId}&total_cost=${fixture.totalPrice}&title=${fixture.campsService.campTitle}&url=${url}`);
+    });
   });
 
   describe('Update flag false', () => {
@@ -83,7 +94,7 @@ describe('Camps Payment Component', () => {
 
       campsService.productInfo = campHelpers().productInfo;
       campsService.sessionStorage.campDeposits = {};
-      
+
       fixture = _$componentController_('campsPayment', null, {});
     }));
 


### PR DESCRIPTION
There was logic missing from the if-else statement in the buildUrl
function that caused the redirect url to point to the confirmation page
instead of the payment confirmation page when the back button is used to
get to the payments page.

* added a test case