### PR TITLE
Change event_Type_ID to event_type

### DIFF
--- a/Gateway/MinistryPlatform.Translation.Test/Services/EventServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/EventServiceTest.cs
@@ -110,7 +110,7 @@ namespace MinistryPlatform.Translation.Test.Services
                 {
                     {"dp_RecordID", 100},
                     {"Event_Title", "event-title-100"},
-                    {"Event_Type_ID", "event-type-100"},
+                    {"Event_Type", "event-type-100"},
                     {"Event_Start_Date", new DateTime(2015, 3, 28, 8, 30, 0)},
                     {"Event_End_Date", new DateTime(2015, 3, 28, 8, 30, 0)}
                 },
@@ -118,7 +118,7 @@ namespace MinistryPlatform.Translation.Test.Services
                 {
                     {"dp_RecordID", 200},
                     {"Event_Title", "event-title-200"},
-                    {"Event_Type_ID", "event-type-200"},
+                    {"Event_Type", "event-type-200"},
                     {"Event_Start_Date", new DateTime(2015, 3, 28, 8, 30, 0)},
                     {"Event_End_Date", new DateTime(2015, 3, 28, 8, 30, 0)}
                 },
@@ -126,7 +126,7 @@ namespace MinistryPlatform.Translation.Test.Services
                 {
                     {"dp_RecordID", 300},
                     {"Event_Title", "event-title-300"},
-                    {"Event_Type_ID", "event-type-300"},
+                    {"Event_Type", "event-type-300"},
                     {"Event_Start_Date", new DateTime(2015, 3, 28, 8, 30, 0)},
                     {"Event_End_Date", new DateTime(2015, 3, 28, 8, 30, 0)}
                 }

--- a/Gateway/MinistryPlatform.Translation/Repositories/EventRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/EventRepository.cs
@@ -319,7 +319,7 @@ namespace MinistryPlatform.Translation.Repositories
             return records.Select(record => new MpEvent
             {
                 EventTitle = (string) record["Event_Title"],
-                EventType = (string) record["Event_Type_ID"],
+                EventType = (string) record["Event_Type"],
                 EventStartDate = (DateTime) record["Event_Start_Date"],
                 EventEndDate = (DateTime) record["Event_End_Date"],
                 EventId = (int) record["dp_RecordID"]


### PR DESCRIPTION
We are having an issue with our Camps Dashboard  trying to get all camp events using the `EventRepository.GetEvents(string eventType, string token)` method and it appears to have been changed to retrieve the `Event_Type_ID` [see here]( https://github.com/crdschurch/crds-angular/blob/development/Gateway/MinistryPlatform.Translation/Repositories/EventRepository.cs#L322) . The problem is that `Event_Type_ID` is NOT being returned and thus the code blows up. 