### PR TITLE
Fixed a syntax error and added a space in the group linking section

### DIFF
--- a/CI/TestSQL/02.TestData/MidgarTrip.sql
+++ b/CI/TestSQL/02.TestData/MidgarTrip.sql
@@ -27,7 +27,7 @@ INSERT INTO [dbo].groups
 
 --Group for (t) GO Midgar Participants, Go Midgar Group as parent
 declare @parentGroup as int
-set @parentGroup = (select Group_ID from Groups where Group_Name = @tripName;)
+set @parentGroup = (select Group_ID from Groups where Group_Name = @tripName);
 
 INSERT INTO [dbo].groups 
 (Group_Name                         ,Group_Type_ID,Ministry_ID,Congregation_ID,Primary_Contact,[Description],[Start_Date]                     ,End_Date,Target_Size,Parent_Group,Priority_ID,Enable_Waiting_List,Small_Group_Information,Offsite_Meeting_Address,Group_Is_Full,Available_Online,Life_Stage_ID,Group_Focus_ID,Meeting_Time,Meeting_Day_ID,Descended_From,Reason_Ended,Domain_ID,Check_in_Information,[Secure_Check-in],Suppress_Nametag,Suppress_Care_Note,On_Classroom_Manager,Promotion_Information,Promote_to_Group,Age_in_Months_to_Promote,Promote_Weekly,__ExternalGroupID,__ExternalParentGroupID,__IsPublic,__ISBlogEnabled,__ISWebEnabled,Group_Notes,Sign_Up_To_Serve,Deadline_Passed_Message_ID) VALUES
@@ -76,7 +76,7 @@ update [dbo].Pledge_Campaigns set Event_ID = (select Event_ID from Events where 
 
 --link the group to the event.
 DECLARE @subGroupID as int
-SET @subGroupID = (select GROUP_ID from groups where group_name = @tripName + '(Trip Participants)');
+SET @subGroupID = (select GROUP_ID from groups where group_name = @tripName + ' (Trip Participants)');
 
 INSERT INTO [dbo].EVENT_GROUPS
 (EVENT_ID                                                   , GROUP_ID   ,Room_ID, Domain_ID) VALUES


### PR DESCRIPTION
Fixed a syntax error (semicolon needed to go AFTER the paren) and added a space before (Trip Participants) when linking a group to the event.