### PR TITLE
DE2678: Fix impersonate link

### DIFF
--- a/crossroads.net/app/routes.js
+++ b/crossroads.net/app/routes.js
@@ -366,6 +366,18 @@
             }
           }
         })
+        .state('impersonate', {
+          parent: 'noSideBar',
+          templateUrl: 'impersonate/impersonate.html',
+          url: '/impersonate',
+          controller: 'ImpersonateController as impersonate',
+          data: {
+            isProtected: true
+          },
+          resolve: {
+            loggedin: crds_utilities.checkLoggedin
+          }
+        })
         .state('explore', {
           parent: 'noHeaderOrFooter',
           url: '/explore',


### PR DESCRIPTION
In a previous merge, app/routes.js was changes to fix the superbowl route and somehow the route for impersonate was removed. This pull request adds the route for impersonate back to app/routes.js which enables the impersonate link in the profile hamburger menu to work correctly again.