### PR TITLE
DE2488: capacity, volunteers default value to 0

### DIFF
--- a/CI/SQL/20170120101700_DE2488-default-event-room-capacity.sql
+++ b/CI/SQL/20170120101700_DE2488-default-event-room-capacity.sql
@@ -1,0 +1,9 @@
+USE [MinistryPlatform]
+GO
+
+ALTER TABLE [dbo].[Event_Rooms] ADD CONSTRAINT
+	[DF_Event_Rooms_Capacity] DEFAULT 0 FOR [Capacity];
+
+ALTER TABLE [dbo].[Event_Rooms] ADD CONSTRAINT
+	[DF_Event_Rooms_Volunteers] DEFAULT 0 FOR [Volunteers];
+  


### PR DESCRIPTION
I dont think this should cause any issues as we added the Capacity and Volunteers columns this past September