### PR TITLE
DE2737 Medical info page redirects correctly

### DIFF
--- a/crossroads.net/app/camps/application_page/camp_waivers/camp_waivers.controller.js
+++ b/crossroads.net/app/camps/application_page/camp_waivers/camp_waivers.controller.js
@@ -82,7 +82,8 @@ export default class CampWaiversController {
 
         this.state.go('campsignup.application', {
           page: 'medical-info',
-          contactId: this.$stateParams.contactId
+          contactId: this.$stateParams.contactId,
+          update: false
         });
       }, () => {
         this.rootScope.$emit('notify', this.rootScope.MESSAGES.generalError);

--- a/crossroads.net/app/camps/application_page/medical_info/medical_info.controller.js
+++ b/crossroads.net/app/camps/application_page/medical_info/medical_info.controller.js
@@ -15,7 +15,7 @@ class MedicalInfoController {
     this.model = this.medicalInfoForm.getModel();
     this.fields = this.medicalInfoForm.getFields();
     this.viewReady = true;
-    this.update = this.stateParams.update;
+    this.update = this.stateParams.update !== null && this.stateParams.update !== undefined ? this.stateParams.update : true;
   }
 
   cancel() {

--- a/crossroads.net/app/camps/camps.routes.js
+++ b/crossroads.net/app/camps/camps.routes.js
@@ -124,7 +124,7 @@ export default function CampRoutes($stateProvider) {
       url: '/:page/:contactId',
       template: '<camps-application-page></camps-application-page>',
       params: {
-        update: false,
+        update: undefined,
         redirectTo: undefined
       },
       resolve: {

--- a/crossroads.net/spec/camps/application_page/camps_medical_info/camps_medical_info.component.spec.js
+++ b/crossroads.net/spec/camps/application_page/camps_medical_info/camps_medical_info.component.spec.js
@@ -2,7 +2,7 @@ import applicationModule from '../../../../app/camps/application_page/applicatio
 import campsModule from '../../../../app/camps/camps.module';
 
 
-fdescribe('Camps Medical Info Component', () => {
+describe('Camps Medical Info Component', () => {
   let $componentController;
   let medicalInfoController;
   // let log;

--- a/crossroads.net/spec/camps/application_page/camps_medical_info/camps_medical_info.component.spec.js
+++ b/crossroads.net/spec/camps/application_page/camps_medical_info/camps_medical_info.component.spec.js
@@ -2,7 +2,7 @@ import applicationModule from '../../../../app/camps/application_page/applicatio
 import campsModule from '../../../../app/camps/camps.module';
 
 
-describe('Camps Medical Info Component', () => {
+fdescribe('Camps Medical Info Component', () => {
   let $componentController;
   let medicalInfoController;
   // let log;
@@ -33,70 +33,88 @@ describe('Camps Medical Info Component', () => {
 
     spyOn(medicalInfoForm, 'getModel').and.callThrough();
     spyOn(medicalInfoForm, 'getFields').and.callThrough();
-
-    const bindings = {};
-    medicalInfoController = $componentController('campMedicalInfo', null, bindings);
-    medicalInfoController.$onInit();
   }));
 
-  it('should set the view as ready', () => {
-    expect(medicalInfoController.viewReady).toBeTruthy();
-  });
-
-  it('should get the model', () => {
-    expect(medicalInfoForm.getModel).toHaveBeenCalled();
-    expect(medicalInfoController.model).toBeDefined();
-  });
-
-  it('should get the fields', () => {
-    expect(medicalInfoForm.getFields).toHaveBeenCalled();
-    expect(medicalInfoController.fields).toBeDefined();
-    expect(medicalInfoController.fields.length).toBeGreaterThan(0);
-  });
-
-  it('should successfully save the form', () => {
-    medicalInfoController.medicalInfo = { $valid: true };
-
-    spyOn(medicalInfoForm, 'save').and.callFake(() => {
-      const deferred = q.defer();
-      deferred.resolve('success!');
-      return deferred.promise;
+  describe('Update flag set to undefined', () => {
+    beforeEach(() => {
+      stateParams.update = undefined;
+      const bindings = {};
+      medicalInfoController = $componentController('campMedicalInfo', null, bindings);
+      medicalInfoController.$onInit();
     });
 
-    medicalInfoController.submit();
-    rootScope.$apply();
-    expect(medicalInfoForm.save).toHaveBeenCalledWith(contactId);
+    it('should set the update flag to true if it is initialized to undefined', () => {
+      expect(medicalInfoController.update).toBeTruthy();
+    });
   });
 
-  it('should reject saving the form', () => {
-    medicalInfoController.medicalInfo = { $valid: true };
-
-    spyOn(medicalInfoForm, 'save').and.callFake(() => {
-      const deferred = q.defer();
-      deferred.reject('error!');
-      return deferred.promise;
+  describe('Update flag set to true', () => {
+    beforeEach(() => {
+      stateParams.update = true;
+      const bindings = {};
+      medicalInfoController = $componentController('campMedicalInfo', null, bindings);
+      medicalInfoController.$onInit();
     });
 
-    medicalInfoController.submit();
-    rootScope.$apply();
-    expect(medicalInfoForm.save).toHaveBeenCalledWith(contactId);
-  });
-
-  it('should disable the submit button while saving', () => {
-    expect(medicalInfoController.submitting).toBe(false);
-
-    medicalInfoController.medicalInfo = { $valid: true };
-
-    spyOn(medicalInfoForm, 'save').and.callFake(() => {
-      const deferred = q.defer();
-      deferred.resolve('success!');
-      return deferred.promise;
+    it('should set the view as ready', () => {
+      expect(medicalInfoController.viewReady).toBeTruthy();
     });
 
-    medicalInfoController.submit();
-    expect(medicalInfoController.submitting).toBe(true);
+    it('should get the model', () => {
+      expect(medicalInfoForm.getModel).toHaveBeenCalled();
+      expect(medicalInfoController.model).toBeDefined();
+    });
 
-    rootScope.$apply();
-    expect(medicalInfoController.submitting).toBe(false);
+    it('should get the fields', () => {
+      expect(medicalInfoForm.getFields).toHaveBeenCalled();
+      expect(medicalInfoController.fields).toBeDefined();
+      expect(medicalInfoController.fields.length).toBeGreaterThan(0);
+    });
+
+    it('should successfully save the form', () => {
+      medicalInfoController.medicalInfo = { $valid: true };
+
+      spyOn(medicalInfoForm, 'save').and.callFake(() => {
+        const deferred = q.defer();
+        deferred.resolve('success!');
+        return deferred.promise;
+      });
+
+      medicalInfoController.submit();
+      rootScope.$apply();
+      expect(medicalInfoForm.save).toHaveBeenCalledWith(contactId);
+    });
+
+    it('should reject saving the form', () => {
+      medicalInfoController.medicalInfo = { $valid: true };
+
+      spyOn(medicalInfoForm, 'save').and.callFake(() => {
+        const deferred = q.defer();
+        deferred.reject('error!');
+        return deferred.promise;
+      });
+
+      medicalInfoController.submit();
+      rootScope.$apply();
+      expect(medicalInfoForm.save).toHaveBeenCalledWith(contactId);
+    });
+
+    it('should disable the submit button while saving', () => {
+      expect(medicalInfoController.submitting).toBe(false);
+
+      medicalInfoController.medicalInfo = { $valid: true };
+
+      spyOn(medicalInfoForm, 'save').and.callFake(() => {
+        const deferred = q.defer();
+        deferred.resolve('success!');
+        return deferred.promise;
+      });
+
+      medicalInfoController.submit();
+      expect(medicalInfoController.submitting).toBe(true);
+
+      rootScope.$apply();
+      expect(medicalInfoController.submitting).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
When in normal registration flow hitting back to go the medical info
page shouldn't disturb the workflow but hitting back when you started at
the dashboard should take you back to the dashboard.