### PR TITLE
Changed size of @tripname to varchar(24) to account for longer string

### DIFF
--- a/CI/TestSQL/02.TestData/BedrockTrip.sql
+++ b/CI/TestSQL/02.TestData/BedrockTrip.sql
@@ -7,7 +7,7 @@ GO
 DECLARE @thisyear as VARCHAR(4)
 set @thisyear = CONVERT(VARCHAR(4), datepart(year, getdate()));
 
-DECLARE @tripName AS VARCHAR(18)
+DECLARE @tripName AS VARCHAR(24)
 set @tripName = '(t+auto) GO Bedrock '+@thisyear;
 
 DECLARE @startYear as VARCHAR(19)
@@ -66,7 +66,7 @@ INSERT INTO [dbo].events
 GO
 
 --Updates
-DECLARE @tripName AS VARCHAR(18)
+DECLARE @tripName AS VARCHAR(24)
 set @tripName = '(t+auto) GO Bedrock '+CONVERT(VARCHAR(4), datepart(year, getdate()));
 
 update [dbo].Pledge_Campaigns set program_id = (select program_id from programs where program_name = @tripName) where campaign_name = @tripName;

--- a/CI/TestSQL/03.TestConfigData/GoBedrockParticipants.sql
+++ b/CI/TestSQL/03.TestConfigData/GoBedrockParticipants.sql
@@ -11,7 +11,7 @@ set @fredDonorId = (select donor_record from Contacts where Email_Address = 'mpc
 DECLARE @thisyear as VARCHAR(4)
 set @thisyear = CONVERT(VARCHAR(4), datepart(year, getdate()));
 
-DECLARE @tripName AS VARCHAR(18)
+DECLARE @tripName AS VARCHAR(24)
 set @tripName = '(t+auto) GO Bedrock '+@thisyear;
 
 DECLARE @startYear as VARCHAR(19)

--- a/CI/TestSQL_TearDown/02.Teardown_MPData/BedrockTrip.sql
+++ b/CI/TestSQL_TearDown/02.Teardown_MPData/BedrockTrip.sql
@@ -2,7 +2,7 @@ USE [MinistryPlatform]
 GO
 
 --Retrieve name of trip in case create occurred in a year prior to teardown
-DECLARE @tripName AS VARCHAR(18)
+DECLARE @tripName AS VARCHAR(24)
 set @tripName = (select event_title from events where event_title like '(t+auto) GO Bedrock%');
 
 DECLARE @pledgeCampaignId as int


### PR DESCRIPTION
Items were failing to be created properly because the sizing of the variable was truncating the data.