### PR TITLE
remove `[]` from cms urls

### DIFF
--- a/crossroads.net/core/services/CMS.service.js
+++ b/crossroads.net/core/services/CMS.service.js
@@ -42,13 +42,13 @@
     }
 
     vm.getNearestSeries = function() {
-      let nearestSeriesAPIAddress = `${this.url}/series?startDate__GreaterThanOrEqual=${vm.todaysDate}&startDate__sort=ASC&__limit[]=1`
+      let nearestSeriesAPIAddress = `${this.url}/series?startDate__GreaterThanOrEqual=${vm.todaysDate}&startDate__sort=ASC&__limit=1`
       return vm.http.get(nearestSeriesAPIAddress)
               .then(rsp => { return _.first(rsp.data.series) });
     }
 
     vm.getLastSeries = function() {
-      let nearestSeriesAPIAddress = `${this.url}/series?endDate__LessThanOrEqual=${vm.todaysDate}&endDate__sort=DESC&__limit[]=1`
+      let nearestSeriesAPIAddress = `${this.url}/series?endDate__LessThanOrEqual=${vm.todaysDate}&endDate__sort=DESC&__limit=1`
       return vm.http.get(nearestSeriesAPIAddress)
               .then(rsp => { return _.first(rsp.data.series) });
     }
@@ -59,7 +59,7 @@
     }
 
     vm.getRecentMessages = function(limit) {
-      return vm.http.get(`${this.url}/messages?date__LessThanOrEqual=${vm.todaysDate}&date__sort=DESC&ID__sort=DESC&SeriesID__GreaterThan=0&__limit[]=${limit}`)
+      return vm.http.get(`${this.url}/messages?date__LessThanOrEqual=${vm.todaysDate}&date__sort=DESC&ID__sort=DESC&SeriesID__GreaterThan=0&__limit=${limit}`)
                       .then(rsp => {return rsp.data.messages.slice(0,limit)});
     }
 

--- a/crossroads.net/core/services/CMSData.service.ts
+++ b/crossroads.net/core/services/CMSData.service.ts
@@ -46,14 +46,14 @@ export class CMSDataService {
     
     public getNearestSeries() {
         let todaysDate = new Date().toISOString().slice(0, 10);
-        let nearestSeriesAPIAddress = `api/series?startDate__GreaterThanOrEqual=${todaysDate}&startDate__sort=ASC&__limit[]=1`
+        let nearestSeriesAPIAddress = `api/series?startDate__GreaterThanOrEqual=${todaysDate}&startDate__sort=ASC&__limit=1`
         return this.http.get(encodeURI(__CMS_ENDPOINT__ + nearestSeriesAPIAddress))
                         .map(rsp => {return rsp.json().series[0]})
     }
     
     public getLastSeries() {
         let todaysDate = new Date().toISOString().slice(0, 10);
-        let nearestSeriesAPIAddress = `api/series?endDate__LessThanOrEqual=${todaysDate}&endDate__sort=DESC&__limit[]=1`
+        let nearestSeriesAPIAddress = `api/series?endDate__LessThanOrEqual=${todaysDate}&endDate__sort=DESC&__limit=2`
         return this.http.get(encodeURI(__CMS_ENDPOINT__ + nearestSeriesAPIAddress))
                         .map(rsp => {
                             return rsp.json().series[0]
@@ -63,7 +63,7 @@ export class CMSDataService {
     
     getXMostRecentMessages(limit:number) {
         let todaysDate = new Date().toISOString().slice(0, 10);
-        return this.http.get(encodeURI(__CMS_ENDPOINT__ + `api/messages?date__LessThanOrEqual=${todaysDate}&date__sort=DESC&ID__sort=DESC&SeriesID__GreaterThan=0&__limit[]=${limit}`))
+        return this.http.get(encodeURI(__CMS_ENDPOINT__ + `api/messages?date__LessThanOrEqual=${todaysDate}&date__sort=DESC&ID__sort=DESC&SeriesID__GreaterThan=0&__limit=${limit}`))
                         .map(rsp => {return rsp.json().messages.slice(0,limit)});
     }
     

--- a/crossroads.net/spec-es6/core/CMS.service.spec.js
+++ b/crossroads.net/spec-es6/core/CMS.service.spec.js
@@ -119,7 +119,7 @@ describe('CMSService', () => {
       fixture.getNearestSeries().then(response => {
         expect(response.title).toBe('Series A')
       });
-      httpBackend.expectGET(`${endpoint}/series?startDate__GreaterThanOrEqual=${todaysDate}&startDate__sort=ASC&__limit[]=1`).respond(200, series);
+      httpBackend.expectGET(`${endpoint}/series?startDate__GreaterThanOrEqual=${todaysDate}&startDate__sort=ASC&__limit=1`).respond(200, series);
       httpBackend.flush();
     });
     
@@ -127,7 +127,7 @@ describe('CMSService', () => {
       let lastSeries = {"series":[{"id":318,"title":"Series A","description":"<p><span>asdf2</span></p>","startDate":"2016-08-30","endDate":"2016-08-31","trailerLink":null,"version":"5","messages":[{"id":3879,"title":"test1","description":"<p>test1</p>","date":"2016-09-14","version":"1","series":318,"tags":[{"id":33,"title":"all","series":[194,205,5],"messages":[3579,3578,3588,3640,3879],"created":"2015-09-23T11:52:06-04:00","className":"Tag"}],"created":"2016-09-14T17:03:48-04:00","className":"Message"},{"id":3881,"title":"test2","description":"<p>test2</p>","date":"2016-09-14","version":"1","series":318,"created":"2016-09-14T17:08:34-04:00","className":"Message"},{"id":3882,"title":"test3","description":"<p>test3</p>","date":"2016-12-14","version":"1","series":318,"created":"2016-09-14T17:22:50-04:00","className":"Message"}],"created":"2016-08-30T11:35:43-04:00","className":"Series"}]}
       let fixture = new CMSService(http);
       fixture.getLastSeries();
-      httpBackend.expectGET(`${endpoint}/series?endDate__LessThanOrEqual=${todaysDate}&endDate__sort=DESC&__limit[]=1`).respond(200, lastSeries);
+      httpBackend.expectGET(`${endpoint}/series?endDate__LessThanOrEqual=${todaysDate}&endDate__sort=DESC&__limit=1`).respond(200, lastSeries);
       httpBackend.flush();
     });
 
@@ -186,7 +186,7 @@ describe('CMSService', () => {
       fixture.getRecentMessages(limit).then(response => {
         expect(response.length).toBe(limit);
       });
-      httpBackend.expectGET(`${endpoint}/messages?date__LessThanOrEqual=${todaysDate}&date__sort=DESC&ID__sort=DESC&SeriesID__GreaterThan=0&__limit[]=${limit}`).respond(200, messages);
+      httpBackend.expectGET(`${endpoint}/messages?date__LessThanOrEqual=${todaysDate}&date__sort=DESC&ID__sort=DESC&SeriesID__GreaterThan=0&__limit=${limit}`).respond(200, messages);
       httpBackend.flush();
     })
   })


### PR DESCRIPTION
elixir was barfing when trying to parse urls with `[]` in them. the
easiest solution was to remove them, as they didn't seem to matter.

if they really do matter, then we can find a way to deal with them, but
I don't think they are a standard.