### PR TITLE
DE2795 Reduced records returned

### DIFF
--- a/CI/SQL/20170119_124900_US6243-create-duplicate-phone-sp.sql
+++ b/CI/SQL/20170119_124900_US6243-create-duplicate-phone-sp.sql
@@ -55,7 +55,7 @@ BEGIN
 				AND c2.Household_Position_ID = @Minor_Child
 		);
 
-	SELECT TOP 1000 main.Household_ID
+	SELECT TOP 500 main.Household_ID
 		, main.Household_Name
 		, main.Contact_ID
 		, main.Display_Name


### PR DESCRIPTION
If the report takes too long it will time out without saying so. Reduced
records returned in order to make the report run faster.