### PR TITLE
session_service redirectIfNeeded logic in new event loop

### DIFF
--- a/crossroads.net/core/services/session_service.js
+++ b/crossroads.net/core/services/session_service.js
@@ -140,7 +140,7 @@
     // TODO: Get this working to DRY up login_controller and register_controller
     vm.redirectIfNeeded = ($injectedState) => {
       $timeout(() => {
-        // timeout ensures processing occurs on next 'loop'
+        // timeout ensures processing occurs on next cycle
         if (vm.hasRedirectionInfo()) {
           const url = vm.exists('redirectUrl');
           const params = vm.exists('params');

--- a/crossroads.net/core/services/session_service.js
+++ b/crossroads.net/core/services/session_service.js
@@ -139,16 +139,19 @@
 
     // TODO: Get this working to DRY up login_controller and register_controller
     vm.redirectIfNeeded = ($injectedState) => {
-      if (vm.hasRedirectionInfo()) {
-        const url = vm.exists('redirectUrl');
-        const params = vm.exists('params');
-        vm.removeRedirectRoute();
-        if (params === undefined) {
-          $injectedState.go(url);
-        } else {
-          $injectedState.go(url, JSON.parse(params));
+      $timeout(function() {
+        // timeout ensures processing occurs on next 'loop'
+        if (vm.hasRedirectionInfo()) {
+          const url = vm.exists('redirectUrl');
+          const params = vm.exists('params');
+          vm.removeRedirectRoute();
+          if (params === undefined) {
+            $injectedState.go(url);
+          } else {
+            $injectedState.go(url, JSON.parse(params));
+          }
         }
-      }
+      });
     };
 
     vm.addRedirectRoute = (redirectUrl, params) => {

--- a/crossroads.net/core/services/session_service.js
+++ b/crossroads.net/core/services/session_service.js
@@ -139,7 +139,7 @@
 
     // TODO: Get this working to DRY up login_controller and register_controller
     vm.redirectIfNeeded = ($injectedState) => {
-      $timeout(function() {
+      $timeout(() => {
         // timeout ensures processing occurs on next 'loop'
         if (vm.hasRedirectionInfo()) {
           const url = vm.exists('redirectUrl');

--- a/crossroads.net/spec-core/services/session.service.spec.js
+++ b/crossroads.net/spec-core/services/session.service.spec.js
@@ -10,10 +10,11 @@ describe('Session Service', function() {
   var state;
   var cookieNames = require('crds-constants').COOKIES;
   var family = [0, 1, 2, 3, 4];
+  var timeout;
 
   beforeEach(angular.mock.module('crossroads.core'));
 
-  beforeEach(inject(function($injector, _$cookies_, _$rootScope_, _Session_, _$modal_) {
+  beforeEach(inject(function($injector, _$cookies_, _$rootScope_, _Session_, _$modal_, _$timeout_) {
     $cookies = _$cookies_;
     state = $injector.get('$state');
     spyOn(state, 'go');
@@ -22,6 +23,7 @@ describe('Session Service', function() {
     Injector = $injector;
     rootScope = _$rootScope_;
     modal = _$modal_;
+    timeout = _$timeout_;
   }));
 
   afterEach(function() {
@@ -189,5 +191,49 @@ describe('Session Service', function() {
     });
   });
 
+  describe('function redirectIfNeeded', function() {
+
+    it('should redirect to url', function() {
+        var existsMock = spyOn(Session,'exists');
+        existsMock.and.callFake(function(args){
+          switch(args)
+          {
+            case 'redirectUrl':
+              return 'content';
+            case 'params':
+              return null;
+            default:
+              return null;
+          }
+        });
+        Session.redirectIfNeeded(state);
+        timeout.flush();
+        expect(state.go).toHaveBeenCalledWith('content', null);
+    });
+
+    it('should redirect to url with params', function() {
+        var existsMock = spyOn(Session,'exists');
+        existsMock.and.callFake(function(args){
+          switch(args)
+          {
+            case 'redirectUrl':
+              return 'content';
+            case 'params':
+              return JSON.stringify({'link':'/'});
+            default:
+              return null;
+          }
+        });
+        Session.redirectIfNeeded(state);
+        timeout.flush();
+        expect(state.go).toHaveBeenCalledWith('content', { link: '/' });    
+    });
+
+    it('should not redirect', function() {
+        Session.redirectIfNeeded(state);
+        expect(state.go).toHaveBeenCalledTimes(0);
+    });
+
+  })
 
 });


### PR DESCRIPTION
Corrects timing/eventing issue in session_service where "redirectIfNeeded" not working correctly from mobile device or desktop going directly to "/signout."