### PR TITLE
DE2802 change page to be from the users table

### DIFF
--- a/CI/SQL/20170224-074700_DE2802-UpdatePageEmailsPage.sql
+++ b/CI/SQL/20170224-074700_DE2802-UpdatePageEmailsPage.sql
@@ -2,7 +2,14 @@ USE [MinistryPlatform]
 GO
 
 UPDATE [dbo].[dp_Pages]
-SET [Description] = 'The master list of active USER email addresses that are, or have been, involved in some way with your crossroads.'
-   ,[Default_Field_List] = 'Contacts.Display_Name, Contacts.Contact_ID, User_Account_Table.User_Email, User_Account_Table.User_ID'
+SET [Table_Name] = 'dp_Users'
+   ,[Description] = 'The master list of active User email addresses that are, or have been, involved in some way with your crossroads account.' 
+  ,[Default_Field_List] = 'dp_Users.User_Name, dp_Users.User_Email, dp_Users.User_ID'
+  ,[Selected_Record_Expression] = 'User_Name'
+  ,[Filter_Clause] = 'dp_Users.User_ID > 0'
+  ,[Contact_ID_Field] = '' 
+  ,[System_Name] = ''
+  ,[Custom_Form_Name] = ''
+  ,[Display_Copy] = 0
 WHERE [Page_ID] = 481;
 GO


### PR DESCRIPTION
Selected record expression was causing the result to be filtered be Contacts.Email_Address when processing via the code, which led to processing problems.  Because we really want to check that the user is not already in the system, checking against the Users table is more accurate.