### PR TITLE
US7077 - GO Local anywhere profile confirmation

### DIFF
--- a/crossroads.net/app/go_volunteer/goVolunteer.routes.js
+++ b/crossroads.net/app/go_volunteer/goVolunteer.routes.js
@@ -122,6 +122,29 @@ export default function GoVolunteerRoutes($stateProvider, $urlMatcherFactoryProv
         GetProject
       }
     })
+    .state('go-local.anywhereconfirm', {
+      parent: 'goCincinnati',
+      url: '/go-local/:initiativeId/crossroads/:city/:projectId/confirm',
+      template: '<go-volunteer-anywhere-profile-confirm></go-volunteer-anywhere-profile-confirm>',
+      params: {
+        page: 'anywhere-profile-confirm'
+      },
+      data: {
+        meta: {
+          title: 'GO Local',
+          description: ''
+        },
+        isProtected: true
+      },
+      resolve: {
+        $state: '$state',
+        $q: '$q',
+        loggedin: crds_utilities.optimisticallyCheckLoggedin,
+        GoVolunteerDataService: 'GoVolunteerDataService',
+        GoVolunteerService: 'GoVolunteerService',
+        GetProject
+      }
+    })
     .state('go-local.signinpage', {
       parent: 'goCincinnati',
       url: '/go-local/:initiative/crossroads/signin',

--- a/crossroads.net/app/go_volunteer/page/anywhereProfileConfirm/goVolunteerAnywhereProfileConfirm.component.js
+++ b/crossroads.net/app/go_volunteer/page/anywhereProfileConfirm/goVolunteerAnywhereProfileConfirm.component.js
@@ -1,0 +1,11 @@
+import controller from './goVolunteerAnywhereProfileConfirm.controller';
+import template from './goVolunteerAnywhereProfileConfirm.html';
+
+export default function goVolunteerAnywhereProfileConfirmComponent() {
+  const component = {
+    template,
+    controller
+  };
+
+  return component;
+}

--- a/crossroads.net/app/go_volunteer/page/anywhereProfileConfirm/goVolunteerAnywhereProfileConfirm.controller.js
+++ b/crossroads.net/app/go_volunteer/page/anywhereProfileConfirm/goVolunteerAnywhereProfileConfirm.controller.js
@@ -1,0 +1,12 @@
+export default class GoVolunteerAnywhereProfileConfirmController {
+  /* @ngInject */
+  constructor( GoVolunteerService) {
+    this.viewReady = false;
+    this.goVolunteerService = GoVolunteerService;
+    this.project = GoVolunteerService.project;
+  }
+
+  $onInit() {
+    this.viewReady = true;
+  }
+}

--- a/crossroads.net/app/go_volunteer/page/anywhereProfileConfirm/goVolunteerAnywhereProfileConfirm.html
+++ b/crossroads.net/app/go_volunteer/page/anywhereProfileConfirm/goVolunteerAnywhereProfileConfirm.html
@@ -1,0 +1,10 @@
+<div ng-if="$ctrl.viewReady">
+  <preloader full-screen='false' ng-show='!$ctrl.viewReady'> </preloader>
+
+  <go-volunteer-project-card project="$ctrl.project"></go-volunteer-project-card>
+
+  <h1>Way to go!</h1>
+  <p>You have successfully registered to volunteer for GO Local.</p>
+  <p>Your project leader will be contacting you with more information.</p>
+  <p>Contact your leader at <a href="mailto:{{$ctrl.project.email}}">{{$ctrl.project.email}}</a> with any immediate questions.</p>
+</div>

--- a/crossroads.net/app/go_volunteer/page/anywhereProfileConfirm/goVolunteerAnywhereProfileConfirm.html
+++ b/crossroads.net/app/go_volunteer/page/anywhereProfileConfirm/goVolunteerAnywhereProfileConfirm.html
@@ -3,8 +3,7 @@
 
   <go-volunteer-project-card project="$ctrl.project"></go-volunteer-project-card>
 
-  <h1>Way to go!</h1>
-  <p>You have successfully registered to volunteer for GO Local.</p>
-  <p>Your project leader will be contacting you with more information.</p>
+  <div dynamic-content="$root.MESSAGES.goVolunteerAnywhereProfileConfirm.content | html"></div>
+
   <p>Contact your leader at <a href="mailto:{{$ctrl.project.email}}">{{$ctrl.project.email}}</a> with any immediate questions.</p>
 </div>

--- a/crossroads.net/app/go_volunteer/page/anywhereProfileConfirm/index.js
+++ b/crossroads.net/app/go_volunteer/page/anywhereProfileConfirm/index.js
@@ -1,0 +1,7 @@
+import CONSTANTS from 'crds-constants';
+
+import goVolunteerAnywhereProfileConfirmComponent from './goVolunteerAnywhereProfileConfirm.component';
+
+angular.module(CONSTANTS.MODULES.GO_VOLUNTEER)
+  .component('goVolunteerAnywhereProfileConfirm', goVolunteerAnywhereProfileConfirmComponent())
+;

--- a/crossroads.net/app/go_volunteer/page/index.js
+++ b/crossroads.net/app/go_volunteer/page/index.js
@@ -29,4 +29,5 @@
   require('./waiver');
   require('./thankYou');
   require('./anywhereProfile');
+  require('./anywhereProfileConfirm');
 })();

--- a/crossroads.net/app/go_volunteer/projectCard/goVolunteerProjectCard.html
+++ b/crossroads.net/app/go_volunteer/projectCard/goVolunteerProjectCard.html
@@ -2,7 +2,7 @@
   <div class='col-sm-3 col-xs-4 card-img card-dark mobile-hard-left col-xs-height'>
 
     <profile-picture contact-id="card.project.contactId"
-                     wrapper-class="card-img-wrapper"
+                     wrapper-class="card-img-wrapper soft-half"
                      image-class="card-img-show embed-responsive-item"
                      disallow-change="false">
     </profile-picture>

--- a/crossroads.net/styles/pages/go-volunteer.scss
+++ b/crossroads.net/styles/pages/go-volunteer.scss
@@ -148,6 +148,10 @@ $gc-red-darker: #44080a;
     transform: translate(-50%, -50%);
     border-radius: 4px;
   }
+
+  .card-dark {
+    background: none;
+  }
 }
 
 .site-image-filter {


### PR DESCRIPTION
Associated CMS pull request:  https://github.com/crdschurch/SS-CMS/pull/257

URL:  /go-local/3/crossroads/Cleveland/564/confirm

* Creates component and route
* Use content block for informative text
* Display project card and project leader's email address

![image](https://cloud.githubusercontent.com/assets/2341619/23492853/3d946ebc-fed5-11e6-8d16-226abb4907c4.png)
