### PR TITLE
DE2902: Group signup fails due to error parsing CMS content

### DIFF
--- a/Gateway/Crossroads.Utilities/Interfaces/IContentBlockService.cs
+++ b/Gateway/Crossroads.Utilities/Interfaces/IContentBlockService.cs
@@ -5,5 +5,6 @@ namespace Crossroads.Utilities.Interfaces
 {
     public interface IContentBlockService : IDictionary<string, ContentBlock>
     {
+        string GetContent(string key);
     }
 }

--- a/Gateway/Crossroads.Utilities/Models/ContentBlock.cs
+++ b/Gateway/Crossroads.Utilities/Models/ContentBlock.cs
@@ -15,8 +15,8 @@ namespace Crossroads.Utilities.Models
         public string Content { get; set; }
         [JsonProperty("type"), JsonConverter(typeof(StringEnumConverter))]
         public ContentBlockType Type { get; set; }
-        [JsonProperty("category"), JsonConverter(typeof(StringEnumConverter))]
-        public ContentBlockCategory Category { get; set; }
+        [JsonProperty("category")]
+        public string Category { get; set; }
     }
 
     public enum ContentBlockType
@@ -29,24 +29,6 @@ namespace Crossroads.Utilities.Models
         Warning,
         [EnumMember(Value = "error")]
         Error
-    }
-
-    public enum ContentBlockCategory
-    {
-        [EnumMember(Value = "common")]
-        Common,
-        [EnumMember(Value = "main")]
-        Main,
-        [EnumMember(Value = "corkboard")]
-        Corkboard,
-        [EnumMember(Value = "trip application")]
-        TripApplication,
-        [EnumMember(Value = "group tool")]
-        GroupTool,
-        [EnumMember(Value = "echeck")]
-        Echeck,
-        [EnumMember(Value = "giving")]
-        Giving
     }
 
     public class ContentBlocks

--- a/Gateway/MinistryPlatform.Translation/Repositories/GroupRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/GroupRepository.cs
@@ -648,7 +648,7 @@ namespace MinistryPlatform.Translation.Repositories
                 {"Nickname", toContactInfo.Nickname},
                 {"Group_Name", groupInfo.Name},
                 {"Congregation_Name", groupInfo.Congregation},
-                {"Childcare_Needed", (childcareNeeded) ? _contentBlockService["communityGroupChildcare"].Content : ""},
+                {"Childcare_Needed", (childcareNeeded) ? _contentBlockService.GetContent("communityGroupChildcare") : ""},
                 {"Base_Url", _configurationWrapper.GetConfigValue("BaseUrl")}
             };
 


### PR DESCRIPTION
* Modify ContentBlockService to change Category to a string instead of enum so that adding new categories in CMS in the future does not cause parsing errors in crds-angular.

* Do not throw an exception in GroupRepository.SendCommunityGroupConfirmationEmail if CMS data is missing/unavailable.

* Add more tests.