### PR TITLE
Added code to delete group attributes from the test groups

### DIFF
--- a/CI/TestSQL_TearDown/02.Teardown_MPData/TD_SignUpToServe_TestData.sql
+++ b/CI/TestSQL_TearDown/02.Teardown_MPData/TD_SignUpToServe_TestData.sql
@@ -68,6 +68,8 @@ DELETE FROM [dbo].cr_childcare_requests WHERE GROUP_ID in (select group_id from 
 
 DELETE FROM Group_Attributes WHERE Group_ID IN (SELECT Group_ID FROM Groups WHERE Group_Name = '(t) Superbowl Oakley Group');
 
+DELETE FROM Group_Attributes WHERE Group_ID IN (SELECT Group_ID FROM Groups WHERE Group_Name = '(t) KidsClub Oakley Group');
+
 DELETE FROM Groups WHERE Group_Name = '(t) KidsClub Oakley Group';
 
 DELETE FROM Groups WHERE Group_Name = '(t) Superbowl Oakley Group';

--- a/CI/TestSQL_TearDown/02.Teardown_MPData/TD_SignUpToServe_TestData.sql
+++ b/CI/TestSQL_TearDown/02.Teardown_MPData/TD_SignUpToServe_TestData.sql
@@ -66,6 +66,8 @@ DELETE from [dbo].cr_childcare_request_dates where childcare_request_id in (sele
 
 DELETE FROM [dbo].cr_childcare_requests WHERE GROUP_ID in (select group_id from groups where group_name in ('(t) KidsClub Oakley Group','(t) Superbowl Oakley Group'));
 
+DELETE FROM Group_Attributes WHERE Group_ID IN (SELECT Group_ID FROM Groups WHERE Group_Name = '(t) Superbowl Oakley Group');
+
 DELETE FROM Groups WHERE Group_Name = '(t) KidsClub Oakley Group';
 
 DELETE FROM Groups WHERE Group_Name = '(t) Superbowl Oakley Group';


### PR DESCRIPTION
This is so the test groups can be deleted in the tear down scripts