### PR TITLE
US6596 - GO Local Branding

### DIFF
--- a/crossroads.net/app/go_volunteer/page/anywhereProfile/goVolunteerAnywhereProfile.html
+++ b/crossroads.net/app/go_volunteer/page/anywhereProfile/goVolunteerAnywhereProfile.html
@@ -1,6 +1,5 @@
-<div ng-if="$ctrl.viewReady">
-  <preloader full-screen='false' ng-show='!$ctrl.viewReady'> </preloader>
-
+<preloader full-screen='false' ng-show='!$ctrl.viewReady'> </preloader>
+<div ng-if="$ctrl.viewReady" class="push-top">
   <go-volunteer-project-card project="$ctrl.project"></go-volunteer-project-card>
 
   <h3>Tell us about yourself, so we can keep you in the loop</h3>
@@ -19,7 +18,7 @@
     </div>
 
     <div class="text-center push-top">
-      <button type="submit" class="btn btn-primary" ng-disabled="$ctrl.anywhereForm.$invalid || $ctrl.submitting">Accept Waiver and Register</button>
+      <button type="submit" class="btn btn-primary-gc" ng-disabled="$ctrl.anywhereForm.$invalid || $ctrl.submitting">Accept Waiver and Register</button>
     </div>
   </form>
 </div>

--- a/crossroads.net/app/go_volunteer/page/anywhereProfileConfirm/goVolunteerAnywhereProfileConfirm.html
+++ b/crossroads.net/app/go_volunteer/page/anywhereProfileConfirm/goVolunteerAnywhereProfileConfirm.html
@@ -1,5 +1,6 @@
-<div ng-if="$ctrl.viewReady">
-  <preloader full-screen='false' ng-show='!$ctrl.viewReady'> </preloader>
+<preloader full-screen='false' ng-show='!$ctrl.viewReady'> </preloader>
+
+<div ng-if="$ctrl.viewReady" class="push-top">
 
   <go-volunteer-project-card project="$ctrl.project"></go-volunteer-project-card>
 

--- a/crossroads.net/core/templates/goCincinnati.html
+++ b/crossroads.net/core/templates/goCincinnati.html
@@ -18,21 +18,24 @@
       </div>
       <header>
         <nav class="navbar navbar-static-top">
-          <div class="row">
-            <div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2 clearfix">
-              <a class="back-btn pull-left" href="#" ui-sref="#">
-                <!--Commenting out until back functionality is implemented
-                <svg viewBox="0 0 32 32" class="icon icon-xlarge icon-angle-left">
-                  <use xlink:href="#angle-left"></use>
-                </svg>
-                -->
+          <div class="row hidden-xs">
+            <div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2">
+              <a class="banner center-block" ui-sref="go-volunteer.city({city: 'cincinnati'})" href="#">
+                <img class="imgix-fluid" data-src="//crds-cms-uploads.imgix.net/content/images/go-local/go-local-header.png" alt="GO Local Banner">
               </a>
-              <a class="logo center-block" ui-sref="go-volunteer.city({city: 'cincinnati'})" href="#">
-                <img class="imgix-fluid" data-src="//crds-cms-uploads.imgix.net/content/images/go.png" alt="GO Cincinnati Logo">
-              </a>
+            </div>
+            <div class="col-xs-2 col-sm-1 col-md-2">
               <div class="hamburger-menu black" ng-click=gvMenu=!gvMenu>
                 <div class="bar" ng-class="{'animate': gvMenu}"></div>
               </div>
+            </div>
+          </div>
+          <div class="visible-xs">
+            <a class="logo center-block" ui-sref="go-volunteer.city({city: 'cincinnati'})" href="#">
+              <img class="imgix-fluid" data-src="//crds-cms-uploads.imgix.net/content/images/go-local/go-local-logo.png" alt="GO Local Logo">
+            </a>
+            <div class="hamburger-menu black pull-right" ng-click=gvMenu=!gvMenu>
+              <div class="bar" ng-class="{'animate': gvMenu}"></div>
             </div>
           </div>
         </nav>

--- a/crossroads.net/core/templates/goCincinnati.html
+++ b/crossroads.net/core/templates/goCincinnati.html
@@ -20,7 +20,7 @@
         <nav class="navbar navbar-static-top">
           <div class="row hidden-xs">
             <div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2">
-              <a class="banner center-block" ui-sref="go-volunteer.city({city: 'cincinnati'})" href="#">
+              <a class="banner center-block" ui-sref="content({link:'/golocal'})" href="#">
                 <img class="imgix-fluid" data-src="//crds-cms-uploads.imgix.net/content/images/go-local/go-local-header.png" alt="GO Local Banner">
               </a>
             </div>
@@ -30,11 +30,11 @@
               </div>
             </div>
           </div>
-          <div class="visible-xs">
-            <a class="logo center-block" ui-sref="go-volunteer.city({city: 'cincinnati'})" href="#">
+          <div class="visible-xs text-center">
+            <a class="logo" ui-sref="content({link:'/golocal'})" href="#">
               <img class="imgix-fluid" data-src="//crds-cms-uploads.imgix.net/content/images/go-local/go-local-logo.png" alt="GO Local Logo">
             </a>
-            <div class="hamburger-menu black pull-right" ng-click=gvMenu=!gvMenu>
+            <div class="gc-menu-right hamburger-menu black" ng-click=gvMenu=!gvMenu>
               <div class="bar" ng-class="{'animate': gvMenu}"></div>
             </div>
           </div>

--- a/crossroads.net/styles/pages/go-volunteer.scss
+++ b/crossroads.net/styles/pages/go-volunteer.scss
@@ -31,11 +31,10 @@ $gc-red-darker: #44080a;
   }
 
   .navbar {
-    margin-top: 20px;
-    min-height: 70px;
-    .logo {
-      height: 70px;
-      width: 70px;
+    //margin-top: 20px;
+    //min-height: 70px;
+
+    .banner {
       overflow: hidden;
       left: 0;
       right: 0;
@@ -44,19 +43,37 @@ $gc-red-darker: #44080a;
       margin-left: auto;
       margin-right: auto;
       z-index: $zindex-navbar + 1;
-      transition: all 0.5s ease;
-      &:hover {
-        transform: rotate(10deg);
-      }
+      text-align: center;
+    }
+
+    .banner img {
+      width: 100%;
+      display: inline-block;
+      margin: 0 -100%;
+    }
+
+    .logo {
+      //height: 70px;
+      //width: 70px;
+      overflow: hidden;
+      left: 0;
+      right: 0;
+      position: absolute;
+      height: auto;
+      margin-left: auto;
+      margin-right: auto;
+      z-index: $zindex-navbar + 1;
+      text-align: center;
     }
 
     .logo img {
-      width: 70px;
-      height: 70px;
+      height: 80px;
+      display: inline-block;
+      margin: 0 auto;
     }
-    .hamburger-menu {
-      z-index: $zindex-navbar + 2;
 
+    .hamburger-menu {
+      float: inherit;
       .bar, .bar:before, .bar:after {
         background: $black;
       }

--- a/crossroads.net/styles/pages/go-volunteer.scss
+++ b/crossroads.net/styles/pages/go-volunteer.scss
@@ -31,15 +31,8 @@ $gc-green: #9ab73c;
   }
 
   .navbar {
-    //margin-top: 20px;
-    //min-height: 70px;
-
     .banner {
       overflow: hidden;
-      left: 0;
-      right: 0;
-      position: absolute;
-      height: auto;
       margin-left: auto;
       margin-right: auto;
       z-index: $zindex-navbar + 1;
@@ -50,20 +43,6 @@ $gc-green: #9ab73c;
       width: 100%;
       display: inline-block;
       margin: 0 -100%;
-    }
-
-    .logo {
-      //height: 70px;
-      //width: 70px;
-      overflow: hidden;
-      left: 0;
-      right: 0;
-      position: absolute;
-      height: auto;
-      margin-left: auto;
-      margin-right: auto;
-      z-index: $zindex-navbar + 1;
-      text-align: center;
     }
 
     .logo img {
@@ -77,7 +56,14 @@ $gc-green: #9ab73c;
       .bar, .bar:before, .bar:after {
         background: $black;
       }
+
+      &.gc-menu-right {
+        position: absolute;
+        top: 0;
+        right: 0;
+      }
     }
+
     .back-btn {
       margin-top: 20px;
       margin-left: -7px;
@@ -193,8 +179,8 @@ $gc-green: #9ab73c;
     bottom: 0;
     left: 0;
     right: 0;
-    background: $go-local-site-filter;
-    background-blend-mode: multiply;
+    //background: $go-local-site-filter;
+    //background-blend-mode: multiply;
     display: block;
     margin: $line-height-computed/2;
     border-radius: 50%;
@@ -214,7 +200,7 @@ $gc-green: #9ab73c;
     font-size: 2.1rem;
     font-weight: bold;
     position: absolute;
-    background: rgba(0,0,0,.3);
+    //background: rgba(0,0,0,.3);
     width: 60px;
     height: 60px;
     line-height: 60px;

--- a/crossroads.net/styles/pages/go-volunteer.scss
+++ b/crossroads.net/styles/pages/go-volunteer.scss
@@ -1,7 +1,7 @@
-$gc-red: #981b1e;
+$go-local-primary: rgb(0, 177, 64);
+$go-local-secondary: rgb(196, 214, 0);
+$go-local-site-filter: rgba(0, 177, 64, 0.55);
 $gc-green: #9ab73c;
-$gc-red-dark: #641314;
-$gc-red-darker: #44080a;
 
 .go-volunteer {
   background-color: $white;
@@ -27,7 +27,7 @@ $gc-red-darker: #44080a;
     font-size: 2.4em;
   }
   .btn-primary-gc {
-    @include button-variant(#fff, $gc-red, $gc-red);
+    @include button-variant(#fff, $go-local-primary, $go-local-primary);
   }
 
   .navbar {
@@ -112,7 +112,7 @@ $gc-red-darker: #44080a;
     animation-duration: .5s;
   }
   .dropdown-menu > .active > a {
-    background-color: $gc-red;
+    background-color: $go-local-primary;
   }
   .progress {
     height: 3px;
@@ -173,6 +173,10 @@ $gc-red-darker: #44080a;
   .media-card-link a {
     position: inherit;
   }
+
+  .icon-checkmark {
+    color: $go-local-secondary;
+  }
 }
 
 .site-image-filter {
@@ -189,7 +193,7 @@ $gc-red-darker: #44080a;
     bottom: 0;
     left: 0;
     right: 0;
-    background: rgba(0, 56, 100, 0.65);
+    background: $go-local-site-filter;
     background-blend-mode: multiply;
     display: block;
     margin: $line-height-computed/2;


### PR DESCRIPTION
## New heading banner
<img width="450" alt="banner" src="https://cloud.githubusercontent.com/assets/2341619/23920033/7fa37902-08cf-11e7-9269-57f624331263.png">

## Mobile view only shows logo
<img width="180" alt="mobile logo" src="https://cloud.githubusercontent.com/assets/2341619/23920036/85a41596-08cf-11e7-9538-1f62b763aacb.png">

## Signup Instruction numbers no longer have gray background
<img width="450" alt="signup instructions" src="https://cloud.githubusercontent.com/assets/2341619/23920046/8a2c02e0-08cf-11e7-8006-b002bdee032b.png">

## Locations page Site images are now grayscale
<img width="450" alt="locations" src="https://cloud.githubusercontent.com/assets/2341619/23920034/827b9f38-08cf-11e7-855b-3992a6195a85.png">

## Selected Project choices are highlighted greed with a yellow checkmark
<img width="450" alt="project choice" src="https://cloud.githubusercontent.com/assets/2341619/23920039/87ffd334-08cf-11e7-821f-aadf92d559bf.png">
