### PR TITLE
Feature/us7504 allow image access without api key

### DIFF
--- a/Gateway/crds-angular.test/app.config
+++ b/Gateway/crds-angular.test/app.config
@@ -4,6 +4,7 @@
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
     <section name="crossroadsCommonUnity" type="Microsoft.Practices.Unity.Configuration.UnityConfigurationSection, Microsoft.Practices.Unity.Configuration" />
+    <section name="crossroadsClientApiKeysUnity" type="Microsoft.Practices.Unity.Configuration.UnityConfigurationSection, Microsoft.Practices.Unity.Configuration" />
   </configSections>
   <appSettings file="MinistryPlatform.config">
     <add key="TokenURL" value="https://adminint.crossroads.net/ministryplatform/oauth/token" />
@@ -103,4 +104,5 @@
     </providers>
   </entityFramework>
   <crossroadsCommonUnity configSource="Crossroads.Web.Common-Unity.config" />
+  <crossroadsClientApiKeysUnity configSource="Crossroads.ClientApiKeys-Unity.config" />
 </configuration>

--- a/Gateway/crds-angular.test/controllers/ImageControllerTest.cs
+++ b/Gateway/crds-angular.test/controllers/ImageControllerTest.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Web.Http;
+using crds_angular.Controllers.API;
+using crds_angular.Services.Interfaces;
+using Crossroads.ClientApiKeys;
+using Crossroads.Web.Common.MinistryPlatform;
+using Crossroads.Web.Common.Security;
+using MinistryPlatform.Translation.Repositories.Interfaces;
+using Moq;
+using NUnit.Framework;
+
+namespace crds_angular.test.controllers
+{
+    public class ImageControllerTest
+    {
+        private ImageController _fixture;
+        private Mock<IMinistryPlatformService> _mpService;
+        private Mock<IAuthenticationRepository> _authenticationRepository;
+        private Mock<IApiUserRepository> _apiUserRepository;
+        private Mock<IUserImpersonationService> _userImpersonationService;
+
+        private List<Type> _attributesThatRequireApiKey;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _attributesThatRequireApiKey = new List<Type>
+            {
+                typeof(HttpPostAttribute),
+                typeof(HttpPutAttribute),
+                typeof(HttpDeleteAttribute)
+            };
+
+            _mpService = new Mock<IMinistryPlatformService>();
+            _authenticationRepository = new Mock<IAuthenticationRepository>();
+            _apiUserRepository = new Mock<IApiUserRepository>();
+            _userImpersonationService = new Mock<IUserImpersonationService>();
+
+            _fixture = new ImageController(_mpService.Object, _authenticationRepository.Object, _apiUserRepository.Object, _userImpersonationService.Object);
+        }
+
+        [Test]
+        public void EndpointMethodsThatOnlyReadImagesShouldIgnoreClientApiKey()
+        {
+            var publicMethods = _fixture.GetType().GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
+            publicMethods.ToList().ForEach(m =>
+            {
+                if (!MethodHasHttpUpdateAttribute(m))
+                {
+                    Assert.IsNotNull(m.GetCustomAttribute<IgnoreClientApiKeyAttribute>(), $"Method {m.Name} should have [IgnoreClientApiKey] attribute, as it is only reading image information");
+                }
+            });
+        }
+
+        [Test]
+        public void EndpointMethodsThatCreateOrUpdateImagesShouldNotIgnoreClientApiKey()
+        {
+            var publicMethods = _fixture.GetType().GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
+            publicMethods.ToList().ForEach(m =>
+            {
+                if (MethodHasHttpUpdateAttribute(m))
+                {
+                    Assert.IsNull(m.GetCustomAttribute<IgnoreClientApiKeyAttribute>(), $"Method {m.Name} should not have [IgnoreClientApiKey] attribute, as it is updating image information");
+                }
+            });
+        }
+
+        private bool MethodHasHttpUpdateAttribute(MethodInfo m)
+        {
+            return m.GetCustomAttributes().ToList().Exists(attr => _attributesThatRequireApiKey.Contains(attr.GetType()));
+        }
+
+    }
+}

--- a/Gateway/crds-angular.test/crds-angular.test.csproj
+++ b/Gateway/crds-angular.test/crds-angular.test.csproj
@@ -79,6 +79,13 @@
       <HintPath>..\packages\Common.Logging.Core.3.0.0\lib\net40\Common.Logging.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Crossroads.ApiVersioning, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Crossroads.ApiVersioning.1.0.4\lib\net45\Crossroads.ApiVersioning.dll</HintPath>
+    </Reference>
+    <Reference Include="Crossroads.ClientApiKeys, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Crossroads.ClientApiKeys.1.0.6\lib\net45\Crossroads.ClientApiKeys.dll</HintPath>
+    </Reference>
     <Reference Include="Crossroads.Web.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Crossroads.Web.Common.1.0.13\lib\net45\Crossroads.Web.Common.dll</HintPath>
       <Private>True</Private>
@@ -193,6 +200,9 @@
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Web.Cors, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Cors.5.2.3\lib\net45\System.Web.Cors.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
@@ -244,6 +254,7 @@
     <Compile Include="controllers\EventParticipantControllerTest.cs" />
     <Compile Include="controllers\GoVolunteerControllerTest.cs" />
     <Compile Include="controllers\GroupToolControllerTest.cs" />
+    <Compile Include="controllers\ImageControllerTest.cs" />
     <Compile Include="controllers\InvitationControllerTest.cs" />
     <Compile Include="controllers\LoginControllerTest.cs" />
     <Compile Include="controllers\LookupControllerTest.cs" />
@@ -396,10 +407,12 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
     <Error Condition="!Exists('..\packages\Crossroads.Web.Common.1.0.13\build\Crossroads.Web.Common.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Crossroads.Web.Common.1.0.13\build\Crossroads.Web.Common.targets'))" />
+    <Error Condition="!Exists('..\packages\Crossroads.ClientApiKeys.1.0.6\build\Crossroads.ClientApiKeys.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Crossroads.ClientApiKeys.1.0.6\build\Crossroads.ClientApiKeys.targets'))" />
   </Target>
   <Import Project="$(SlowCheetahTargets)" Condition="Exists('$(SlowCheetahTargets)')" Label="SlowCheetah" />
   <Import Project="..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets" Condition="Exists('..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets')" />
   <Import Project="..\packages\Crossroads.Web.Common.1.0.13\build\Crossroads.Web.Common.targets" Condition="Exists('..\packages\Crossroads.Web.Common.1.0.13\build\Crossroads.Web.Common.targets')" />
+  <Import Project="..\packages\Crossroads.ClientApiKeys.1.0.6\build\Crossroads.ClientApiKeys.targets" Condition="Exists('..\packages\Crossroads.ClientApiKeys.1.0.6\build\Crossroads.ClientApiKeys.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Gateway/crds-angular.test/packages.config
+++ b/Gateway/crds-angular.test/packages.config
@@ -3,6 +3,7 @@
   <package id="AutoMapper" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging" version="3.0.0" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.0.0" targetFramework="net45" />
+  <package id="Crossroads.ClientApiKeys" version="1.0.6" targetFramework="net45" />
   <package id="Crossroads.Web.Common" version="1.0.13" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.2" targetFramework="net45" />
   <package id="FactoryGirl.NET" version="1.0.0.0" targetFramework="net45" />
@@ -11,6 +12,7 @@
   <package id="FSharp.Core" version="3.1.2.5" targetFramework="net45" />
   <package id="GoogleMapsAPI.NET" version="1.0.0" targetFramework="net45" />
   <package id="log4net" version="2.0.7" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Cors" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
@@ -30,6 +32,7 @@
   <package id="RestSharp" version="105.2.3" targetFramework="net45" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net45" />
   <package id="SlowCheetah" version="2.5.14" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net45" />
   <package id="Twilio" version="4.7.2" targetFramework="net45" />
   <package id="Unity" version="3.5.1404.0" targetFramework="net45" />
 </packages>

--- a/Gateway/crds-angular/Controllers/API/ImageController.cs
+++ b/Gateway/crds-angular/Controllers/API/ImageController.cs
@@ -9,11 +9,10 @@ using crds_angular.Models.Json;
 using crds_angular.Security;
 using crds_angular.Util;
 using log4net;
-using MinistryPlatform.Translation.PlatformService;
 using MPInterfaces = MinistryPlatform.Translation.Repositories.Interfaces;
 using Crossroads.ApiVersioning;
 using crds_angular.Services.Interfaces;
-using Crossroads.Web.Common;
+using Crossroads.ClientApiKeys;
 using Crossroads.Web.Common.MinistryPlatform;
 using Crossroads.Web.Common.Security;
 
@@ -31,7 +30,7 @@ namespace crds_angular.Controllers.API
             _mpService = mpService;
         }
 
-        private IHttpActionResult GetImage(Int32 fileId, String fileName, String token)
+        private IHttpActionResult GetImage(int fileId, string fileName, string token)
         {
             var imageStream = _mpService.GetFile(fileId, token);
             if (imageStream == null)
@@ -51,7 +50,8 @@ namespace crds_angular.Controllers.API
         [VersionedRoute(template: "image/{fileId}", minimumVersion: "1.0.0")]
         [Route("image/{fileId:int}")]
         [HttpGet]
-        public IHttpActionResult GetImage(Int32 fileId)
+        [IgnoreClientApiKey]
+        public IHttpActionResult GetImage(int fileId)
         {
             try
             {
@@ -68,7 +68,6 @@ namespace crds_angular.Controllers.API
             }
         }
 
-
         /// <summary>
         /// Retrieves a profile image given a contact ID.
         /// </summary>
@@ -77,7 +76,8 @@ namespace crds_angular.Controllers.API
         [VersionedRoute(template: "image/profile/{contactId}", minimumVersion: "1.0.0")]
         [Route("image/profile/{contactId:int}")]
         [HttpGet]
-        public IHttpActionResult GetProfileImage(Int32 contactId)
+        [IgnoreClientApiKey]
+        public IHttpActionResult GetProfileImage(int contactId)
         {
             var token = _apiUserService.GetToken();
             var files = _mpService.GetFileDescriptions("Contacts", contactId, token);
@@ -95,7 +95,8 @@ namespace crds_angular.Controllers.API
         [VersionedRoute(template: "image/pledge-campaign/{recordId}", minimumVersion: "1.0.0")]
         [Route("image/pledgecampaign/{recordId:int}")]
         [HttpGet]
-        public IHttpActionResult GetCampaignImage(Int32 recordId)
+        [IgnoreClientApiKey]
+        public IHttpActionResult GetCampaignImage(int recordId)
         {
             var token = _apiUserService.GetToken();
             var files = _mpService.GetFileDescriptions("Pledge_Campaigns", recordId, token);
@@ -112,7 +113,7 @@ namespace crds_angular.Controllers.API
         {
             return (Authorized(token =>
             {
-                const String fileName = "profile.png";
+                const string fileName = "profile.png";
 
                 var contactId = _mpService.GetContactInfo(token).ContactId;
                 var files = _mpService.GetFileDescriptions("MyContact", contactId, token);


### PR DESCRIPTION
* [US7504](https://rally1.rallydev.com/#/38108142417d/detail/userstory/102570326692) on Architecture Kanban is ✔️ and ready for code review
* Added [[IgnoreClientApiKey]](https://github.com/crdschurch/crds-client-api-keys/blob/development/Crossroads.ClientApiKeys/src/IgnoreClientApiKeyAttribute.cs#L7-L9) attribute to all GET methods
* Unit test to make sure GET methods include [IgnoreClientApiKey] attribute, and POST/PUT/DELETE methods do not
  * This test will work even as new methods are added to this controller, so we will not accidentally put a new GET method in place that requires a key