### PR TITLE
US8190 - Connect Promo

### DIFF
--- a/crossroads.net/app/live_stream/landing/landing.html
+++ b/crossroads.net/app/live_stream/landing/landing.html
@@ -19,28 +19,7 @@
     </div>
   </section>
 
-  <section class="landing-connect">
-    <header class="crds-hero">
-      <div>
-        <div dynamic-content="$root.MESSAGES.streamingLandingConnectIntro.content | html"></div>
-      </div>
-    </header>
-    <div class="container">
-      <div>
-        <article>
-          <div dynamic-content="$root.MESSAGES.streamingLandingConnectMap.content | html" ></div>
-        </article>
-        <article>
-          <div dynamic-content="$root.MESSAGES.streamingLandingConnectNearby.content | html" ></div>
-        </article>
-        <article>
-          <div dynamic-content="$root.MESSAGES.streamingLandingConnectTogether.content | html" ></div>
-        </article>
-      </div>
-    </div>
-    <br>
-    <div class="text-center" dynamic-content="$root.MESSAGES.streamingLandingConnectButton.content | html" ></div>
-  </section>
+  <div dynamic-content="$root.MESSAGES.streamingLandingConnect.content | html"></div>
 
   <countdown-intro ng-show="landing.streamStatus === 'Upcoming'"></countdown-intro>
   <current-series></current-series>

--- a/crossroads.net/styles/pages/streaming.scss
+++ b/crossroads.net/styles/pages/streaming.scss
@@ -700,10 +700,6 @@ streaming, landing {
 
   .landing-connect {
     padding: 0 2em 4em;
-    background-image: url('//s3.amazonaws.com/ample-crds/crds-anywhere-landing-bg.png');
-    background-repeat: no-repeat;
-    background-size: cover;
-    background-position: center;
 
     p,
     h3,


### PR DESCRIPTION
Only use one content block for the connect promo section.

Per Brian's request, this transitions from using several content blocks to a single one, mostly so the background image can be controlled through the CMS.