### PR TITLE
US8121 - Clean up End_Date for Group Participant Attributes

### DIFF
--- a/CI/SQL/20170531_095800_US8121-end-date-group-participant-attributes.sql
+++ b/CI/SQL/20170531_095800_US8121-end-date-group-participant-attributes.sql
@@ -1,0 +1,26 @@
+﻿USE [MinistryPlatform]
+GO
+
+CREATE INDEX IX_Group_Participant_Attributes__GroupParticipantID ON Group_Participant_Attributes(Group_Participant_ID);
+GO
+
+CREATE TRIGGER crds_tr_End_Date_Group_Participant_Attributes
+	ON Group_Participants
+	AFTER UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+	-- When Group_Participants.End_Date is modified, apply the same change to Group_Participant_Attributes.End_Date
+	IF UPDATE(End_Date)
+	BEGIN
+		UPDATE gpa
+		SET gpa.End_Date = gp.End_Date
+		FROM
+			INSERTED i
+			INNER JOIN Group_Participants gp ON gp.Group_Participant_ID = i.Group_Participant_ID
+			INNER JOIN Group_Participant_Attributes gpa ON gpa.Group_Participant_ID = gp.Group_Participant_ID
+		;
+	END
+END
+GO

--- a/CI/SQL/20170531_095800_US8121-end-date-group-participant-attributes.sql
+++ b/CI/SQL/20170531_095800_US8121-end-date-group-participant-attributes.sql
@@ -15,11 +15,10 @@ BEGIN
 	IF UPDATE(End_Date)
 	BEGIN
 		UPDATE gpa
-		SET gpa.End_Date = gp.End_Date
+		SET gpa.End_Date = i.End_Date
 		FROM
 			INSERTED i
-			INNER JOIN Group_Participants gp ON gp.Group_Participant_ID = i.Group_Participant_ID
-			INNER JOIN Group_Participant_Attributes gpa ON gpa.Group_Participant_ID = gp.Group_Participant_ID
+			INNER JOIN Group_Participant_Attributes gpa ON gpa.Group_Participant_ID = i.Group_Participant_ID
 		;
 	END
 END

--- a/CI/SQL/20170531_100500_US8121-group-participant-end-date-cleanup.sql
+++ b/CI/SQL/20170531_100500_US8121-group-participant-end-date-cleanup.sql
@@ -1,0 +1,13 @@
+﻿USE [MinistryPlatform]
+GO
+
+-- One-time data cleanup to make Group_Participant_Attributes.End_Date match Group_Participants.End_Date
+-- This is part of US8121
+UPDATE gpa
+SET gpa.End_Date = gp.End_Date
+FROM
+	Group_Participants gp
+	INNER JOIN Group_Participant_Attributes gpa ON gpa.Group_Participant_ID = gp.Group_Participant_ID
+WHERE
+	COALESCE(gp.End_Date, '1900-01-01') <> COALESCE(gpa.End_Date, '1900-01-01')
+;


### PR DESCRIPTION
* New trigger that will sync End_Date in Group_Participant_Attributes
* New index on Group_Participant_Attributes to ensure the trigger is efficient
* One-time query to clean up existing data