### PR TITLE
If participant is part of the group already, don't add them a second …

### DIFF
--- a/Gateway/MinistryPlatform.Translation/Repositories/GroupRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/GroupRepository.cs
@@ -615,9 +615,18 @@ namespace MinistryPlatform.Translation.Repositories
 
         public bool ParticipantGroupMember(int groupId, int participantId)
         {
+            return (GetParticipantGroupMemberId(groupId, participantId) > 0);
+        }
+
+        public int GetParticipantGroupMemberId(int groupId, int participantId)
+        {
+            object gpid = null;
             var searchString = string.Format(",{0},{1}", groupId, participantId);
             var teams = ministryPlatformService.GetPageViewRecords("GroupParticipantsById", ApiLogin(), searchString);
-            return teams.Count != 0;
+            if (teams.Count!=0 && teams.FirstOrDefault().TryGetValue("Group_Participant_ID", out gpid))
+                return (int)gpid;
+            else
+                return -1;
         }
 
         public bool checkIfUserInGroup(int participantId, IList<MpGroupParticipant> groupParticipants)

--- a/Gateway/MinistryPlatform.Translation/Repositories/Interfaces/IEventRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/Interfaces/IEventRepository.cs
@@ -11,7 +11,7 @@ namespace MinistryPlatform.Translation.Repositories.Interfaces
     {
         int CreateEvent(MpEventReservationDto eventReservationReservation);
         void UpdateEvent(MpEventReservationDto eventReservationReservation);
-        int SafeRegisterParticipant(int participantId, int eventId, int groupId = 0, int groupParticipantId = 0);
+        int SafeRegisterParticipant(int eventId, int participantId, int groupId = 0, int groupParticipantId = 0);
         int RegisterParticipantForEvent(int participantId, int eventId, int groupId = 0, int groupParticipantId = 0);
         int RegisterInterestedParticipantWithEndDate(int participantId, int eventId, DateTime? endDate);
         void SetParticipantAsRegistered(int eventId, int participantId);

--- a/Gateway/MinistryPlatform.Translation/Repositories/Interfaces/IGroupRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/Interfaces/IGroupRepository.cs
@@ -32,6 +32,8 @@ namespace MinistryPlatform.Translation.Repositories.Interfaces
 
         bool ParticipantGroupMember(int groupId, int participantId);
 
+        int GetParticipantGroupMemberId(int groupId, int participantId);
+
         List<MpGroup> GetGroupsForEvent(int eventId);
 
         void SendCommunityGroupConfirmationEmail(int participantId, int groupId, bool waitlist, bool childcareNeeded);

--- a/Gateway/crds-angular/Services/GroupService.cs
+++ b/Gateway/crds-angular/Services/GroupService.cs
@@ -210,26 +210,34 @@ namespace crds_angular.Services
             {
                 foreach (var participant in participants)
                 {
-                    int groupParticipantId;
-
                     var roleId = participant.groupRoleId ?? _groupRoleDefaultId;
 
                     var participantId = participant.particpantId.Value;
-                    groupParticipantId = _mpGroupRepository.addParticipantToGroup(participantId,
-                                                               Convert.ToInt32(groupId),
-                                                               roleId,
-                                                               participant.childCareNeeded,
-                                                               DateTime.Now);
 
-                    var configuration = MpObjectAttributeConfigurationFactory.GroupParticipant();
-                    _objectAttributeService.SaveObjectAttributes(groupParticipantId, participant.AttributeTypes, participant.SingleAttributes, configuration);                    
+                    int groupParticipantId = _mpGroupRepository.GetParticipantGroupMemberId(Convert.ToInt32(groupId), participantId);
 
-                    if (participant.capacityNeeded > 0)
+                    if (groupParticipantId < 0) 
                     {
-                        DecrementCapacity(participant.capacityNeeded, group);
-                    }
+                        groupParticipantId = _mpGroupRepository.addParticipantToGroup(participantId,
+                                                                                      Convert.ToInt32(groupId),
+                                                                                      roleId,
+                                                                                      participant.childCareNeeded,
+                                                                                      DateTime.Now);
 
-                    _logger.Debug("Added user - group/participant id = " + groupParticipantId);
+                        var configuration = MpObjectAttributeConfigurationFactory.GroupParticipant();
+                        _objectAttributeService.SaveObjectAttributes(groupParticipantId, participant.AttributeTypes, participant.SingleAttributes, configuration);
+
+                        if (participant.capacityNeeded > 0)
+                        {
+                            DecrementCapacity(participant.capacityNeeded, group);
+                        }
+
+                        _logger.Debug("Added user - group/participant id = " + groupParticipantId);
+                    }
+                    else
+                    {
+                        _logger.Debug("User "+participantId+ " was already a member of group "+groupId);
+                    }
 
                     // Now see what future events are scheduled for this group, and register the user for those
                     var events = _mpGroupRepository.getAllEventsForGroup(Convert.ToInt32(groupId));
@@ -238,7 +246,8 @@ namespace crds_angular.Services
                     {
                         foreach (var e in events.Where(x => x.EventType != (Convert.ToString(_childcareEventTypeId))))
                         {
-                            _eventService.RegisterParticipantForEvent(participantId, e.EventId, groupId, groupParticipantId);
+                            //SafeRegisterParticipant will not register again if they are already registered
+                            _eventService.SafeRegisterParticipant( e.EventId, participantId, groupId, groupParticipantId);
                             _logger.Debug("Added participant " + participant + " to group event " + e.EventId);
                         }
                     }


### PR DESCRIPTION
…time.

Ditto for event participant. And fixed the interface parameter list for
SafeRegisterParticipant to match the implementation