### PR TITLE
DE3565 - Exclude cancelled events from Childcare Decision tool

### DIFF
--- a/Gateway/MinistryPlatform.Translation.Test/Services/EventServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/EventServiceTest.cs
@@ -54,58 +54,60 @@ namespace MinistryPlatform.Translation.Test.Services
         private const int EventParticipantPageId = 281;
         private const int EventParticipantStatusDefaultId = 2;
         private const int EventsPageId = 308;
-        private const string EventsWithEventTypeId = "EventsWithEventTypeId";
 
-        private List<Dictionary<string, object>> MockEventsDictionaryByEventTypeId()
+        private List<MpEvent> MockEventsListByEventTypeId()
         {
-            return new List<Dictionary<string, object>>
+            return new List<MpEvent>
             {
-                new Dictionary<string, object>
+                new MpEvent
                 {
-                    {"dp_RecordID", 100},
-                    {"Event Title", "event-title-100"},
-                    {"Event Type", "event-type-100"},
-                    {"Event Start Date", new DateTime(2015, 3, 28, 8, 30, 0)},
-                    {"Event End Date", new DateTime(2015, 3, 28, 8, 30, 0)},
-                    {"Congregation_ID", 1}
+                    EventId = 100,
+                    EventTitle = "event-title-100",
+                    EventType = "event-type-100",
+                    EventStartDate = new DateTime(2015, 3, 28, 8, 30, 0),
+                    EventEndDate = new DateTime(2015, 3, 28, 8, 30, 0),
+                    CongregationId = 1,
+                    Cancelled = false
                 },
-                new Dictionary<string, object>
+                new MpEvent
                 {
-                    {"dp_RecordID", 200},
-                    {"Event Title", "event-title-200"},
-                    {"Event Type", "event-type-200"},
-                    {"Event Start Date", new DateTime(2015, 4, 1, 8, 30, 0)},
-                    {"Event End Date", new DateTime(2015, 4, 1, 8, 30, 0)},
-                    {"Congregation_ID", 1}
+                    EventId = 200,
+                    EventTitle = "event-title-200",
+                    EventType = "event-type-200",
+                    EventStartDate = new DateTime(2015, 4, 1, 8, 30, 0),
+                    EventEndDate = new DateTime(2015, 4, 1, 8, 30, 0),
+                    CongregationId = 1,
+                    Cancelled = false
                 },
-                new Dictionary<string, object>
+                new MpEvent
                 {
-                    {"dp_RecordID", 300},
-                    {"Event Title", "event-title-300"},
-                    {"Event Type", "event-type-300"},
-                    {"Event Start Date", new DateTime(2015, 4, 2, 8, 30, 0)},
-                    {"Event End Date", new DateTime(2015, 4, 2, 8, 30, 0)},
-                    {"Congregation_ID", 1}
-                }
-                ,
-                new Dictionary<string, object>
+                    EventId = 300,
+                    EventTitle = "event-title-300",
+                    EventType = "event-type-300",
+                    EventStartDate = new DateTime(2015, 4, 2, 8, 30, 0),
+                    EventEndDate = new DateTime(2015, 4, 2, 8, 30, 0),
+                    CongregationId = 1,
+                    Cancelled = false
+                },
+                new MpEvent
                 {
-                    {"dp_RecordID", 400},
-                    {"Event Title", "event-title-400"},
-                    {"Event Type", "event-type-400"},
-                    {"Event Start Date", new DateTime(2015, 4, 30, 8, 30, 0)},
-                    {"Event End Date", new DateTime(2015, 4, 30, 8, 30, 0)},
-                    {"Congregation_ID", 1}
-                }
-                ,
-                new Dictionary<string, object>
+                    EventId = 400,
+                    EventTitle = "event-title-400",
+                    EventType = "event-type-400",
+                    EventStartDate = new DateTime(2015, 4, 30, 8, 30, 0),
+                    EventEndDate = new DateTime(2015, 4, 30, 8, 30, 0),
+                    CongregationId = 1,
+                    Cancelled = false
+                },
+                new MpEvent
                 {
-                    {"dp_RecordID", 500},
-                    {"Event Title", "event-title-500"},
-                    {"Event Type", "event-type-500"},
-                    {"Event Start Date", new DateTime(2015, 5, 1, 8, 30, 0)},
-                    {"Event End Date", new DateTime(2015, 5, 1, 8, 30, 0)},
-                    {"Congregation_ID", 1}
+                    EventId = 500,
+                    EventTitle = "event-title-500",
+                    EventType = "event-type-500",
+                    EventStartDate = new DateTime(2015, 5, 1, 8, 30, 0),
+                    EventEndDate = new DateTime(2015, 5, 1, 8, 30, 0),
+                    CongregationId = 1,
+                    Cancelled = false
                 }
             };
         }
@@ -258,16 +260,16 @@ namespace MinistryPlatform.Translation.Test.Services
         public void GetEventsByTypeAndRange()
         {
             var eventTypeId = 1;
-            var search = ",," + eventTypeId;
-            _ministryPlatformService.Setup(mock => mock.GetPageViewRecords(EventsWithEventTypeId, It.IsAny<string>(), search, "", 0))
-                .Returns(MockEventsDictionaryByEventTypeId());
 
-            var startDate = new DateTime(2015, 4, 1);
-            var endDate = new DateTime(2015, 4, 30);
-            var events = _fixture.GetEventsByTypeForRange(eventTypeId, startDate, endDate, It.IsAny<string>());
-            Assert.IsNotNull(events);
-            Assert.AreEqual(3, events.Count);
-            Assert.AreEqual("event-title-200", events[0].EventTitle);
+            _ministryPlatformRestService.Setup(m => m.UsingAuthenticationToken("ABC")).Returns(_ministryPlatformRestService.Object);
+            _ministryPlatformRestService.Setup(m => m.Search<MpEvent>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), false))
+                .Returns(MockEventsListByEventTypeId());
+
+            var startDate = new DateTime(2015, 3, 1);
+            var endDate = new DateTime(2015, 5, 30);
+            var events = _fixture.GetEventsByTypeForRange(eventTypeId, startDate, endDate, "ABC");
+            Assert.AreEqual(events.Count, 5);
+            _ministryPlatformService.VerifyAll();
         }
 
         [Test]

--- a/Gateway/MinistryPlatform.Translation/Repositories/ChildcareRequestRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/ChildcareRequestRepository.cs
@@ -221,7 +221,7 @@ namespace MinistryPlatform.Translation.Repositories
         public List<MpEvent> FindChildcareEvents(int childcareRequestId, List<MpChildcareRequestDate> requestedDates, MpChildcareRequest request)
         {
            var apiToken = _apiUserService.GetToken();
-           var events = _eventService.GetEventsByTypeForRange(_childcareEventType, request.StartDate, request.EndDate, apiToken);
+           var events = _eventService.GetEventsByTypeForRange(_childcareEventType, request.StartDate, request.EndDate, apiToken, false);
            return events;
         }
 

--- a/Gateway/MinistryPlatform.Translation/Repositories/EventRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/EventRepository.cs
@@ -330,27 +330,31 @@ namespace MinistryPlatform.Translation.Repositories
             }).ToList();
         }
 
-        public List<MpEvent> GetEventsByTypeForRange(int eventTypeId, DateTime startDate, DateTime endDate, string token)
+        public List<MpEvent> GetEventsByTypeForRange(int eventTypeId, DateTime startDate, DateTime endDate, string token, bool includeCancelledEvents = true)
         {
-            const string viewKey = "EventsWithEventTypeId";
-            var search = ",," + eventTypeId;
-            var eventRecords = _ministryPlatformService.GetPageViewRecords(viewKey, token, search);
+            string columns = string.Join(", ",
+                "Event_ID",
+                "Event_Title",
+                "Event_Type_ID_Table.Event_Type AS Event_Type_ID",   // aliased to Event_Type_ID to match JsonProperty on MpEvent.Event_Type!
+                "Event_Start_Date",
+                "Event_End_Date",
+                "Congregation_ID",
+                "Cancelled"
+            );
 
-            var events = eventRecords.Select(record => new MpEvent
-            {
-                EventTitle = record.ToString("Event Title"),
-                EventType = record.ToString("Event Type"),
-                EventStartDate = record.ToDate("Event Start Date", true),
-                EventEndDate = record.ToDate("Event End Date", true),
-                EventId = record.ToInt("dp_RecordID"),
-                CongregationId = record.ToInt("Congregation_ID")
-            }).ToList();
+            string search = $"Events.Event_Type_ID = {eventTypeId}";
 
-            //now we have a list, filter by date range.
-            var filteredEvents =
-                events.Where(e => e.EventStartDate.Date >= startDate.Date && e.EventStartDate.Date <= endDate.Date)
-                    .ToList();
-            return filteredEvents;
+            string startDateString = startDate.Date.ToString("yyyy-MM-dd");
+            string endDateString = endDate.Date.AddDays(1).ToString("yyyy-MM-dd");
+            search += $" AND Events.Event_Start_Date >= '{startDateString}' AND Events.Event_End_Date < '{endDateString}'";
+
+            if (!includeCancelledEvents)
+                search += " AND Events.Cancelled = 0";
+
+            string orderBy = "Events.Event_ID";
+
+            List<MpEvent> eventList = _ministryPlatformRestRepository.UsingAuthenticationToken(token).Search<MpEvent>(search, columns, orderBy, false);
+            return eventList;
         }
 
         public List<MpEvent> GetEventsByParentEventId(int parentEventId)

--- a/Gateway/MinistryPlatform.Translation/Repositories/Interfaces/IEventRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/Interfaces/IEventRepository.cs
@@ -18,7 +18,7 @@ namespace MinistryPlatform.Translation.Repositories.Interfaces
         void UpdateParticipantEndDate(int eventParticipantId, DateTime? endDate);
         int UnregisterParticipantForEvent(int participantId, int eventId);
         List<MpEvent> GetEvents(string eventType, string token);
-        List<MpEvent> GetEventsByTypeForRange(int eventTypeId, DateTime startDate, DateTime endDate, string token);
+        List<MpEvent> GetEventsByTypeForRange(int eventTypeId, DateTime startDate, DateTime endDate, string token, bool includeCancelledEvents = true);
         List<MpGroup> GetGroupsForEvent(int eventId);
         int GetEventParticipantRecordId(int eventId, int participantId);
         bool EventHasParticipant(int eventId, int participantId);

--- a/Gateway/crds-angular.test/Services/ServeServiceTest.cs
+++ b/Gateway/crds-angular.test/Services/ServeServiceTest.cs
@@ -604,7 +604,7 @@ namespace crds_angular.test.Services
             _eventService.Verify(
                 m =>
                     m.GetEventsByTypeForRange(eventTypeId, It.IsAny<DateTime>(), It.IsAny<DateTime>(),
-                        It.IsAny<string>()), Times.Exactly(1));
+                        It.IsAny<string>(), It.IsAny<bool>()), Times.Exactly(1));
             _eventService.Verify(m => m.RegisterParticipantForEvent(47, It.IsAny<int>(), 0, 0), Times.Exactly(5));
             _opportunityService.Verify(
                 (m => m.RespondToOpportunity(47, opportunityId, It.IsAny<string>(), It.IsAny<int>(), signUp)),
@@ -682,7 +682,7 @@ namespace crds_angular.test.Services
             _eventService.Verify(
                 m =>
                     m.GetEventsByTypeForRange(eventTypeId, It.IsAny<DateTime>(), It.IsAny<DateTime>(),
-                        It.IsAny<string>()), Times.Exactly(1));
+                        It.IsAny<string>(), It.IsAny<bool>()), Times.Exactly(1));
             _eventService.Verify(m => m.RegisterParticipantForEvent(47, It.IsAny<int>(), 0, 0), Times.Exactly(5));
             _opportunityService.Verify(
                 (m => m.RespondToOpportunity(47, opportunityId, It.IsAny<string>(), It.IsAny<int>(), signUp)),
@@ -887,7 +887,7 @@ namespace crds_angular.test.Services
             _eventService.Verify(
                 m =>
                     m.GetEventsByTypeForRange(eventTypeId, It.IsAny<DateTime>(), It.IsAny<DateTime>(),
-                        It.IsAny<string>()), Times.Exactly(1));
+                        It.IsAny<string>(), It.IsAny<bool>()), Times.Exactly(1));
 
             _eventService.Verify(m => m.RegisterParticipantForEvent(47, It.IsIn<int>(expectedEventIds), 0, 0),
                 Times.Exactly(3));
@@ -1129,7 +1129,7 @@ namespace crds_angular.test.Services
             _eventService.Setup(
                 m =>
                     m.GetEventsByTypeForRange(eventTypeId, It.IsAny<DateTime>(), It.IsAny<DateTime>(),
-                        It.IsAny<string>())).Returns(mockEvents);
+                        It.IsAny<string>(), It.IsAny<bool>())).Returns(mockEvents);
 
             foreach (var mockEvent in mockEvents)
             {


### PR DESCRIPTION
* Replace SOAP call with REST so we can do filtering in the query itself and return less data.