### PR TITLE
US8694: Ignore client API keys in Stripe Webhook Handler

### DIFF
--- a/Gateway/crds-angular.test/controllers/StripeEventControllerTest.cs
+++ b/Gateway/crds-angular.test/controllers/StripeEventControllerTest.cs
@@ -1,15 +1,14 @@
 ﻿using System;
-using System.Messaging;
 using System.Net;
+using System.Reflection;
 using System.Web.Http.Results;
 using crds_angular.Controllers.API;
 using crds_angular.Models.Crossroads.Stewardship;
 using crds_angular.Models.Json;
 using crds_angular.Services;
 using crds_angular.Services.Interfaces;
-using Crossroads.Utilities.Interfaces;
+using Crossroads.ClientApiKeys;
 using Crossroads.Utilities.Messaging.Interfaces;
-using Crossroads.Web.Common;
 using Crossroads.Web.Common.Configuration;
 using Moq;
 using Newtonsoft.Json.Linq;
@@ -104,6 +103,12 @@ namespace crds_angular.test.controllers
             _messageQueueFactory.VerifyAll();
             _messageFactory.VerifyAll();
 
+        }
+
+        [Test]
+        public void TestControllerIgnoresClientApiKeys()
+        {
+            Assert.IsNotNull(_fixture.GetType().GetCustomAttribute<IgnoreClientApiKeyAttribute>(), $"{_fixture.GetType().FullName} should specify the IgnoreClientApiKey Attribute at the class level");
         }
 
         // This test unfortunately does not work, as you cannot mock Message and MessageQueue.

--- a/Gateway/crds-angular/Controllers/API/StripeEventController.cs
+++ b/Gateway/crds-angular/Controllers/API/StripeEventController.cs
@@ -6,15 +6,16 @@ using crds_angular.Services.Interfaces;
 using crds_angular.Models.Crossroads.Stewardship;
 using crds_angular.Models.Json;
 using crds_angular.Services;
-using Crossroads.Utilities.Interfaces;
 using Crossroads.Utilities.Messaging.Interfaces;
 using Crossroads.ApiVersioning;
-using Crossroads.Web.Common;
+using Crossroads.ClientApiKeys;
 using Crossroads.Web.Common.Configuration;
 using MinistryPlatform.Translation.Exceptions;
 
 namespace crds_angular.Controllers.API
 {
+    // Ignore Client API Keys for all methods, since Stripe cannot send custom headers in webhooks
+    [IgnoreClientApiKey]
     public class StripeEventController : ApiController
     {
         private readonly ILog _logger = LogManager.GetLogger(typeof(StripeEventController));
@@ -24,9 +25,6 @@ namespace crds_angular.Controllers.API
         private readonly bool _asynchronous;
         private readonly IStripeEventService _stripeEventService;
 
-        // This value is used when creating the batch name for exporting to GP.  It must be 15 characters or less.
-        private const string BatchNameDateFormat = @"\M\PyyyyMMddHHmm";
-
         public StripeEventController(IConfigurationWrapper configuration, IStripeEventService stripeEventService = null,
             IMessageQueueFactory messageQueueFactory = null, IMessageFactory messageFactory = null)
         {
@@ -35,7 +33,7 @@ namespace crds_angular.Controllers.API
 
             b = configuration.GetConfigValue("StripeWebhookAsynchronousProcessingMode");
             _asynchronous = b != null && bool.Parse(b);
-            if (_asynchronous)
+            if (_asynchronous && messageQueueFactory != null)
             {
                 var eventQueueName = configuration.GetConfigValue("StripeWebhookEventQueueName");
                 _eventQueue = messageQueueFactory.CreateQueue(eventQueueName, QueueAccessMode.Send);
@@ -68,7 +66,7 @@ namespace crds_angular.Controllers.API
                 return (Ok());
             }
 
-            StripeEventResponseDTO response = null;
+            StripeEventResponseDTO response;
             try
             {
                 if (_asynchronous)


### PR DESCRIPTION
* Added [IgnoreClientApiKey] on the stripe webhook handler - Stripe can't send any custom headers, so we need to allow "keyless" requests
* Also cleaned up some ReSharper warnings