### PR TITLE
DE3793 - Mobile iOS Scroll [Hotfix]

### DIFF
--- a/crossroads.net/core/core.run.js
+++ b/crossroads.net/core/core.run.js
@@ -36,6 +36,7 @@
     }
 
     function setupHeader() {
+      $('html, body').removeClass('noscroll');
       // header options
       var options = {
         el: '[data-header]',

--- a/crossroads.net/styles/legacy.scss
+++ b/crossroads.net/styles/legacy.scss
@@ -113,7 +113,11 @@
 }
 
 .noscroll {
-  position: relative;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   height: 100%;
   overflow: hidden;
 }
@@ -140,6 +144,14 @@
   .mobile-menu {
     position: fixed;
     top: 0;
+
+    &.modal {
+      overflow: hidden;
+    }
+
+    .modal-dialog .modal-content {
+      padding-bottom: 5em;
+    }
 
     &:not(.in) {
       .modal-dialog {


### PR DESCRIPTION
Addresses the following defect:

Logged in or out on iOS devices.
The main menu, as well as the menu under My Profile the page only partially loads (you can't scroll) unless you refresh. 

Notes from Tate:
it looks like at some point the class 'noscroll' is getting added to the body. When that happens, the page content is cut off and you can't scroll down the page. From my testing, it seems to show up when you go to the login form. It doesn't matter if you log in or not from that point.

Looking at the legacy.scss file, the .noscroll stuff is right in the file
