### PR TITLE
DE3856 mobile nav click area

### DIFF
--- a/crossroads.net/app/index.html
+++ b/crossroads.net/app/index.html
@@ -155,7 +155,7 @@
 <script type="text/javascript" src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js"></script>
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/svg4everybody/2.1.8/svg4everybody.min.js"></script>
 <script type="text/javascript" src="//cdn.jsdelivr.net/g/mutationobserver"></script>
-<script type="text/javascript" src="//dz6ito7tas43n.cloudfront.net/documents/js/crds-shared-header-v0.4.2.min.js"></script>
+<script type="text/javascript" src="//dz6ito7tas43n.cloudfront.net/documents/js/crds-shared-header-v0.4.3.min.js"></script>
 <!-- build:angjs -->
 <script src="/assets/ang.js"></script>
 <!-- endbuild -->


### PR DESCRIPTION
This PR updates the shared header to it's latest version which resolves [DE3856: Click Area on Mobile Profile Nav](https://rally1.rallydev.com/#/66096747656d/detail/defect/133684844556).

This is related to crdschurch/crds-maestro#181 and crdschurch/crds-shared-header#62.