### PR TITLE
hotfix/DE3956 - Styles Removed on State Change

### DIFF
--- a/crossroads.net/app/routes.content.js
+++ b/crossroads.net/app/routes.content.js
@@ -45,7 +45,7 @@
               if(Session.isActive() && link === "/" ) {
                 link = getPersonalizedContentPath(link);
               }
-              
+
               link = addTrailingSlashIfNecessary(link);
 
               promise = Page.get({ url: link }).$promise;
@@ -165,9 +165,10 @@
                   statusCode: ContentPageService.page.errorCode
                 };
 
-                $rootScope.renderLegacyStyles = (typeof ContentPageService.page.legacyStyles !== 'undefined'
+
+                $rootScope.doRenderLegacyStyles = (typeof ContentPageService.page.legacyStyles !== 'undefined'
                   ? Boolean(parseInt(ContentPageService.page.legacyStyles))
-                  : $rootScope.renderLegacyStyles); // revert to value set on route
+                  : $rootScope.doRenderLegacyStyles); // revert to value set on route
 
                 $rootScope.bodyClasses = [];
                 if (typeof ContentPageService.page.bodyClasses !== 'undefined' && ContentPageService.page.bodyClasses !== null) {

--- a/crossroads.net/app/routes.js
+++ b/crossroads.net/app/routes.js
@@ -26,7 +26,7 @@
           abstract: true,
           template: '<ui-view/>',
           resolve: {
-            Meta: ['SystemPage', '$state', function(SystemPage, $state) {
+            Meta: ['SystemPage', '$state', '$rootScope', function(SystemPage, $state, $rootScope) {
               return SystemPage.get({
                 state: $state.next.name
               }).$promise.then(
@@ -36,7 +36,7 @@
                         $state.next.data = {};
                       }
 
-                      $state.params.renderLegacyStyles = (typeof systemPage.systemPages[0].legacyStyles !== 'undefined'
+                      $rootScope.doRenderLegacyStyles = (typeof systemPage.systemPages[0].legacyStyles !== 'undefined'
                         ? Boolean(parseInt(systemPage.systemPages[0].legacyStyles))
                         : true); // revert to value set on route
 

--- a/crossroads.net/core/core.controller.js
+++ b/crossroads.net/core/core.controller.js
@@ -57,14 +57,12 @@
     $rootScope.$on('$stateChangeStart', function(event, toState, toParams, fromState, fromParams) {
       vm.bodyClasses = {};
       $rootScope.bodyClasses = [];
-
-      if (fromState.url === '^') {
-        $rootScope.renderLegacyStyles = toState.data !== undefined ? toState.data.renderLegacyStyles !== false : true;
-      }
+      delete $rootScope.doRenderLegacyStyles;
 
       // This was removed to fix DE3879. When it was removed, it broke the ability to do a trip deposit.
       if ((toState.resolve !== undefined || (toState.data !== undefined && toState.data.resolve)) && !event.defaultPrevented) {
         vm.resolving = true;
+        $rootScope.renderLegacyStyles = true;
       }
 
       if (fromState.name == 'explore') {
@@ -74,9 +72,12 @@
     });
 
     $rootScope.$on('$stateChangeSuccess', function(event, toState, toParams, fromState, fromParams) {
-      if (typeof fromParams.renderLegacyStyles !== 'undefined') {
-        $rootScope.renderLegacyStyles = fromParams.renderLegacyStyles;
+      if(typeof $rootScope.doRenderLegacyStyles !== 'undefined') {
+        $rootScope.renderLegacyStyles = $rootScope.doRenderLegacyStyles;
+      } else {
+        $rootScope.renderLegacyStyles = toState.data !== undefined ? toState.data.renderLegacyStyles !== false : true;
       }
+
       if (typeof fromParams.bodyClasses !== 'undefined') {
         $rootScope.bodyClasses = fromParams.bodyClasses;
       }


### PR DESCRIPTION
This PR hotfixes the release branch to resolve a style regression in the /profile section of the site, introduced via [DE3879](https://rally1.rallydev.com/#/66096747656d/detail/defect/134433728664?fdp=true). 

Let me know if you have any questions. 