### PR TITLE
DE4021 - Show donations made via directed giving in the Tax Deductible section

### DIFF
--- a/CI/Reports/CRDS ContributionStatement.rdl
+++ b/CI/Reports/CRDS ContributionStatement.rdl
@@ -52,10 +52,6 @@
           <DataField>Statement_ID</DataField>
           <rd:TypeName>System.String</rd:TypeName>
         </Field>
-        <Field Name="Row_No">
-          <DataField>Row_No</DataField>
-          <rd:TypeName>System.Int32</rd:TypeName>
-        </Field>
         <Field Name="Donation_ID">
           <DataField>Donation_ID</DataField>
           <rd:TypeName>System.Int32</rd:TypeName>
@@ -75,10 +71,6 @@
         <Field Name="Non_Deductible_Amount">
           <DataField>Non_Deductible_Amount</DataField>
           <rd:TypeName>System.Decimal</rd:TypeName>
-        </Field>
-        <Field Name="Payment_Type_ID">
-          <DataField>Payment_Type_ID</DataField>
-          <rd:UserDefined>true</rd:UserDefined>
         </Field>
         <Field Name="Deductible_Amount">
           <DataField>Deductible_Amount</DataField>
@@ -124,50 +116,9 @@
           <DataField>Campaign_Name</DataField>
           <rd:TypeName>System.String</rd:TypeName>
         </Field>
-        <Field Name="Section_Title">
-          <DataField>Section_Title</DataField>
-          <rd:TypeName>System.String</rd:TypeName>
-        </Field>
-        <Field Name="Header_Title">
-          <DataField>Header_Title</DataField>
-          <rd:TypeName>System.String</rd:TypeName>
-        </Field>
         <Field Name="Section_Sort">
           <DataField>Section_Sort</DataField>
           <rd:TypeName>System.Int32</rd:TypeName>
-        </Field>
-      </Fields>
-    </DataSet>
-    <DataSet Name="data_Lookup_Statement_Headers">
-      <Query>
-        <DataSourceName>MPReportsDS</DataSourceName>
-        <QueryParameters>
-          <QueryParameter Name="@DomainID">
-            <Value>=Parameters!DomainID.Value</Value>
-          </QueryParameter>
-          <QueryParameter Name="@UserID">
-            <Value>=Parameters!UserID.Value</Value>
-          </QueryParameter>
-          <QueryParameter Name="@PageID">
-            <Value>=Parameters!PageID.Value</Value>
-          </QueryParameter>
-        </QueryParameters>
-        <CommandType>StoredProcedure</CommandType>
-        <CommandText>report_filter_statement_headers</CommandText>
-        <rd:UseGenericDesigner>true</rd:UseGenericDesigner>
-      </Query>
-      <Fields>
-        <Field Name="Statement_Header">
-          <DataField>Statement_Header</DataField>
-          <rd:TypeName>System.String</rd:TypeName>
-        </Field>
-        <Field Name="Statement_Header_ID">
-          <DataField>Statement_Header_ID</DataField>
-          <rd:TypeName>System.Int32</rd:TypeName>
-        </Field>
-        <Field Name="Header_Sort">
-          <DataField>Header_Sort</DataField>
-          <rd:TypeName>System.Byte</rd:TypeName>
         </Field>
       </Fields>
     </DataSet>
@@ -266,7 +217,7 @@
               </TablixColumns>
               <TablixRows>
                 <TablixRow>
-                  <Height>4.22361in</Height>
+                  <Height>5.49444in</Height>
                   <TablixCells>
                     <TablixCell>
                       <CellContents>
@@ -477,7 +428,7 @@
                                     </TablixCells>
                                   </TablixRow>
                                   <TablixRow>
-                                    <Height>1.19045in</Height>
+                                    <Height>1.65045in</Height>
                                     <TablixCells>
                                       <TablixCell>
                                         <CellContents>
@@ -513,7 +464,7 @@
                                                             <Paragraph>
                                                               <TextRuns>
                                                                 <TextRun>
-                                                                  <Value>=Fields!Header_Title.Value</Value>
+                                                                  <Value EvaluationMode="Constant" />
                                                                   <Style>
                                                                     <FontSize>9pt</FontSize>
                                                                   </Style>
@@ -558,7 +509,7 @@
                                                             <Paragraph>
                                                               <TextRuns>
                                                                 <TextRun>
-                                                                  <Value>=Fields!Section_Title.Value</Value>
+                                                                  <Value EvaluationMode="Constant">Tax-Deductible Information:</Value>
                                                                   <Style>
                                                                     <FontSize>12pt</FontSize>
                                                                     <FontWeight>Bold</FontWeight>
@@ -639,7 +590,7 @@
                                                             <Paragraph>
                                                               <TextRuns>
                                                                 <TextRun>
-                                                                  <Value>=IIF(Fields!Section_Title.Value = "Stock Giving:","","Amount")</Value>
+                                                                  <Value EvaluationMode="Constant">Amount</Value>
                                                                   <Style>
                                                                     <FontWeight>Bold</FontWeight>
                                                                   </Style>
@@ -748,7 +699,7 @@
                                                             <Paragraph>
                                                               <TextRuns>
                                                                 <TextRun>
-                                                                  <Value>=Switch(Fields!Section_Title.Value = "Stock Giving:" ,"Stock", Fields!Section_Title.Value = "Tax-Deductible Information:" , "Payment Type" )</Value>
+                                                                  <Value EvaluationMode="Constant">Payment Type</Value>
                                                                   <Style>
                                                                     <FontWeight>Bold</FontWeight>
                                                                   </Style>
@@ -806,7 +757,7 @@
                                                             <Border>
                                                               <Style>None</Style>
                                                             </Border>
-                                                            <BackgroundColor>=IIF(ROWNUMBER("Section_Title_Group") MOD 2, "WHITE", "GAINSBORO")</BackgroundColor>
+                                                            <BackgroundColor>=IIF(ROWNUMBER("TaxDeductable_Row_Group") MOD 2, "WHITE", "GAINSBORO")</BackgroundColor>
                                                             <VerticalAlign>Middle</VerticalAlign>
                                                             <PaddingLeft>2pt</PaddingLeft>
                                                             <PaddingRight>2pt</PaddingRight>
@@ -825,7 +776,7 @@
                                                             <Paragraph>
                                                               <TextRuns>
                                                                 <TextRun>
-                                                                  <Value>=IIF(Fields!Section_Title.Value = "Stock Giving:","",Fields!Amount.Value)</Value>
+                                                                  <Value>=Fields!Amount.Value</Value>
                                                                   <Style>
                                                                     <FontSize>9pt</FontSize>
                                                                     <Format>'$'#,0.00;('$'#,0.00)</Format>
@@ -842,7 +793,7 @@
                                                             <Border>
                                                               <Style>None</Style>
                                                             </Border>
-                                                            <BackgroundColor>=IIF(ROWNUMBER("Section_Title_Group") MOD 2, "WHITE", "GAINSBORO")</BackgroundColor>
+                                                            <BackgroundColor>=IIF(ROWNUMBER("TaxDeductable_Row_Group") MOD 2, "WHITE", "GAINSBORO")</BackgroundColor>
                                                             <VerticalAlign>Middle</VerticalAlign>
                                                             <PaddingLeft>2pt</PaddingLeft>
                                                             <PaddingRight>2pt</PaddingRight>
@@ -873,7 +824,7 @@
                                                             <Border>
                                                               <Style>None</Style>
                                                             </Border>
-                                                            <BackgroundColor>=IIF(ROWNUMBER("Section_Title_Group") MOD 2, "WHITE", "GAINSBORO")</BackgroundColor>
+                                                            <BackgroundColor>=IIF(ROWNUMBER("TaxDeductable_Row_Group") MOD 2, "WHITE", "GAINSBORO")</BackgroundColor>
                                                             <VerticalAlign>Middle</VerticalAlign>
                                                             <PaddingLeft>2pt</PaddingLeft>
                                                             <PaddingRight>2pt</PaddingRight>
@@ -906,7 +857,7 @@
                                                             <Border>
                                                               <Style>None</Style>
                                                             </Border>
-                                                            <BackgroundColor>=IIF(ROWNUMBER("Section_Title_Group") MOD 2, "WHITE", "GAINSBORO")</BackgroundColor>
+                                                            <BackgroundColor>=IIF(ROWNUMBER("TaxDeductable_Row_Group") MOD 2, "WHITE", "GAINSBORO")</BackgroundColor>
                                                             <VerticalAlign>Middle</VerticalAlign>
                                                             <PaddingLeft>2pt</PaddingLeft>
                                                             <PaddingRight>2pt</PaddingRight>
@@ -939,11 +890,181 @@
                                                             <Border>
                                                               <Style>None</Style>
                                                             </Border>
-                                                            <BackgroundColor>=IIF(ROWNUMBER("Section_Title_Group") MOD 2, "WHITE", "GAINSBORO")</BackgroundColor>
+                                                            <BackgroundColor>=IIF(ROWNUMBER("TaxDeductable_Row_Group") MOD 2, "WHITE", "GAINSBORO")</BackgroundColor>
                                                             <VerticalAlign>Middle</VerticalAlign>
                                                             <PaddingLeft>2pt</PaddingLeft>
                                                             <PaddingRight>2pt</PaddingRight>
                                                             <PaddingTop>2pt</PaddingTop>
+                                                            <PaddingBottom>2pt</PaddingBottom>
+                                                          </Style>
+                                                        </Textbox>
+                                                      </CellContents>
+                                                    </TablixCell>
+                                                  </TablixCells>
+                                                </TablixRow>
+                                                <TablixRow>
+                                                  <Height>0.46in</Height>
+                                                  <TablixCells>
+                                                    <TablixCell>
+                                                      <CellContents>
+                                                        <Textbox Name="Textbox8">
+                                                          <CanGrow>true</CanGrow>
+                                                          <KeepTogether>true</KeepTogether>
+                                                          <Paragraphs>
+                                                            <Paragraph>
+                                                              <TextRuns>
+                                                                <TextRun>
+                                                                  <Value>Total:</Value>
+                                                                  <Style>
+                                                                    <FontSize>9pt</FontSize>
+                                                                    <FontWeight>Bold</FontWeight>
+                                                                  </Style>
+                                                                </TextRun>
+                                                              </TextRuns>
+                                                              <Style>
+                                                                <TextAlign>Left</TextAlign>
+                                                              </Style>
+                                                            </Paragraph>
+                                                          </Paragraphs>
+                                                          <rd:DefaultName>Textbox8</rd:DefaultName>
+                                                          <Style>
+                                                            <Border>
+                                                              <Style>None</Style>
+                                                            </Border>
+                                                            <VerticalAlign>Middle</VerticalAlign>
+                                                            <PaddingLeft>2pt</PaddingLeft>
+                                                            <PaddingRight>2pt</PaddingRight>
+                                                            <PaddingTop>20pt</PaddingTop>
+                                                            <PaddingBottom>2pt</PaddingBottom>
+                                                          </Style>
+                                                        </Textbox>
+                                                      </CellContents>
+                                                    </TablixCell>
+                                                    <TablixCell>
+                                                      <CellContents>
+                                                        <Textbox Name="Textbox9">
+                                                          <CanGrow>true</CanGrow>
+                                                          <KeepTogether>true</KeepTogether>
+                                                          <Paragraphs>
+                                                            <Paragraph>
+                                                              <TextRuns>
+                                                                <TextRun>
+                                                                  <Value>=Sum(Fields!Deductible_Amount.Value)</Value>
+                                                                  <Style>
+                                                                    <FontSize>9pt</FontSize>
+                                                                    <FontWeight>Bold</FontWeight>
+                                                                    <Format>'$'#,0.00;('$'#,0.00)</Format>
+                                                                  </Style>
+                                                                </TextRun>
+                                                              </TextRuns>
+                                                              <Style>
+                                                                <TextAlign>Right</TextAlign>
+                                                              </Style>
+                                                            </Paragraph>
+                                                          </Paragraphs>
+                                                          <rd:DefaultName>Textbox9</rd:DefaultName>
+                                                          <Style>
+                                                            <Border>
+                                                              <Style>None</Style>
+                                                            </Border>
+                                                            <VerticalAlign>Middle</VerticalAlign>
+                                                            <PaddingLeft>2pt</PaddingLeft>
+                                                            <PaddingRight>2pt</PaddingRight>
+                                                            <PaddingTop>20pt</PaddingTop>
+                                                            <PaddingBottom>2pt</PaddingBottom>
+                                                          </Style>
+                                                        </Textbox>
+                                                      </CellContents>
+                                                    </TablixCell>
+                                                    <TablixCell>
+                                                      <CellContents>
+                                                        <Textbox Name="Textbox10">
+                                                          <CanGrow>true</CanGrow>
+                                                          <KeepTogether>true</KeepTogether>
+                                                          <Paragraphs>
+                                                            <Paragraph>
+                                                              <TextRuns>
+                                                                <TextRun>
+                                                                  <Value />
+                                                                  <Style />
+                                                                </TextRun>
+                                                              </TextRuns>
+                                                              <Style />
+                                                            </Paragraph>
+                                                          </Paragraphs>
+                                                          <rd:DefaultName>Textbox10</rd:DefaultName>
+                                                          <Style>
+                                                            <Border>
+                                                              <Style>None</Style>
+                                                            </Border>
+                                                            <VerticalAlign>Middle</VerticalAlign>
+                                                            <PaddingLeft>2pt</PaddingLeft>
+                                                            <PaddingRight>2pt</PaddingRight>
+                                                            <PaddingTop>20pt</PaddingTop>
+                                                            <PaddingBottom>2pt</PaddingBottom>
+                                                          </Style>
+                                                        </Textbox>
+                                                      </CellContents>
+                                                    </TablixCell>
+                                                    <TablixCell>
+                                                      <CellContents>
+                                                        <Textbox Name="Textbox11">
+                                                          <CanGrow>true</CanGrow>
+                                                          <KeepTogether>true</KeepTogether>
+                                                          <Paragraphs>
+                                                            <Paragraph>
+                                                              <TextRuns>
+                                                                <TextRun>
+                                                                  <Value />
+                                                                  <Style>
+                                                                    <FontSize>9pt</FontSize>
+                                                                  </Style>
+                                                                </TextRun>
+                                                              </TextRuns>
+                                                              <Style />
+                                                            </Paragraph>
+                                                          </Paragraphs>
+                                                          <rd:DefaultName>Textbox11</rd:DefaultName>
+                                                          <Style>
+                                                            <Border>
+                                                              <Style>None</Style>
+                                                            </Border>
+                                                            <VerticalAlign>Middle</VerticalAlign>
+                                                            <PaddingLeft>2pt</PaddingLeft>
+                                                            <PaddingRight>2pt</PaddingRight>
+                                                            <PaddingTop>20pt</PaddingTop>
+                                                            <PaddingBottom>2pt</PaddingBottom>
+                                                          </Style>
+                                                        </Textbox>
+                                                      </CellContents>
+                                                    </TablixCell>
+                                                    <TablixCell>
+                                                      <CellContents>
+                                                        <Textbox Name="Textbox12">
+                                                          <CanGrow>true</CanGrow>
+                                                          <KeepTogether>true</KeepTogether>
+                                                          <Paragraphs>
+                                                            <Paragraph>
+                                                              <TextRuns>
+                                                                <TextRun>
+                                                                  <Value />
+                                                                  <Style>
+                                                                    <FontSize>9pt</FontSize>
+                                                                  </Style>
+                                                                </TextRun>
+                                                              </TextRuns>
+                                                              <Style />
+                                                            </Paragraph>
+                                                          </Paragraphs>
+                                                          <rd:DefaultName>Textbox12</rd:DefaultName>
+                                                          <Style>
+                                                            <Border>
+                                                              <Style>None</Style>
+                                                            </Border>
+                                                            <VerticalAlign>Middle</VerticalAlign>
+                                                            <PaddingLeft>2pt</PaddingLeft>
+                                                            <PaddingRight>2pt</PaddingRight>
+                                                            <PaddingTop>20pt</PaddingTop>
                                                             <PaddingBottom>2pt</PaddingBottom>
                                                           </Style>
                                                         </Textbox>
@@ -967,9 +1088,9 @@
                                             <TablixRowHierarchy>
                                               <TablixMembers>
                                                 <TablixMember>
-                                                  <Group Name="Section_Title_Group">
+                                                  <Group Name="TaxDeductable_Row_Group">
                                                     <GroupExpressions>
-                                                      <GroupExpression>=Fields!Section_Title.Value</GroupExpression>
+                                                      <GroupExpression>=Fields!Section_Sort.Value</GroupExpression>
                                                     </GroupExpressions>
                                                   </Group>
                                                   <SortExpressions>
@@ -998,6 +1119,9 @@
                                                         </SortExpression>
                                                       </SortExpressions>
                                                     </TablixMember>
+                                                    <TablixMember>
+                                                      <KeepWithGroup>Before</KeepWithGroup>
+                                                    </TablixMember>
                                                   </TablixMembers>
                                                 </TablixMember>
                                               </TablixMembers>
@@ -1008,9 +1132,407 @@
                                             <Filters>
                                               <Filter>
                                                 <FilterExpression>=Fields!Section_Sort.Value</FilterExpression>
-                                                <Operator>NotEqual</Operator>
+                                                <Operator>Equal</Operator>
                                                 <FilterValues>
-                                                  <FilterValue DataType="Integer">4</FilterValue>
+                                                  <FilterValue DataType="Integer">1</FilterValue>
+                                                </FilterValues>
+                                              </Filter>
+                                            </Filters>
+                                            <Style>
+                                              <Border>
+                                                <Style>None</Style>
+                                              </Border>
+                                            </Style>
+                                          </Tablix>
+                                        </CellContents>
+                                      </TablixCell>
+                                    </TablixCells>
+                                  </TablixRow>
+                                  <TablixRow>
+                                    <Height>1.20295in</Height>
+                                    <TablixCells>
+                                      <TablixCell>
+                                        <CellContents>
+                                          <Tablix Name="Stocks_Tablix">
+                                            <TablixBody>
+                                              <TablixColumns>
+                                                <TablixColumn>
+                                                  <Width>0.71467in</Width>
+                                                </TablixColumn>
+                                                <TablixColumn>
+                                                  <Width>1.76449in</Width>
+                                                </TablixColumn>
+                                                <TablixColumn>
+                                                  <Width>5.2493in</Width>
+                                                </TablixColumn>
+                                              </TablixColumns>
+                                              <TablixRows>
+                                                <TablixRow>
+                                                  <Height>0.4125in</Height>
+                                                  <TablixCells>
+                                                    <TablixCell>
+                                                      <CellContents>
+                                                        <Textbox Name="StocksHeaderTitle_Textbox">
+                                                          <CanGrow>true</CanGrow>
+                                                          <KeepTogether>true</KeepTogether>
+                                                          <Paragraphs>
+                                                            <Paragraph>
+                                                              <TextRuns>
+                                                                <TextRun>
+                                                                  <Value>Please contact your accountant to determine your stock donation value and add to your tax deductible total.</Value>
+                                                                  <Style>
+                                                                    <FontSize>9pt</FontSize>
+                                                                  </Style>
+                                                                </TextRun>
+                                                              </TextRuns>
+                                                              <Style>
+                                                                <TextAlign>Left</TextAlign>
+                                                              </Style>
+                                                            </Paragraph>
+                                                          </Paragraphs>
+                                                          <rd:DefaultName>StocksHeaderTitle_Textbox</rd:DefaultName>
+                                                          <RepeatWith>Stocks_Tablix</RepeatWith>
+                                                          <Style>
+                                                            <Border>
+                                                              <Style>None</Style>
+                                                            </Border>
+                                                            <VerticalAlign>Bottom</VerticalAlign>
+                                                            <PaddingLeft>2pt</PaddingLeft>
+                                                            <PaddingRight>2pt</PaddingRight>
+                                                            <PaddingTop>2pt</PaddingTop>
+                                                            <PaddingBottom>2pt</PaddingBottom>
+                                                          </Style>
+                                                        </Textbox>
+                                                        <ColSpan>3</ColSpan>
+                                                      </CellContents>
+                                                    </TablixCell>
+                                                    <TablixCell />
+                                                    <TablixCell />
+                                                  </TablixCells>
+                                                </TablixRow>
+                                                <TablixRow>
+                                                  <Height>0.27045in</Height>
+                                                  <TablixCells>
+                                                    <TablixCell>
+                                                      <CellContents>
+                                                        <Textbox Name="StocksSectionTitle_Textbox">
+                                                          <CanGrow>true</CanGrow>
+                                                          <KeepTogether>true</KeepTogether>
+                                                          <Paragraphs>
+                                                            <Paragraph>
+                                                              <TextRuns>
+                                                                <TextRun>
+                                                                  <Value>Stock Giving:</Value>
+                                                                  <Style>
+                                                                    <FontSize>12pt</FontSize>
+                                                                    <FontWeight>Bold</FontWeight>
+                                                                  </Style>
+                                                                </TextRun>
+                                                              </TextRuns>
+                                                              <Style />
+                                                            </Paragraph>
+                                                          </Paragraphs>
+                                                          <rd:DefaultName>StocksSectionTitle_Textbox</rd:DefaultName>
+                                                          <RepeatWith>Stocks_Tablix</RepeatWith>
+                                                          <Style>
+                                                            <Border>
+                                                              <Style>None</Style>
+                                                            </Border>
+                                                            <VerticalAlign>Middle</VerticalAlign>
+                                                            <PaddingLeft>2pt</PaddingLeft>
+                                                            <PaddingRight>2pt</PaddingRight>
+                                                            <PaddingTop>2pt</PaddingTop>
+                                                            <PaddingBottom>2pt</PaddingBottom>
+                                                          </Style>
+                                                        </Textbox>
+                                                        <ColSpan>3</ColSpan>
+                                                      </CellContents>
+                                                    </TablixCell>
+                                                    <TablixCell />
+                                                    <TablixCell />
+                                                  </TablixCells>
+                                                </TablixRow>
+                                                <TablixRow>
+                                                  <Height>0.27566in</Height>
+                                                  <TablixCells>
+                                                    <TablixCell>
+                                                      <CellContents>
+                                                        <Textbox Name="StocksDateTitle_Textbox">
+                                                          <CanGrow>true</CanGrow>
+                                                          <KeepTogether>true</KeepTogether>
+                                                          <Paragraphs>
+                                                            <Paragraph>
+                                                              <TextRuns>
+                                                                <TextRun>
+                                                                  <Value>Date</Value>
+                                                                  <Style>
+                                                                    <FontWeight>Bold</FontWeight>
+                                                                  </Style>
+                                                                </TextRun>
+                                                              </TextRuns>
+                                                              <Style />
+                                                            </Paragraph>
+                                                          </Paragraphs>
+                                                          <rd:DefaultName>StocksDateTitle_Textbox</rd:DefaultName>
+                                                          <RepeatWith>Stocks_Tablix</RepeatWith>
+                                                          <Style>
+                                                            <Border>
+                                                              <Style>None</Style>
+                                                            </Border>
+                                                            <BottomBorder>
+                                                              <Color>Black</Color>
+                                                              <Style>Solid</Style>
+                                                              <Width>1pt</Width>
+                                                            </BottomBorder>
+                                                            <PaddingLeft>2pt</PaddingLeft>
+                                                            <PaddingRight>2pt</PaddingRight>
+                                                            <PaddingTop>2pt</PaddingTop>
+                                                            <PaddingBottom>2pt</PaddingBottom>
+                                                          </Style>
+                                                        </Textbox>
+                                                      </CellContents>
+                                                    </TablixCell>
+                                                    <TablixCell>
+                                                      <CellContents>
+                                                        <Textbox Name="StocksFillerTitle_Textbox">
+                                                          <CanGrow>true</CanGrow>
+                                                          <KeepTogether>true</KeepTogether>
+                                                          <Paragraphs>
+                                                            <Paragraph>
+                                                              <TextRuns>
+                                                                <TextRun>
+                                                                  <Value />
+                                                                  <Style>
+                                                                    <FontWeight>Bold</FontWeight>
+                                                                  </Style>
+                                                                </TextRun>
+                                                              </TextRuns>
+                                                              <Style>
+                                                                <TextAlign>Right</TextAlign>
+                                                              </Style>
+                                                            </Paragraph>
+                                                          </Paragraphs>
+                                                          <rd:DefaultName>StocksFillerTitle_Textbox</rd:DefaultName>
+                                                          <Style>
+                                                            <Border>
+                                                              <Style>None</Style>
+                                                            </Border>
+                                                            <BottomBorder>
+                                                              <Style>Solid</Style>
+                                                            </BottomBorder>
+                                                            <PaddingLeft>2pt</PaddingLeft>
+                                                            <PaddingRight>2pt</PaddingRight>
+                                                            <PaddingTop>2pt</PaddingTop>
+                                                            <PaddingBottom>2pt</PaddingBottom>
+                                                          </Style>
+                                                        </Textbox>
+                                                      </CellContents>
+                                                    </TablixCell>
+                                                    <TablixCell>
+                                                      <CellContents>
+                                                        <Textbox Name="StocksDescriptionTitle_Textbox">
+                                                          <CanGrow>true</CanGrow>
+                                                          <KeepTogether>true</KeepTogether>
+                                                          <Paragraphs>
+                                                            <Paragraph>
+                                                              <TextRuns>
+                                                                <TextRun>
+                                                                  <Value>Stock</Value>
+                                                                  <Style>
+                                                                    <FontWeight>Bold</FontWeight>
+                                                                  </Style>
+                                                                </TextRun>
+                                                              </TextRuns>
+                                                              <Style />
+                                                            </Paragraph>
+                                                          </Paragraphs>
+                                                          <rd:DefaultName>StocksDescriptionTitle_Textbox</rd:DefaultName>
+                                                          <RepeatWith>Stocks_Tablix</RepeatWith>
+                                                          <Style>
+                                                            <Border>
+                                                              <Style>None</Style>
+                                                            </Border>
+                                                            <BottomBorder>
+                                                              <Color>Black</Color>
+                                                              <Style>Solid</Style>
+                                                              <Width>1pt</Width>
+                                                            </BottomBorder>
+                                                            <PaddingLeft>2pt</PaddingLeft>
+                                                            <PaddingRight>2pt</PaddingRight>
+                                                            <PaddingTop>2pt</PaddingTop>
+                                                            <PaddingBottom>2pt</PaddingBottom>
+                                                          </Style>
+                                                        </Textbox>
+                                                      </CellContents>
+                                                    </TablixCell>
+                                                  </TablixCells>
+                                                </TablixRow>
+                                                <TablixRow>
+                                                  <Height>0.24434in</Height>
+                                                  <TablixCells>
+                                                    <TablixCell>
+                                                      <CellContents>
+                                                        <Textbox Name="StocksDonation_Date">
+                                                          <CanGrow>true</CanGrow>
+                                                          <KeepTogether>true</KeepTogether>
+                                                          <Paragraphs>
+                                                            <Paragraph>
+                                                              <TextRuns>
+                                                                <TextRun>
+                                                                  <Value>=Format(Fields!Donation_Date.Value, "MM/dd/yyyy")</Value>
+                                                                  <Style>
+                                                                    <FontSize>9pt</FontSize>
+                                                                  </Style>
+                                                                </TextRun>
+                                                              </TextRuns>
+                                                              <Style>
+                                                                <TextAlign>Left</TextAlign>
+                                                              </Style>
+                                                            </Paragraph>
+                                                          </Paragraphs>
+                                                          <rd:DefaultName>StocksDonation_Date</rd:DefaultName>
+                                                          <Style>
+                                                            <Border>
+                                                              <Style>None</Style>
+                                                            </Border>
+                                                            <BackgroundColor>=IIF(ROWNUMBER("Stocks_Row_Group") MOD 2, "WHITE", "GAINSBORO")</BackgroundColor>
+                                                            <VerticalAlign>Middle</VerticalAlign>
+                                                            <PaddingLeft>2pt</PaddingLeft>
+                                                            <PaddingRight>2pt</PaddingRight>
+                                                            <PaddingTop>2pt</PaddingTop>
+                                                            <PaddingBottom>2pt</PaddingBottom>
+                                                          </Style>
+                                                        </Textbox>
+                                                      </CellContents>
+                                                    </TablixCell>
+                                                    <TablixCell>
+                                                      <CellContents>
+                                                        <Textbox Name="StocksFiller_Textbox">
+                                                          <CanGrow>true</CanGrow>
+                                                          <KeepTogether>true</KeepTogether>
+                                                          <Paragraphs>
+                                                            <Paragraph>
+                                                              <TextRuns>
+                                                                <TextRun>
+                                                                  <Value />
+                                                                  <Style>
+                                                                    <FontSize>9pt</FontSize>
+                                                                  </Style>
+                                                                </TextRun>
+                                                              </TextRuns>
+                                                              <Style>
+                                                                <TextAlign>Right</TextAlign>
+                                                              </Style>
+                                                            </Paragraph>
+                                                          </Paragraphs>
+                                                          <rd:DefaultName>StocksFiller_Textbox</rd:DefaultName>
+                                                          <Style>
+                                                            <Border>
+                                                              <Style>None</Style>
+                                                            </Border>
+                                                            <BackgroundColor>=IIF(ROWNUMBER("Stocks_Row_Group") MOD 2, "WHITE", "GAINSBORO")</BackgroundColor>
+                                                            <VerticalAlign>Middle</VerticalAlign>
+                                                            <PaddingLeft>2pt</PaddingLeft>
+                                                            <PaddingRight>2pt</PaddingRight>
+                                                            <PaddingTop>2pt</PaddingTop>
+                                                            <PaddingBottom>2pt</PaddingBottom>
+                                                          </Style>
+                                                        </Textbox>
+                                                      </CellContents>
+                                                    </TablixCell>
+                                                    <TablixCell>
+                                                      <CellContents>
+                                                        <Textbox Name="StocksDonation_Description">
+                                                          <CanGrow>true</CanGrow>
+                                                          <KeepTogether>true</KeepTogether>
+                                                          <Paragraphs>
+                                                            <Paragraph>
+                                                              <TextRuns>
+                                                                <TextRun>
+                                                                  <Value>=Fields!Payment_Type.Value</Value>
+                                                                  <Style>
+                                                                    <FontSize>9pt</FontSize>
+                                                                  </Style>
+                                                                </TextRun>
+                                                              </TextRuns>
+                                                              <Style />
+                                                            </Paragraph>
+                                                          </Paragraphs>
+                                                          <rd:DefaultName>StocksDonation_Description</rd:DefaultName>
+                                                          <Style>
+                                                            <Border>
+                                                              <Style>None</Style>
+                                                            </Border>
+                                                            <BackgroundColor>=IIF(ROWNUMBER("Stocks_Row_Group") MOD 2, "WHITE", "GAINSBORO")</BackgroundColor>
+                                                            <VerticalAlign>Middle</VerticalAlign>
+                                                            <PaddingLeft>2pt</PaddingLeft>
+                                                            <PaddingRight>2pt</PaddingRight>
+                                                            <PaddingTop>2pt</PaddingTop>
+                                                            <PaddingBottom>2pt</PaddingBottom>
+                                                          </Style>
+                                                        </Textbox>
+                                                      </CellContents>
+                                                    </TablixCell>
+                                                  </TablixCells>
+                                                </TablixRow>
+                                              </TablixRows>
+                                            </TablixBody>
+                                            <TablixColumnHierarchy>
+                                              <TablixMembers>
+                                                <TablixMember />
+                                                <TablixMember />
+                                                <TablixMember>
+                                                  <KeepTogether>true</KeepTogether>
+                                                </TablixMember>
+                                              </TablixMembers>
+                                            </TablixColumnHierarchy>
+                                            <TablixRowHierarchy>
+                                              <TablixMembers>
+                                                <TablixMember>
+                                                  <Group Name="Stocks_Row_Group">
+                                                    <GroupExpressions>
+                                                      <GroupExpression>=Fields!Section_Sort.Value</GroupExpression>
+                                                    </GroupExpressions>
+                                                  </Group>
+                                                  <SortExpressions>
+                                                    <SortExpression>
+                                                      <Value>=Fields!Section_Sort.Value</Value>
+                                                    </SortExpression>
+                                                  </SortExpressions>
+                                                  <TablixMembers>
+                                                    <TablixMember>
+                                                      <KeepWithGroup>After</KeepWithGroup>
+                                                      <RepeatOnNewPage>true</RepeatOnNewPage>
+                                                    </TablixMember>
+                                                    <TablixMember>
+                                                      <KeepWithGroup>After</KeepWithGroup>
+                                                      <RepeatOnNewPage>true</RepeatOnNewPage>
+                                                    </TablixMember>
+                                                    <TablixMember>
+                                                      <KeepWithGroup>After</KeepWithGroup>
+                                                      <RepeatOnNewPage>true</RepeatOnNewPage>
+                                                    </TablixMember>
+                                                    <TablixMember>
+                                                      <Group Name="StocksGroup1" />
+                                                      <SortExpressions>
+                                                        <SortExpression>
+                                                          <Value>=Fields!Donation_Date.Value</Value>
+                                                        </SortExpression>
+                                                      </SortExpressions>
+                                                    </TablixMember>
+                                                  </TablixMembers>
+                                                </TablixMember>
+                                              </TablixMembers>
+                                            </TablixRowHierarchy>
+                                            <RepeatColumnHeaders>true</RepeatColumnHeaders>
+                                            <RepeatRowHeaders>true</RepeatRowHeaders>
+                                            <DataSetName>data_Main</DataSetName>
+                                            <Filters>
+                                              <Filter>
+                                                <FilterExpression>=Fields!Section_Sort.Value</FilterExpression>
+                                                <Operator>Equal</Operator>
+                                                <FilterValues>
+                                                  <FilterValue DataType="Integer">2</FilterValue>
                                                 </FilterValues>
                                               </Filter>
                                             </Filters>
@@ -1037,6 +1559,9 @@
                                   <TablixMember>
                                     <RepeatOnNewPage>true</RepeatOnNewPage>
                                   </TablixMember>
+                                  <TablixMember>
+                                    <RepeatOnNewPage>true</RepeatOnNewPage>
+                                  </TablixMember>
                                 </TablixMembers>
                               </TablixRowHierarchy>
                               <RepeatColumnHeaders>true</RepeatColumnHeaders>
@@ -1044,7 +1569,7 @@
                               <DataSetName>data_Main</DataSetName>
                               <Top>0.01389in</Top>
                               <Left>0.02154in</Left>
-                              <Height>3.19045in</Height>
+                              <Height>4.8534in</Height>
                               <Width>7.72846in</Width>
                               <Style>
                                 <Border>
@@ -1052,78 +1577,6 @@
                                 </Border>
                               </Style>
                             </Tablix>
-                            <Textbox Name="TotalAmount2">
-                              <KeepTogether>true</KeepTogether>
-                              <Paragraphs>
-                                <Paragraph>
-                                  <TextRuns>
-                                    <TextRun>
-                                      <Value>=Sum(Fields!Deductible_Amount.Value)</Value>
-                                      <Style>
-                                        <FontSize>9pt</FontSize>
-                                        <FontWeight>Bold</FontWeight>
-                                        <Format>C</Format>
-                                      </Style>
-                                    </TextRun>
-                                  </TextRuns>
-                                  <Style>
-                                    <TextAlign>Right</TextAlign>
-                                  </Style>
-                                </Paragraph>
-                              </Paragraphs>
-                              <Top>3.475in</Top>
-                              <Left>0.76399in</Left>
-                              <Height>0.25in</Height>
-                              <Width>1.33671in</Width>
-                              <ZIndex>1</ZIndex>
-                              <Style>
-                                <Border>
-                                  <Color>LightGrey</Color>
-                                  <Style>None</Style>
-                                </Border>
-                                <VerticalAlign>Bottom</VerticalAlign>
-                                <PaddingLeft>2pt</PaddingLeft>
-                                <PaddingRight>2pt</PaddingRight>
-                                <PaddingTop>2pt</PaddingTop>
-                                <PaddingBottom>2pt</PaddingBottom>
-                              </Style>
-                            </Textbox>
-                            <Textbox Name="GrandTotal_Label">
-                              <KeepTogether>true</KeepTogether>
-                              <Paragraphs>
-                                <Paragraph>
-                                  <TextRuns>
-                                    <TextRun>
-                                      <Value EvaluationMode="Constant">Total:</Value>
-                                      <Style>
-                                        <FontSize>9pt</FontSize>
-                                        <FontWeight>Bold</FontWeight>
-                                      </Style>
-                                    </TextRun>
-                                  </TextRuns>
-                                  <Style>
-                                    <TextAlign>Left</TextAlign>
-                                  </Style>
-                                </Paragraph>
-                              </Paragraphs>
-                              <rd:DefaultName>GrandTotal_Label</rd:DefaultName>
-                              <Top>3.475in</Top>
-                              <Left>0.02718in</Left>
-                              <Height>0.25in</Height>
-                              <Width>0.68125in</Width>
-                              <ZIndex>2</ZIndex>
-                              <Style>
-                                <Border>
-                                  <Color>LightGrey</Color>
-                                  <Style>None</Style>
-                                </Border>
-                                <VerticalAlign>Bottom</VerticalAlign>
-                                <PaddingLeft>2pt</PaddingLeft>
-                                <PaddingRight>2pt</PaddingRight>
-                                <PaddingTop>2pt</PaddingTop>
-                                <PaddingBottom>2pt</PaddingBottom>
-                              </Style>
-                            </Textbox>
                             <Tablix Name="CampaignContributions">
                               <TablixBody>
                                 <TablixColumns>
@@ -1133,11 +1586,11 @@
                                 </TablixColumns>
                                 <TablixRows>
                                   <TablixRow>
-                                    <Height>0.46667in</Height>
+                                    <Height>0.6in</Height>
                                     <TablixCells>
                                       <TablixCell>
                                         <CellContents>
-                                          <Textbox Name="Deductible_Amount1">
+                                          <Textbox Name="CampaignDetail_Textbox">
                                             <CanGrow>true</CanGrow>
                                             <KeepTogether>true</KeepTogether>
                                             <Paragraphs>
@@ -1154,7 +1607,7 @@
                                                 </Style>
                                               </Paragraph>
                                             </Paragraphs>
-                                            <rd:DefaultName>Deductible_Amount1</rd:DefaultName>
+                                            <rd:DefaultName>CampaignDetail_Textbox</rd:DefaultName>
                                             <Style>
                                               <Border>
                                                 <Color>LightGrey</Color>
@@ -1162,7 +1615,7 @@
                                               </Border>
                                               <PaddingLeft>2pt</PaddingLeft>
                                               <PaddingRight>2pt</PaddingRight>
-                                              <PaddingTop>16pt</PaddingTop>
+                                              <PaddingTop>24pt</PaddingTop>
                                               <PaddingBottom>2pt</PaddingBottom>
                                             </Style>
                                           </Textbox>
@@ -1194,10 +1647,10 @@
                                   </FilterValues>
                                 </Filter>
                               </Filters>
-                              <Top>3.75694in</Top>
-                              <Height>0.46667in</Height>
+                              <Top>4.89444in</Top>
+                              <Height>0.6in</Height>
                               <Width>7.75in</Width>
-                              <ZIndex>3</ZIndex>
+                              <ZIndex>1</ZIndex>
                               <Visibility>
                                 <Hidden>=Iif (CountRows() &gt; 0, false, true)</Hidden>
                               </Visibility>
@@ -1249,7 +1702,7 @@
             <FixedColumnHeaders>true</FixedColumnHeaders>
             <FixedRowHeaders>true</FixedRowHeaders>
             <DataSetName>data_Main</DataSetName>
-            <Height>4.22361in</Height>
+            <Height>5.49444in</Height>
             <Width>7.77in</Width>
             <Style>
               <Border>
@@ -1258,7 +1711,7 @@
             </Style>
           </Tablix>
         </ReportItems>
-        <Height>4.22361in</Height>
+        <Height>5.49444in</Height>
         <Style />
       </Body>
       <Width>7.77986in</Width>

--- a/CI/Reports/CRDS ContributionStatement.rdl
+++ b/CI/Reports/CRDS ContributionStatement.rdl
@@ -1337,7 +1337,7 @@
                                                             <Paragraph>
                                                               <TextRuns>
                                                                 <TextRun>
-                                                                  <Value>Stock</Value>
+                                                                  <Value>Stock Description</Value>
                                                                   <Style>
                                                                     <FontWeight>Bold</FontWeight>
                                                                   </Style>

--- a/CI/SQL/20170805_122800_DE4021-fix-paper-statements.sql
+++ b/CI/SQL/20170805_122800_DE4021-fix-paper-statements.sql
@@ -1,0 +1,503 @@
+﻿USE [MinistryPlatform]
+GO
+
+-- Created 4/6/2017 for Paper Statements
+
+ALTER PROCEDURE [dbo].[report_CRDS_Donor_Contribution_Statement] (
+    @UserID varchar(40), 
+	@FromDate DateTime,
+	@ToDate DateTime,
+	@AccountingCompanyID Int,
+	@Congregations varchar(max),
+	@Campaigns varchar(max),
+	@PageID Int,
+    @SelectionID Int = 0
+)
+AS
+
+/* 
+   Overview: 
+     .5 #Selected contains the Statement_ID for the selected donors (this has to work for co-givers)
+	 1. #Donations is all deposited donations, filter here for fromdate and todate
+	 2. #D is the list of all the donors from #Donations, filter here for congregation (can't filter by selection here in case they selected a co-giver)
+	 3. #Donors is #D with duplicates removed, and filtered here for selected donors
+	 4. #Pledges is the basic info for all pledges, filter here by Campaigns 
+	 5. #PledgeTotals will contain the sum of all contributions for pledges in #Pledges
+	 6. #PledgeDataFilter is #PledgeTotals filtered to only include data for donors in #Donors 
+	 7. #Gifts prettifies the data
+	 8  And then we select from #Gifts union #PledgeTotals 
+   
+   Modifications:
+	6/5 KD: Added page id and selection id to run for specific donors. Unfortunately we can't do this on donations - it has to be on donors
+	6/6 KD: Remove all the soft credit donor stuff
+	6/21 NT: Added sorting by postcode
+	6/28 NT: Taking out the issue with a combination of family and individual statements in one household with pledges
+	8/5 CB: Fix issues DE4021, DE4027, DE4028, and DE4042
+*/
+
+--For Testing 
+/*
+Declare @UserID varchar(40) = '00000000-0000-0000-0000-000000000000';
+Declare @FromDate DateTime = '20170101'
+Declare	@ToDate DateTime = '20170630'
+Declare	@AccountingCompanyID Int = 1 --Crossroads
+Declare @Campaigns varchar(max) = '1103,60' --Oakley
+Declare @Congregations varchar(max) = '1' --Oakley
+Declare @PageID INT = 299 --Donors
+DECLARE @SelectionID INT = 0
+*/
+BEGIN
+	DECLARE @DomainID INT = 1
+
+	SET NOCOUNT ON
+	SET FMTONLY OFF
+
+	-- Normalize dates to remove time and ensure end date is inclusive
+	SET @FromDate = CONVERT(DATE, @FromDate)
+	SET @ToDate = CONVERT(DATE, @ToDate + 1)
+
+	CREATE TABLE #Congregations (Congregation_ID INT)
+	INSERT INTO #Congregations SELECT item FROM dp_Split(@Congregations, ',')
+
+	CREATE TABLE #Campaigns (Campaign_ID INT)
+	INSERT INTO #Campaigns SELECT item FROM dp_Split(@Campaigns, ',')
+
+	CREATE TABLE #Selections (Statement_ID VARCHAR(15))
+	INSERT INTO #Selections
+	        SELECT CASE WHEN C.Household_ID IS NULL OR D.Statement_Type_ID = 1 THEN 'C' + CONVERT(VARCHAR(10),C.Contact_ID) ELSE 'F' + CONVERT(VARCHAR(10),C.Household_ID) END
+			FROM dp_Selected_Records SR 
+			INNER JOIN dp_Selections S ON S.Selection_ID = SR.Selection_ID  
+			INNER JOIN dbo.dp_Users U ON U.[User_ID] = S.[User_ID] AND U.User_GUID = @UserID 
+			INNER JOIN Donors D ON SR.record_id = D.Donor_ID
+			INNER JOIN Contacts C ON D.Contact_ID = C.Contact_ID
+			WHERE S.Page_ID = @PageID 
+				AND (    (S.Selection_ID = @SelectionID AND @SelectionID > 0) 
+						OR (S.Selection_Name = 'dp_DEFAULT' AND @SelectionID < 1 AND S.Sub_Page_ID IS NULL)
+					)
+					
+	--creating #Donations to use indexing
+	--#Donations holds all deposited donations within the specified time range
+	CREATE TABLE #Donations (
+		Donation_ID INT
+		, Donor_ID INT 
+		, Donation_Amount Money
+		, Donation_Date Datetime
+		, Payment_Type_ID INT
+		, Item_Number VARCHAR(15)		
+		, Is_Recurring_Gift BIT
+		, Notes NVARCHAR(500));
+
+	INSERT INTO #Donations (
+		Donation_ID 
+		, Donor_ID 
+		, Donation_Amount 
+		, Donation_Date
+		, Payment_Type_ID
+		, Item_Number		
+		, Is_Recurring_Gift
+		, Notes )
+	SELECT 
+		Donation_ID
+		, Donor_ID
+		, Donation_Amount
+		, Donation_Date
+		, Payment_Type_ID
+		, Item_Number
+		, Is_Recurring_Gift
+		, Notes
+	FROM
+		Donations
+	WHERE 
+		(Donation_Date >= @FromDate AND Donation_Date < @ToDate)
+		AND Donation_Status_ID = 2;  --deposited
+
+	CREATE INDEX IX_Donations_DonationID ON #Donations(Donation_ID); --#Donation table Index
+
+	--#D is going to hold a list of donors. The statement id will be the same for donors within families and diff for individuals. 
+	CREATE TABLE #D (
+		Donor_ID INT
+		, Contact_ID INT
+		, Statement_ID VARCHAR(15)
+		, Contact_Or_Household_ID INT
+		, Statement_Type_ID INT
+		, Statement_Method_ID INT
+		, Statement_Frequency_ID INT
+	);
+
+	INSERT INTO #D (
+		Donor_ID
+		, Contact_ID
+		, Statement_ID
+		, Contact_Or_Household_ID
+		, Statement_Type_ID 
+		, Statement_Method_ID
+		, Statement_Frequency_ID
+	)
+	SELECT   -- Finds Donor with atleast 1 Donation made between from date and To date
+		Do.Donor_ID
+		, Do.Contact_ID
+		, Statement_ID = CASE WHEN C.Household_ID IS NULL OR Do.Statement_Type_ID = 1 THEN 'C' + CONVERT(VARCHAR(10),C.Contact_ID) ELSE 'F' + CONVERT(VARCHAR(10),C.Household_ID) END
+		, Contact_Or_Household_ID = CASE WHEN C.Household_ID IS NULL OR Do.Statement_Type_ID = 1 THEN C.Contact_ID ELSE C.Household_ID END
+		, Do.Statement_Type_ID 
+		, Do.Statement_Method_ID
+		, Do.Statement_Frequency_ID
+	FROM
+		Donors Do
+		INNER JOIN Contacts C ON C.Contact_ID = Do.Contact_ID
+		LEFT JOIN Households H ON C.Household_ID = H.Household_ID
+		INNER JOIN #Congregations cong ON COALESCE(H.Congregation_ID, 5) = cong.Congregation_ID   -- 5 = Not site specific
+	WHERE --Using EXISTS instead of JOIN because we only want one row per donor and #Donations will have one row for each donation
+		EXISTS ( 
+			SELECT 1
+			FROM #Donations D
+			WHERE D.Donor_ID = Do.Donor_ID 
+		)
+
+
+
+    /*  UNION  US8143 No more soft credit
+
+	SELECT -- Finds soft credit donors with at least 1 soft credit donation between from date and to date
+		DD.Soft_Credit_Donor
+		, Do.Contact_ID		
+		, Statement_ID = CASE WHEN C.Household_ID IS NULL OR Do.Statement_Type_ID = 1 THEN 'C' + CONVERT(VARCHAR(10),C.Contact_ID) ELSE 'F' + CONVERT(VARCHAR(10),C.Household_ID) END
+		, Contact_Or_Household_ID = CASE WHEN C.Household_ID IS NULL OR Do.Statement_Type_ID = 1 THEN C.Contact_ID ELSE C.Household_ID END	
+		, Do.Statement_Type_ID 
+		, Do.Statement_Method_ID
+		, Do.Statement_Frequency_ID
+	FROM
+		Donation_Distributions DD
+		INNER JOIN Donors Do ON Do.Donor_ID = DD.Soft_Credit_Donor
+		INNER JOIN Contacts C ON C.Contact_ID = Do.Contact_ID
+		INNER JOIN Households H ON C.Household_ID = H.Household_ID
+		INNER JOIN #Congregations cong ON H.Congregation_ID = cong.Congregation_ID
+	WHERE
+		 EXISTS ( --Using EXISTS instead of JOIN because we only want one row per donor and #Donations will have one row for each donation
+			SELECT 1
+			FROM #Donations D
+			JOIN Donation_Distributions DD ON DD.Donation_ID = D.Donation_ID
+			WHERE DD.Soft_Credit_Donor IS NOT NULL AND DD.Soft_Credit_Donor = Do.Donor_ID 
+		);
+	*/
+
+	CREATE INDEX IX_D_DonorID ON #D(Donor_ID);
+
+	--#DONORS is the same as #D but removing duplicates (if you donated regular and soft credit) and removing donors who don't get a statement
+	CREATE TABLE #DONORS (
+		Donor_ID INT,
+		Contact_ID INT,
+		Statement_ID VARCHAR(15),
+		Statement_Type_ID INT,
+		Contact_Or_Household_ID INT,
+		Mail_Name VARCHAR(1000),
+		Address_Line_1 VARCHAR(1000),
+		Apt_or_Suite  VARCHAR(1000),
+		City VARCHAR(50),
+		[State] VARCHAR(50),
+		Postal_Code VARCHAR(15)
+	);
+
+	INSERT INTO #DONORS
+	SELECT DISTINCT
+		#D.Donor_ID
+		, #D.Contact_ID
+		, #D.Statement_ID
+		, #D.Statement_Type_ID
+		, #D.Contact_Or_Household_ID
+		, Mail_Name = CASE WHEN C.Company = 1 THEN C.Display_Name
+						--Show all names with individual statements US7181
+						WHEN #D.Statement_Type_ID = 1 THEN C.First_Name + SPACE(1) + C.Last_Name
+						WHEN CNT.num < 2 AND C.Household_Position_id = 2  THEN SP.First_Name + Space(1) + SP.Last_Name
+						WHEN SP.Last_Name <> C.Last_Name AND CNT.num < 2 THEN C.First_Name + SPACE(1) + C.Last_Name + ' & ' + SP.First_Name + SPACE(1) + Sp.Last_Name
+						WHEN SP.Gender_ID < C.Gender_ID AND CNT.num < 2 THEN ISNULL(SP.First_Name + ' & ','') + C.First_Name + Space(1) + C.Last_Name
+						WHEN CNT.num >= 2 AND C.Household_Position_ID = 1 THEN STUFF(REPLACE((SELECT '#!' + LTRIM(RTRIM(co.first_name + ' '+ co.last_name)) AS 'data()' FROM contacts co WHERE #D.Statement_Type_ID = 2 AND C.Household_ID = co.Household_ID AND co.Household_Position_ID =1 FOR XML PATH('')),' #!',' & '), 1, 2, '')
+	    				WHEN CNT.num = 2 AND CountLast.sameLast = 2 AND C.Household_Position_id = 2 THEN CONCAT((STUFF(REPLACE((SELECT '#!' + LTRIM(RTRIM(co.first_name)) AS 'data()' FROM contacts co WHERE #D.Statement_Type_ID = 2 AND C.Household_ID = co.Household_ID AND co.Household_Position_ID =1 FOR XML PATH('')),' #!',' & '), 1, 2, '')),' ',(SELECT TOP 1 Last_Name FROM Contacts con WHERE #D.Statement_Type_ID = 2 AND C.Household_ID = con.Household_ID AND con.Household_Position_ID =1))
+						ELSE ISNULL(C.First_Name + ISNULL(' & ' + SP.First_Name,'') + SPACE(1) + C.Last_Name, C.Display_Name) END
+		, A.Address_Line_1
+		, A.Address_Line_2 Apt_or_Suite
+		, A.City
+		, A.[State/Region] AS [State]
+		, A.Postal_Code
+	FROM #D 
+		INNER JOIN Contacts C ON C.Contact_ID = #D.Contact_ID
+		OUTER APPLY (SELECT Count(*) as num FROM Contacts S WHERE #D.Statement_Type_ID = 2 AND S.Household_ID = C.Household_ID AND C.Contact_ID <> S.Contact_ID AND S.Household_Position_ID = 1) CNT -- head of house holds count
+		OUTER APPLY (SELECT Top 1 Contact_ID, Household_ID, Last_Name, Nickname, First_Name, Gender_ID FROM Contacts S WHERE #D.Statement_Type_ID = 2 AND S.Household_ID = C.Household_ID AND C.Contact_ID <> S.Contact_ID AND S.Household_Position_ID = 1) SP --Select top 1 other HoH that's not donor
+		OUTER APPLY (SELECT Count(Last_Name) as sameLast From Contacts CTS WHERE CTS.Last_Name in (SELECT TS.Last_Name from Contacts TS group by TS.Last_Name having count(TS.Last_Name ) > 1) AND CTS.Household_ID = C.Household_ID AND  CTS.household_position_id = 1) CountLast -- head of households with same last name count
+		LEFT OUTER JOIN Households H ON H.Household_ID = C.Household_ID
+		LEFT OUTER JOIN Addresses A ON A.Address_ID = H.Address_ID
+	WHERE 
+		 Statement_Method_ID <> 4		-- No Statement Needed
+		 AND Statement_Frequency_ID <> 3		-- Never
+		 AND (@SelectionID = 0 
+		      OR EXISTS ( 
+		       SELECT 1
+			   FROM #Selections S
+			   WHERE S.Statement_ID = #D.Statement_ID 
+		       )
+			)
+	ORDER BY Donor_ID;
+
+	CREATE INDEX IX_DONORS_DonorID ON #DONORS(Donor_ID);
+
+	--Handle Campaign Pledges 
+	--getting all of them so we can handle spouse, children, etc
+	--#Pledges will hold all information about pledges all campaigns in the list
+	CREATE TABLE #Pledges (Donor_ID INT, Pledge_ID INT, Pledge_Campaign_ID INT, Total_Pledge money, Campaign_Name varchar (50) )
+	INSERT INTO #Pledges
+	SELECT Donor_ID, p.Pledge_ID, p.Pledge_Campaign_id, p.Total_Pledge, c.Campaign_Name
+	FROM Pledges p
+	INNER JOIN Pledge_Campaigns c on p.Pledge_Campaign_ID = c.Pledge_Campaign_ID
+	WHERE p.Pledge_Campaign_ID in (SELECT Campaign_ID FROM #Campaigns) 
+	AND p.Pledge_Status_ID in (1,2) --only report on active or completed pledges
+
+	--#PledgeTotals holds all pledge totals for the campaign
+	CREATE TABLE #PledgeTotals (Pledge_ID INT, Pledge_Owner INT, Total_Pledge money, Sum_Donations_ForPledge money,Campaign_Name varchar (50))	  
+	--#PledgeData will hold all information about pledges for any statement_id in the list
+	CREATE TABLE #PledgeData (
+		Pledge_ID INT,
+		Total_Pledge money,
+		Sum_Donations_ForPledge money,
+		Statement_ID VARCHAR(15),
+		Postal_Code NVARCHAR(15),
+		Campaign_Name varchar (50)
+	)
+	
+	--If they selected none in the list we aren't going to give them any even if they selected other ones
+	IF NOT EXISTS (Select 1 from #Campaigns where campaign_id = 0)
+	BEGIN
+
+	  --We can't join on donors yet because we want all donations for the pledge regardless of the donor
+	
+	  INSERT INTO #PledgeTotals 
+	  SELECT p.Pledge_ID, p.Donor_ID, p.Total_Pledge, SUM (dd.amount),p.campaign_name
+	  FROM #Pledges p
+	  LEFT JOIN Donation_Distributions dd ON dd.Pledge_ID =p.Pledge_ID
+	  LEFT JOIN Donations d ON dd.Donation_ID = d.Donation_ID
+	  WHERE Pledge_Campaign_ID in (SELECT Campaign_ID from #Campaigns)
+	  AND (d.Donation_Status_ID = 2 OR d.Donation_Status_ID IS NULL) --deposited only or there are no donations
+	  GROUP BY p.Pledge_ID, p.Donor_ID, p.Total_Pledge, p.campaign_name
+	  
+	  	--select * from #PledgeTotals where pledge_owner = 7557276
+
+	  --get the statement_id for the pledge the same way as we got it for the #Gifts and sum the donations for the pledge
+	  --using distinct instead of exists because it's waaaayyy faster 21 seconds vs > 3 minutes when I killed it
+	  
+	  INSERT INTO #PledgeData
+	  SELECT distinct
+	    pt.Pledge_ID,
+		pt.Total_Pledge, 
+		pt.Sum_Donations_ForPledge, 
+		Statement_ID = CASE WHEN C.Household_ID IS NULL OR d.Statement_Type_ID = 1 THEN 'C' + CONVERT(VARCHAR(10),C.Contact_ID) ELSE 'F' + CONVERT(VARCHAR(10),C.Household_ID) END,
+		a.Postal_Code,
+		pt.Campaign_Name
+      FROM #PledgeTotals pt
+      INNER JOIN Donors d ON d.Donor_ID = pt.Pledge_Owner
+	  INNER JOIN Contacts c ON d.Contact_ID = c.Contact_ID
+	  INNER JOIN #Donors fd ON fd.Contact_Or_Household_ID = 
+		    CASE WHEN (fd.Statement_Type_ID = 1 AND d.Statement_Type_ID = 1) THEN c.Contact_ID
+	        WHEN (fd.Statement_Type_ID = 2 AND d.Statement_Type_ID = 2) THEN c.Household_ID	
+			ELSE 1 --leave them off
+			END
+	  LEFT JOIN Households h ON h.Household_ID = c.Household_ID
+	  LEFT JOIN Addresses a ON a.Address_ID = h.Address_ID 
+	END 
+
+	--#Gifts will contain all of the donations for the time period with the information setup for the statements
+	CREATE TABLE #Gifts(
+	    Donor_ID INT
+		, Donation_ID INT
+		, Donation_Distribution_ID INT
+		, Donation_Date DATETIME
+		, Amount MONEY
+		, Non_Deductible_Amount MONEY
+		, Deductible_Amount MONEY
+		, Payment_Type VARCHAR(50)
+		, Payment_Type_ID INT	
+		, Item_Number VARCHAR(15)
+		, Fund_Name VARCHAR(50)		
+		, Is_Soft_Credit_Donor BIT
+		, Donation_Detail VARCHAR(1000)
+		, Mail_Name VARCHAR(1000)
+		, Address_Line_1 VARCHAR(1000)
+		, Apt_or_Suite  VARCHAR(1000)
+		, City VARCHAR(50)
+		, [State] VARCHAR(50)
+		, Postal_Code VARCHAR(15)
+		, Statement_ID VARCHAR(15)
+		, Is_Recurring_Gift BIT
+		, Section_Sort INT
+	);
+
+	INSERT INTO #Gifts
+		(Donation_ID
+		, Donor_ID
+		, Donation_Distribution_ID
+		, Donation_Date
+		, Amount
+		, Non_Deductible_Amount
+		, Deductible_Amount
+		, Payment_Type
+		, Payment_Type_ID
+		, Item_Number
+		, Fund_Name			
+		, Is_Soft_Credit_Donor 
+		, Donation_Detail 
+		, Mail_Name
+		, Address_Line_1
+		, Apt_or_Suite 
+		, City
+		, [State]
+		, Postal_Code
+		, Statement_ID
+		, Is_Recurring_Gift
+		, Section_Sort
+	)
+		-- Tax deductible only (pull from Donation Distributions)
+		SELECT Do.Donor_ID
+			, D.Donation_ID
+			, DD.Donation_Distribution_ID
+			, D.Donation_Date
+			, Amount = DD.Amount
+			, Non_Deductible_Amount = 0
+			, Deductible_Amount = DD.Amount 
+			, PT.Payment_Type
+			, D.Payment_Type_ID
+			, D.Item_Number
+			, Prog.Statement_Title AS Fund_Name	
+			, Is_Soft_Credit_Donor = 0 --CASE WHEN DD.Soft_Credit_Donor IS NULL THEN 0 ELSE 1 END	
+			, Donation_Detail = ISNULL(D.Notes, 'No Description Given')
+			, Do.Mail_Name
+			, Do.Address_Line_1
+			, Do.Apt_or_Suite
+			, Do.City
+			, Do.[State]
+			, Do.Postal_Code
+			, Do.Statement_ID --The RDL will group by this
+			, D.Is_Recurring_Gift
+			, Section_Sort = 1 --Tax Deductible
+		FROM #Donations D
+			INNER JOIN Donation_Distributions DD ON DD.Donation_ID = D.Donation_ID
+			INNER JOIN #DONORS Do ON Do.Donor_ID = D.Donor_ID --CASE WHEN DD.Soft_Credit_Donor IS NULL THEN D.Donor_ID ELSE DD.Soft_Credit_Donor END  --use Donation distribution soft credit donor id as donor id for SCDonations else use donor id in donations as donor id 
+			INNER JOIN Programs Prog ON Prog.Program_ID = DD.Program_ID
+			INNER JOIN Congregations Cong ON Cong.Congregation_ID = Prog.Congregation_ID AND Cong.Accounting_Company_ID = ISNULL(@AccountingCompanyID, Cong.Accounting_Company_ID)
+			INNER JOIN Payment_Types PT ON PT.Payment_Type_ID = D.Payment_Type_ID
+		WHERE
+			D.Payment_Type_ID <> 6 AND		-- Omit Non-Cash/Asset (e.g., stock)
+			ISNULL(Prog.Tax_Deductible_Donations, 0) = 1 --Omit Non Deductible
+	UNION ALL
+		-- Non-tax deductible only (pull from Donations instead of Donation Distributions so stock donations that have been split into multiple distributions are listed only once)
+		SELECT Do.Donor_ID
+			, D.Donation_ID
+			, 0
+			, D.Donation_Date
+			, Amount = 0   -- amount is not used for stock giving
+			, Non_Deductible_Amount = 0   -- amount is not used for stock giving
+			, Deductible_Amount = 0
+			, PT.Payment_Type
+			, D.Payment_Type_ID
+			, D.Item_Number
+			, Fund_Name = null -- program name is not used for stock giving
+			, Is_Soft_Credit_Donor = 0 --CASE WHEN DD.Soft_Credit_Donor IS NULL THEN 0 ELSE 1 END	
+			, Donation_Detail = ISNULL(D.Notes, 'No Description Given')
+			, Do.Mail_Name
+			, Do.Address_Line_1
+			, Do.Apt_or_Suite
+			, Do.City
+			, Do.[State]
+			, Do.Postal_Code
+			, Do.Statement_ID --The RDL will group by this
+			, D.Is_Recurring_Gift
+			, Section_Sort = 2 --Stock Giving
+		FROM #Donations D
+			INNER JOIN #DONORS Do ON Do.Donor_ID = D.Donor_ID --CASE WHEN DD.Soft_Credit_Donor IS NULL THEN D.Donor_ID ELSE DD.Soft_Credit_Donor END  --use Donation distribution soft credit donor id as donor id for SCDonations else use donor id in donations as donor id 
+			INNER JOIN Payment_Types PT ON PT.Payment_Type_ID = D.Payment_Type_ID
+		WHERE 
+			D.Payment_Type_ID = 6 AND		-- Omit everything except Non-Cash/Asset (e.g., stock)
+			EXISTS (
+				SELECT
+					1
+				FROM
+					Donation_Distributions dd
+					INNER JOIN Programs Prog ON Prog.Program_ID = dd.Program_ID
+					INNER JOIN Congregations Cong ON Cong.Congregation_ID = Prog.Congregation_ID AND Cong.Accounting_Company_ID = ISNULL(@AccountingCompanyID, Cong.Accounting_Company_ID)
+				WHERE
+					dd.Donation_ID = d.Donation_ID AND
+					ISNULL(Prog.Tax_Deductible_Donations, 0) = 1
+			)
+	;
+
+	CREATE INDEX IX_Gifts_DonorID ON #Gifts(Donor_ID)
+
+	
+
+	SELECT
+		Statement_ID
+		, Donation_ID
+		, Donation_Date
+		, Amount
+		, Non_Deductible_Amount
+		, Deductible_Amount
+		, Payment_Type = CASE
+							WHEN Is_Soft_Credit_Donor = 1 THEN Donation_Detail
+							WHEN Payment_Type_ID = 0 THEN Donation_Detail
+							WHEN Payment_Type_ID = 1 THEN CONCAT('Check #', Item_Number)
+							WHEN Payment_Type_ID = 2 THEN 'Cash'
+							WHEN Payment_Type_ID = 4 AND Is_Recurring_Gift = 1 THEN 'Recurring Credit Card'
+							WHEN Payment_Type_ID = 4 THEN 'One-time Credit Card'
+							WHEN Payment_Type_ID = 5 AND Is_Recurring_Gift = 1 THEN 'Recurring ACH'
+							WHEN Payment_Type_ID = 5 THEN 'One-time ACH'
+							WHEN Payment_Type_ID = 6 THEN ISNULL(Donation_Detail, 'Non-cash')
+							ELSE ISNULL(Item_Number, Payment_Type)
+						END
+		, Fund_Name AS [Donation_Description]
+		, Mail_Name
+		, Address_Line_1
+		, Apt_or_Suite
+		, City
+		, [State]
+		, Postal_Code
+		, Section_Sort
+		, NULL AS Total_Pledge
+ 		, NULL AS Given_to_Pledge
+ 		, NULL AS Campaign_Name
+	FROM #Gifts 
+		UNION ALL
+ 	--The campaign pledge data
+ 	SELECT 
+ 	      Statement_ID
+ 		, NULL
+ 		, NULL
+ 		, NULL
+ 		, NULL
+ 		, NULL
+ 		, NULL
+ 		, NULL
+ 		, NULL
+ 		, NULL
+ 		, NULL
+ 		, NULL
+ 		, NULL
+ 		, Postal_Code
+ 		, 4 --Campaign Contributions
+ 		, Total_Pledge		
+ 		, ISNULL(Sum_Donations_ForPledge,0)  AS Given_to_Pledge
+ 		, Campaign_Name
+	FROM #PledgeData
+	--Sorting by postal code US7181
+	ORDER BY postal_code, statement_id, section_sort
+	
+	
+	DROP TABLE #Donations;
+	DROP TABLE #D;
+	DROP TABLE #DONORS;
+	DROP TABLE #Gifts;
+	DROP TABLE #Congregations;
+
+	DROP TABLE #Campaigns;
+	DROP TABLE #Pledges;
+	DROP TABLE #PledgeData; 
+	DROP TABLE #PledgeTotals;
+	DROP TABLE #Selections;
+
+END
+GO


### PR DESCRIPTION
DE4027 - Fix for missing donations caused by using UNION instead of UNION ALL
DE4028 - Show each stock donation once regardless of number of distributions
DE4042 - Include donors who are missing a Household record or have NULL Congregation ID (treat as Not Site Specific)
Fix typo in SQL - 'No Description Given'