### PR TITLE
DE4087 update error message to make @angiemama happy

### DIFF
--- a/crossroads.net/app/trips/trippromise/tripPromise.html
+++ b/crossroads.net/app/trips/trippromise/tripPromise.html
@@ -20,7 +20,7 @@
       </label>
       <ng-messages for="$ctrl.tripPromiseForm.promise.$error" ng-if="$ctrl.validation.showErrors($ctrl.tripPromiseForm, 'promise')">
         <span ng-message="required">
-          <span dynamic-content="$root.MESSAGES.fieldCanNotBeBlank.content | html"></span>
+          <span dynamic-content="$root.MESSAGES.TripIPromiseRequiredMessage.content | html"></span>
         </span>
       </ng-messages>
     </div>


### PR DESCRIPTION
The purpose of this pull request is to update the error message displayed when a user does not check the box before attempting to submit the I Promise document for their trip. 
The previous message was: 

> Please enter a value.

And the new message is:

> Please check the box to confirm you read the I Promise statement.

Please view the PR for the defect/DE4897-IPromiseRequired branch in the SS-CMS repository for the actual content block. 