### PR TITLE
US10378 - Reskin /serve

### DIFF
--- a/crossroads.net/core/templates/screenWidth.html
+++ b/crossroads.net/core/templates/screenWidth.html
@@ -1,18 +1,13 @@
 <ng-include src="'templates/header.html'"></ng-include>
 
 <div ng-class="{'crds-legacy-styles': renderLegacyStyles, 'crds-styles': !renderLegacyStyles}">
-  <div class="container-fluid main animated fadeIn">
-    <div class="row">
-      <div class="col-md-12">
-        <preloader ng-if="app.resolving" full-screen='true'> </preloader>
-        <div ng-if="!app.resolving">
-          <div ui-view ng-if="!app.resolving"> </div>
-          <form-builder page="page"></form-builder>
-        </div>
-      </div>
+  <div class="main animated fadeIn">
+    <preloader ng-if="app.resolving" full-screen='true'> </preloader>
+    <div ng-if="!app.resolving">
+      <div ui-view ng-if="!app.resolving"> </div>
+      <form-builder page="page"></form-builder>
     </div>
   </div>
-  <!--/container-->
 
   <ng-include src="'templates/footer.html'"></ng-include>
 </div>


### PR DESCRIPTION
Remove the fluid container, which added unnecessary padding.

I'm worried this change will introduce regressions on other pages using the Screen Width template, but a list of which pages those are isn't readily available, so I'm not exactly sure how we go about regression testing.

Also note that, for now, the testing should be done at `/ddk-reskin/serve`. The main serve page will be changed after this is merged and after the proper channels are notified.