### PR TITLE
DE4616 - Missing password ID

### DIFF
--- a/crossroads.net/core/passwordField/passwordField.html
+++ b/crossroads.net/core/passwordField/passwordField.html
@@ -2,7 +2,7 @@
   <div class="form-group push-quarter-bottom" ng-class="{ 'has-error': passwd.passwordInvalid() }">
     <div class="input-group">
       <label class="sr-only">Password</label>
-      <input class="form-control" placeholder="Password" type="{{passwd.inputType}}" ng-minlength="{{passwd.minLength}}" autocomplete="off" autocorrect="off" autocapitalize="off" ng-model="passwd.passwd" ng-model-options="{ updateOn: 'change blur' }" name="password" ng-required="{{passwd.required}}">
+      <input id="{{passwd.prefix}}-password" class="form-control" placeholder="Password" type="{{passwd.inputType}}" ng-minlength="{{passwd.minLength}}" autocomplete="off" autocorrect="off" autocapitalize="off" ng-model="passwd.passwd" ng-model-options="{ updateOn: 'change blur' }" name="password" ng-required="{{passwd.required}}">
       <span class="input-group-btn">
         <button class="btn btn-option" type="button" id="{{passwd.prefix}}-show-hide-password" ng-click="passwd.pwprocess()">
           {{passwd.pwprocessing}}


### PR DESCRIPTION
I accidentally removed an ID from the password field during the original reskin. This ID was important for automated testing and I received a request from Jason to reimplement it.

Reimplementing the original ID attribute to the password input. Not sure how to test this...

No corresponding PRs.