### PR TITLE
Defect/de4590 gp export view missing comma

### DIFF
--- a/Gateway/MinistryPlatform.Translation.Test/Services/DonationServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/DonationServiceTest.cs
@@ -442,8 +442,8 @@ namespace MinistryPlatform.Translation.Test.Services
 
             var mockGPExportData = MockGPExportDataTest2();
 
-            _ministryPlatformService.Setup(mock => mock.GetPageViewRecords(viewId, It.IsAny<string>(), $"{depositId.ToString()},", "", 0)).Returns(MockGPExport());
-            _ministryPlatformService.Setup(mock => mock.GetPageViewRecords(paymentViewId, It.IsAny<string>(), $"{depositId.ToString()},", "", 0)).Returns(MockGPPaymentExport());
+            _ministryPlatformService.Setup(mock => mock.GetPageViewRecords(viewId, It.IsAny<string>(), $"{depositId},", "", 0)).Returns(MockGPExport());
+            _ministryPlatformService.Setup(mock => mock.GetPageViewRecords(paymentViewId, It.IsAny<string>(), $"{depositId},", "", 0)).Returns(MockGPPaymentExport());
 
             _ministryPlatformRest.Setup(m => m.UsingAuthenticationToken(It.IsAny<string>())).Returns(_ministryPlatformRest.Object);
             _ministryPlatformRest.Setup(m => m.Search<int>("GL_Account_Mapping", $"GL_Account_Mapping.Program_ID={It.IsAny<int>()} AND GL_Account_Mapping.Congregation_ID={It.IsAny<int>()}", "Processor_Fee_Mapping_ID_Table.Program_ID", null, false))

--- a/Gateway/MinistryPlatform.Translation.Test/Services/DonationServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/DonationServiceTest.cs
@@ -567,7 +567,7 @@ namespace MinistryPlatform.Translation.Test.Services
 
             var mockGPExportData = MockGPExportDataTest1(programId);            
             
-            _ministryPlatformService.Setup(mock => mock.GetPageViewRecords(viewId, It.IsAny<string>(), depositId.ToString(), "", 0)).Returns(returnedData);
+            _ministryPlatformService.Setup(mock => mock.GetPageViewRecords(viewId, It.IsAny<string>(), $"{depositId},", "", 0)).Returns(returnedData);
             
             _ministryPlatformRest.Setup(m => m.UsingAuthenticationToken(It.IsAny<string>())).Returns(_ministryPlatformRest.Object);
             _ministryPlatformRest.Setup(m => m.Search<int>("GL_Account_Mapping", $"GL_Account_Mapping.Program_ID={programId} AND GL_Account_Mapping.Congregation_ID={congregationId}", "Processor_Fee_Mapping_ID_Table.Program_ID", null, false))

--- a/Gateway/MinistryPlatform.Translation.Test/Services/DonationServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/DonationServiceTest.cs
@@ -567,7 +567,8 @@ namespace MinistryPlatform.Translation.Test.Services
 
             var mockGPExportData = MockGPExportDataTest1(programId);            
             
-            _ministryPlatformService.Setup(mock => mock.GetPageViewRecords(viewId, It.IsAny<string>(), $"{depositId},", "", 0)).Returns(returnedData);
+            var searchStr = $"{depositId},";
+            _ministryPlatformService.Setup(mock => mock.GetPageViewRecords(viewId, It.IsAny<string>(), searchStr, "", 0)).Returns(returnedData);
             
             _ministryPlatformRest.Setup(m => m.UsingAuthenticationToken(It.IsAny<string>())).Returns(_ministryPlatformRest.Object);
             _ministryPlatformRest.Setup(m => m.Search<int>("GL_Account_Mapping", $"GL_Account_Mapping.Program_ID={programId} AND GL_Account_Mapping.Congregation_ID={congregationId}", "Processor_Fee_Mapping_ID_Table.Program_ID", null, false))

--- a/Gateway/MinistryPlatform.Translation.Test/Services/DonationServiceTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/DonationServiceTest.cs
@@ -442,8 +442,8 @@ namespace MinistryPlatform.Translation.Test.Services
 
             var mockGPExportData = MockGPExportDataTest2();
 
-            _ministryPlatformService.Setup(mock => mock.GetPageViewRecords(viewId, It.IsAny<string>(), depositId.ToString(), "", 0)).Returns(MockGPExport());
-            _ministryPlatformService.Setup(mock => mock.GetPageViewRecords(paymentViewId, It.IsAny<string>(), depositId.ToString(), "", 0)).Returns(MockGPPaymentExport());
+            _ministryPlatformService.Setup(mock => mock.GetPageViewRecords(viewId, It.IsAny<string>(), $"{depositId.ToString()},", "", 0)).Returns(MockGPExport());
+            _ministryPlatformService.Setup(mock => mock.GetPageViewRecords(paymentViewId, It.IsAny<string>(), $"{depositId.ToString()},", "", 0)).Returns(MockGPPaymentExport());
 
             _ministryPlatformRest.Setup(m => m.UsingAuthenticationToken(It.IsAny<string>())).Returns(_ministryPlatformRest.Object);
             _ministryPlatformRest.Setup(m => m.Search<int>("GL_Account_Mapping", $"GL_Account_Mapping.Program_ID={It.IsAny<int>()} AND GL_Account_Mapping.Congregation_ID={It.IsAny<int>()}", "Processor_Fee_Mapping_ID_Table.Program_ID", null, false))

--- a/Gateway/MinistryPlatform.Translation/Repositories/DonationRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/DonationRepository.cs
@@ -563,7 +563,8 @@ namespace MinistryPlatform.Translation.Repositories
 
         public List<MpGPExportDatum> GetGPExportDataForPayments(int depositId , string token)
         {
-            var results = _ministryPlatformService.GetPageViewRecords(_paymentGPExportPageView, token, depositId.ToString());
+            var searchStr = $"{depositId},";
+            var results = _ministryPlatformService.GetPageViewRecords(_paymentGPExportPageView, token, searchStr);
             return (from result in results
                     let amount = Convert.ToDecimal(result.ToString("Payment_Amount"))
 

--- a/Gateway/MinistryPlatform.Translation/Repositories/DonationRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/DonationRepository.cs
@@ -627,7 +627,8 @@ namespace MinistryPlatform.Translation.Repositories
 
         public List<MpGPExportDatum> GetGpExportData(int depositId, string token)
         {
-            var results = _ministryPlatformService.GetPageViewRecords(_gpExportPageView, token, depositId.ToString());
+            var searchStr = $"{depositId},";
+            var results = _ministryPlatformService.GetPageViewRecords(_gpExportPageView, token, searchStr);
 
 
             return (from result in results let amount = Convert.ToDecimal(result.ToString("Amount"))                


### PR DESCRIPTION
added a comma to the mp search string so that it doesn't search through every column but rather the one column where we expect the data to be.