### PR TITLE
Defect/de4652 header helper class register

### DIFF
--- a/crossroads.net/core/register/register_page.html
+++ b/crossroads.net/core/register/register_page.html
@@ -1,4 +1,4 @@
-<div class="imgix-fluid-bg img-background" data-src="//crds-cms-uploads.imgix.net/content/images/register-bg.jpg">
+<div class="imgix-fluid-bg img-background with-header" data-src="//crds-cms-uploads.imgix.net/content/images/register-bg.jpg">
 </div>
 
 <div class="container auth-container">

--- a/crossroads.net/core/templates/header.html
+++ b/crossroads.net/core/templates/header.html
@@ -1,5 +1,5 @@
 <div class="crds-shared-header">
-  <header ng-if="!app.state.current.data.hideMenu" class="hidden-print" id="top-header" style="height: 72px">
+  <header ng-if="!app.state.current.data.hideMenu" class="hidden-print" id="top-header" style="height: 70px">
     <div data-header></div>
   </header>
 </div>

--- a/crossroads.net/core/templates/header.html
+++ b/crossroads.net/core/templates/header.html
@@ -1,5 +1,5 @@
 <div class="crds-shared-header">
-  <header ng-if="!app.state.current.data.hideMenu" class="hidden-print" id="top-header" style="height: 64px">
+  <header ng-if="!app.state.current.data.hideMenu" class="hidden-print" id="top-header" style="height: 72px">
     <div data-header></div>
   </header>
 </div>

--- a/crossroads.net/styles/main.scss
+++ b/crossroads.net/styles/main.scss
@@ -80,10 +80,7 @@
 
     &.with-header {
       position: absolute;
-      top: 64px;
-      @media screen and (min-width: $screen-md) {
-        top: 72px;
-      }
+      top: 70px;
     }
   }
 


### PR DESCRIPTION
Similar to US10723, we needed to add a little spacing to the shared header on /register

This changes the height on the shared-header on /register and /signin and keeps the top of the background shown instead of being hidden by the shared header.
