### PR TITLE
Defect/de4666 signin type fixes

### DIFF
--- a/crossroads.net/core/login/login_form.html
+++ b/crossroads.net/core/login/login_form.html
@@ -25,7 +25,7 @@
   <div class="clearfix">
     <div ng-if="!modal && !processing" class="pull-right font-size-smaller">
       <a class="block" ui-sref="forgotPassword">Forgot password?</a>
-      <a class="block" href="/help">Need Help?</a>
+      <a class="block" href="/help">Need help?</a>
     </div>
   </div>
 

--- a/crossroads.net/core/login/login_page.html
+++ b/crossroads.net/core/login/login_page.html
@@ -9,17 +9,17 @@
       <div class="panel">
         <div class="panel-body">
           <div class="row">
-            <div class="col-sm-6 auth-form" ng-show="$root.username == undefined">
+            <div class="col-sm-7 auth-form" ng-show="$root.username == undefined">
               <login-form register-url="register"></login-form>
             </div>
 
-            <div class="col-sm-6" ng-show="$root.username != undefined">
+            <div class="col-sm-7" ng-show="$root.username != undefined">
               <preloader full-screen='true'> </preloader>
             </div>
 
             <div class="divider">&nbsp;</div>
 
-            <div class="col-sm-6 hidden-xs auth-details">
+            <div class="col-sm-5 hidden-xs auth-details">
               <div dynamic-content="$root.MESSAGES.signinRegisterPromo.content | html"></div>
             </div>
           </div>

--- a/crossroads.net/core/register/register_form.html
+++ b/crossroads.net/core/register/register_form.html
@@ -33,13 +33,13 @@
 
   <password-field min-length="8" passwd-strength="true" required="true" passwd="register.newuser.password" submitted="register.registerForm.$submitted" prefix="register.passwordPrefix"></password-field>
 
-  <input type="submit" class="btn btn-primary btn-block" value="Register an Account" ng-disabled="!register.showRegisterButton" >
+  <input type="submit" class="btn btn-primary btn-block" value="Register an account" ng-disabled="!register.showRegisterButton" >
 
   <span dynamic-content="$root.MESSAGES.registrationFooter.content | html"></span>
 </form>
 
 <hr>
 
-<p ng-if="!register.showLoginCallback">Already have an account? <a ui-sref="login">Sign In</a>.</p>
+<p class="font-size-smaller" ng-if="!register.showLoginCallback">Already have an account? <a ui-sref="login">Sign in</a>.</p>
 
-<p ng-if="register.showLoginCallback">Already have an account? <a ng-click="register.loginCallback()">Sign In</a>.</p>
+<p class="font-size-smaller" ng-if="register.showLoginCallback">Already have an account? <a ng-click="register.loginCallback()">Sign in</a>.</p>

--- a/crossroads.net/core/register/register_page.html
+++ b/crossroads.net/core/register/register_page.html
@@ -9,17 +9,17 @@
       <div class="panel">
         <div class="panel-body">
           <div class="row">
-            <div class="col-sm-6 auth-form" ng-show="$root.username == undefined">
+            <div class="col-sm-7 auth-form" ng-show="$root.username == undefined">
               <register-form register-callback='register.redirectToGetStarted'> </register-form>
             </div>
 
-            <div class="col-sm-6" ng-show="$root.username != undefined">
+            <div class="col-sm-7" ng-show="$root.username != undefined">
               <preloader full-screen='true'> </preloader>
             </div>
 
             <div class="divider">&nbsp;</div>
 
-            <div class="col-sm-6 hidden-xs auth-details">
+            <div class="col-sm-5 hidden-xs auth-details">
               <div dynamic-content="$root.MESSAGES.signinRegisterPromo.content | html"></div>
             </div>
           </div>


### PR DESCRIPTION
Adjust the capitalization on buttons and links in both /signin and /register to reflect sentence-casing.

CMS changes have been made to adjust the font-size (body font on /signin and /register should be 14px for the most part) and add spacing on the legal beneath the CTA on /register.

No corresponding PRs.