### PR TITLE
DE4669 - Register bg bug

### DIFF
--- a/crossroads.net/core/register/register_page.html
+++ b/crossroads.net/core/register/register_page.html
@@ -1,4 +1,4 @@
-<div class="imgix-fluid-bg img-background" data-src="//crds-cms-uploads.imgix.net/content/images/register-bg.jpg">
+<div class="imgix-fluid-bg img-background with-header" data-src="//crds-cms-uploads.imgix.net/content/images/register-bg.jpg">
 </div>
 
 <div class="container auth-container">


### PR DESCRIPTION
Add class to account for shared header on /register. The background now scrolls.

No corresponding PRs.