### PR TITLE
Feature/us10792 journey active

### DIFF
--- a/Gateway/MinistryPlatform.Translation.Test/Services/GroupToolRepositoryTest.cs
+++ b/Gateway/MinistryPlatform.Translation.Test/Services/GroupToolRepositoryTest.cs
@@ -227,7 +227,48 @@ namespace MinistryPlatform.Translation.Test.Services
             Assert.AreEqual(inquiryResults[0]["Inquiry_Date"], results[0].RequestDate);
             Assert.AreEqual(inquiryResults[0]["Placed"], results[0].Placed);
             Assert.AreEqual(inquiryResults[0]["Contact_ID"], results[0].ContactId);
+        }
 
+        [Test]
+        public void GetCurrentyJourneyShouldReturnAttributeName()
+        {
+            var dto = new List<MpAttribute>
+            {
+                new MpAttribute
+                {
+                    Name = "This is not the best journey in the world"
+                }
+            };
+            _apiUserRepository.Setup(m => m.GetDefaultApiUserToken()).Returns("TheBestToken");
+            _ministryPlatformRestRepository.Setup(m => m.UsingAuthenticationToken("TheBestToken")).Returns(_ministryPlatformRestRepository.Object);
+            _ministryPlatformRestRepository.Setup(
+                m =>
+                    m.Search<MpAttribute>(
+                        "ATTRIBUTE_CATEGORY_ID_TABLE.ATTRIBUTE_CATEGORY_ID = 51 AND GETDATE() BETWEEN START_DATE AND ISNULL(END_DATE, GETDATE())",
+                        "Attribute_Name",(string) null, (bool) false)).Returns(dto);
+
+            var result = _fixture.GetCurrentJourney();
+
+            _ministryPlatformRestRepository.VerifyAll();
+            Assert.AreEqual(result, dto[0].Name);
+
+        }
+
+        [Test]
+        public void GetCurrentJourneyShouldReturnNull()
+        {
+            _apiUserRepository.Setup(m => m.GetDefaultApiUserToken()).Returns("TheBestToken");
+            _ministryPlatformRestRepository.Setup(m => m.UsingAuthenticationToken("TheBestToken")).Returns(_ministryPlatformRestRepository.Object);
+            _ministryPlatformRestRepository.Setup(
+                m =>
+                    m.Search<MpAttribute>(
+                        "ATTRIBUTE_CATEGORY_ID_TABLE.ATTRIBUTE_CATEGORY_ID = 51 AND GETDATE() BETWEEN START_DATE AND ISNULL(END_DATE, GETDATE())",
+                        "Attribute_Name", (string)null, (bool)false)).Returns(new List<MpAttribute>());
+
+            var result = _fixture.GetCurrentJourney();
+
+            _ministryPlatformRestRepository.VerifyAll();
+            Assert.IsNull(result);
         }
     }
 }

--- a/Gateway/MinistryPlatform.Translation/Repositories/GroupToolRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/GroupToolRepository.cs
@@ -26,6 +26,7 @@ namespace MinistryPlatform.Translation.Repositories
         private readonly IMinistryPlatformService _ministryPlatformService;
         private readonly IMinistryPlatformRestRepository _mpRestRepository;
         private readonly IApiUserRepository _apiUserRepository;
+        private const int JourneyCategoryID = 51;
 
         public GroupToolRepository(IMinistryPlatformService ministryPlatformService,
                                IConfigurationWrapper configurationWrapper,
@@ -40,6 +41,14 @@ namespace MinistryPlatform.Translation.Repositories
             _groupInquiriesNotPlacedPageViewId = _configurationWrapper.GetConfigIntValue("GroupInquiriesNotPlacedPageView");
             _mpRestRepository = mpRestRepository;
             _apiUserRepository = apiUserRepository;
+        }
+
+        public string GetCurrentJourney()
+        {
+            var token = _apiUserRepository.GetDefaultApiUserToken();
+            var filter = $"ATTRIBUTE_CATEGORY_ID_TABLE.ATTRIBUTE_CATEGORY_ID = {JourneyCategoryID} AND GETDATE() BETWEEN START_DATE AND ISNULL(END_DATE, GETDATE())";
+            var attribute = _mpRestRepository.UsingAuthenticationToken(token).Search<MpAttribute>(filter, "Attribute_Name").FirstOrDefault();
+            return attribute?.Name;
         }
 
         public List<MpInvitation> GetInvitations(int sourceId, int invitationTypeId)

--- a/Gateway/MinistryPlatform.Translation/Repositories/Interfaces/IGroupToolRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/Interfaces/IGroupToolRepository.cs
@@ -10,5 +10,6 @@ namespace MinistryPlatform.Translation.Repositories.Interfaces
         List<MpInquiry> GetInquiries(int? groupId = null);
         List<MpGroupSearchResultDto> SearchGroups(int[] groupTypeIds, string[] keywords = null, int? groupId = null);
         void ArchivePendingGroupInquiriesOlderThan90Days();
+        string GetCurrentJourney();
     }
 }

--- a/Gateway/crds-angular.test/Services/GroupToolServiceTest.cs
+++ b/Gateway/crds-angular.test/Services/GroupToolServiceTest.cs
@@ -1801,6 +1801,26 @@ namespace crds_angular.test.Services
         }
 
         [Test]
+        public void ShouldReturnJourneyName()
+        {
+            const string journeyName = "This is not the greatest journey in the world no, this is just a tribute";
+            _groupToolRepository.Setup(m => m.GetCurrentJourney()).Returns(journeyName);
+
+            var result = _fixture.GetCurrentJourney();
+            _groupToolRepository.VerifyAll();
+            Assert.AreEqual(result, journeyName);
+        }
+
+        [Test]
+        public void ShouldReturnNullJourneyName()
+        {
+            _groupToolRepository.Setup(m => m.GetCurrentJourney()).Returns((string) null);
+            var result = _fixture.GetCurrentJourney();
+            _groupToolRepository.VerifyAll();
+            Assert.IsNull(result);
+        }
+
+        [Test]
         public void TestSendSmallGroupPendingInquiryReminderEmails()
         {
             var inquiries = new List<MpInquiry>

--- a/Gateway/crds-angular/Controllers/API/GroupToolController.cs
+++ b/Gateway/crds-angular/Controllers/API/GroupToolController.cs
@@ -152,6 +152,27 @@ namespace crds_angular.Controllers.API
         }
 
         /// <summary>
+        /// Returns the name of the a current journey or null if there isn't a journey going on.
+        /// Note: Will only return one journey name.
+        /// </summary>
+        /// <returns>journey name (string)</returns>
+        [VersionedRoute(template: "grouptool/getcurrentjourney", minimumVersion: "1.0.0")]
+        [Route("grouptool/getcurrentjourney")]
+        [HttpGet]
+        public IHttpActionResult getCurrentJourney()
+        {
+            try
+            {
+                return Ok(new { journeyName = _groupToolService.GetCurrentJourney()} );
+            }
+            catch(Exception e)
+            {
+                _logger.Error("Could not get current journey: " + e.Message);
+                return BadRequest();
+            }
+        }
+
+        /// <summary>
         /// Remove a participant from my group.
         /// </summary>
         /// <param name="groupTypeId">An integer identifying the type of group.</param>

--- a/Gateway/crds-angular/Services/GroupToolService.cs
+++ b/Gateway/crds-angular/Services/GroupToolService.cs
@@ -181,6 +181,11 @@ namespace crds_angular.Services
             return request;
         }
 
+        public string GetCurrentJourney()
+        {
+            return _groupToolRepository.GetCurrentJourney();
+        }
+
         public List<Inquiry> GetInquiries(int groupId, string token)
         {
             var requests = new List<Inquiry>();

--- a/Gateway/crds-angular/Services/Interfaces/IGroupToolService.cs
+++ b/Gateway/crds-angular/Services/Interfaces/IGroupToolService.cs
@@ -39,5 +39,6 @@ namespace crds_angular.Services.Interfaces
         void ArchivePendingGroupInquiriesOlderThan90Days();
         List<GroupDTO> GetGroupToolGroups(string token);
         Inquiry GetGroupInquiryForContactId(int groupId, int contactId);
+        string GetCurrentJourney();
     }
 }


### PR DESCRIPTION
Adds an endpoint to get the name of the current journey if one is active. Returns null if there is no active journey. 