### PR TITLE
ajcolub/US10932 - update labels on student camp application

### DIFF
--- a/crossroads.net/app/camps/application_page/camper_info/camper_info_form.service.js
+++ b/crossroads.net/app/camps/application_page/camper_info/camper_info_form.service.js
@@ -209,7 +209,7 @@ class CamperInfoForm {
             key: 'crossroadsSite',
             type: 'crdsSelect',
             templateOptions: {
-              label: 'Student’s Crossroads Site',
+              label: 'Usually Attend Services at',
               required: true,
               valueProp: 'dp_RecordID',
               labelProp: 'dp_RecordName',
@@ -230,7 +230,7 @@ class CamperInfoForm {
             key: 'roommate',
             type: 'crdsInput',
             templateOptions: {
-              label: 'Preferred Roommate First and Last Name',
+              label: 'Preferred Small Group Leader or Friend',
               required: false
             }
           }


### PR DESCRIPTION
The purpose of this PR is to update two labels on the Student Camp application.

Was:
![image](https://user-images.githubusercontent.com/29924975/33087030-6fe4297c-ceb7-11e7-8d61-395449e13d91.png)

Updated to:
![image](https://user-images.githubusercontent.com/29924975/33087059-7e49b40a-ceb7-11e7-8727-9d2e9f238164.png)
