### PR TITLE
DE4720 - Session timeout password field

### DIFF
--- a/crossroads.net/core/passwordField/passwordField.html
+++ b/crossroads.net/core/passwordField/passwordField.html
@@ -1,29 +1,31 @@
-<ng-form name="passwd.passwordForm" class="password-field">
-  <div class="form-group push-quarter-bottom" ng-class="{ 'has-error': passwd.passwordInvalid() }">
-    <div class="input-group-flex">
-      <div class="input-group with-icon-btn">
-        <label class="sr-only">Password</label>
-        <input id="{{passwd.prefix}}-password" class="form-control" placeholder="Password" type="{{passwd.inputType}}" ng-minlength="{{passwd.minLength}}" autocomplete="off" autocorrect="off" autocapitalize="off" ng-model="passwd.passwd" ng-model-options="{ updateOn: 'change blur' }" name="password" ng-required="{{passwd.required}}">
-        <div class="icon-btn-wrapper"></div>
-        <span class="addon-btn">
-          <button type="button" id="{{passwd.prefix}}-show-hide-password" class="text-muted" ng-click="passwd.pwprocess()">
-            <svg class="icon icon-1" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
-              <use xlink:href="/assets/svgs/icons.svg#eye" xmlns:xlink="http://www.w3.org/1999/xlink" ng-show="passwd.pwprocessing === 'SHOW'"></use>
-              <use xlink:href="/assets/svgs/icons.svg#eye-slash" xmlns:xlink="http://www.w3.org/1999/xlink" ng-show="passwd.pwprocessing === 'HIDE'"></use>
-            </svg>
-          </button>
-        </span>
+<div class="crds-styles">
+  <ng-form name="passwd.passwordForm" class="password-field">
+    <div class="form-group push-quarter-bottom" ng-class="{ 'has-error': passwd.passwordInvalid() }">
+      <div class="input-group-flex">
+        <div class="input-group with-icon-btn">
+          <label class="sr-only">Password</label>
+          <input id="{{passwd.prefix}}-password" class="form-control" placeholder="Password" type="{{passwd.inputType}}" ng-minlength="{{passwd.minLength}}" autocomplete="off" autocorrect="off" autocapitalize="off" ng-model="passwd.passwd" ng-model-options="{ updateOn: 'change blur' }" name="password" ng-required="{{passwd.required}}">
+          <div class="icon-btn-wrapper"></div>
+          <span class="addon-btn">
+            <button type="button" id="{{passwd.prefix}}-show-hide-password" class="text-muted" ng-click="passwd.pwprocess()">
+              <svg class="icon icon-1" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+                <use xlink:href="/assets/svgs/icons.svg#eye" xmlns:xlink="http://www.w3.org/1999/xlink" ng-show="passwd.pwprocessing === 'SHOW'"></use>
+                <use xlink:href="/assets/svgs/icons.svg#eye-slash" xmlns:xlink="http://www.w3.org/1999/xlink" ng-show="passwd.pwprocessing === 'HIDE'"></use>
+              </svg>
+            </button>
+          </span>
+        </div>
+      </div>
+
+      <div class="error help-block">
+        <ng-messages for="passwd.passwordForm.password.$error">
+          <ng-messages-include src="on-blur-messages"></ng-messages-include>
+        </ng-messages>
+
+        <ng-messages for="passwd.passwordForm.password.$error" ng-if="passwd.submitted">
+          <ng-messages-include src="on-submit-messages"></ng-messages-include>
+        </ng-messages>
       </div>
     </div>
-
-    <div class="error help-block">
-      <ng-messages for="passwd.passwordForm.password.$error">
-        <ng-messages-include src="on-blur-messages"></ng-messages-include>
-      </ng-messages>
-
-      <ng-messages for="passwd.passwordForm.password.$error" ng-if="passwd.submitted">
-        <ng-messages-include src="on-submit-messages"></ng-messages-include>
-      </ng-messages>
-    </div>
-  </div>
-</ng-form>
+  </ng-form>
+</div>


### PR DESCRIPTION
The password field is a shared component being pulled in on pages that haven't been reskinned. To prevent ugliness, I'm wrapping the markup of this particular component in a div with crds-styles applied.

No corresponding PRs.

Not sure if this is the cleanest implementation or how it'll impact load times on any screens with a password field. Please provide thorough pushback/alternate solutions because this feels like it could be handled better.