### PR TITLE
Setting Program end dates to 2 years out

### DIFF
--- a/CI/TestSQL/02.TestData/MP_TestPledgeCampaign.sql
+++ b/CI/TestSQL/02.TestData/MP_TestPledgeCampaign.sql
@@ -4,7 +4,9 @@ GO
 DECLARE @startDate as VARCHAR(19)
 set @startDate = CONVERT(VARCHAR(4), datepart(year, getdate()))+'0101';
 DECLARE @endDate as VARCHAR(19)
-set @endDate = CONVERT(VARCHAR(4), datepart(year, getdate()))+'1231';
+DECLARE @endDateTime as Date
+set @endDateTime = dateadd(year, 2, getdate())
+set @endDate = CONVERT(VARCHAR(4), datepart(year,@endDateTime) )+'1231';
 DECLARE @curr_pledgeCampaign_id AS INT
 DECLARE @pledgeCampaignId AS INT
 DECLARE @programId AS INT


### PR DESCRIPTION
Test pledges were not avaialable to give to. This is because thier
end date was last year. The SQL script to create the pledges and
programs was setting all programs to end at the end of the year.
This SQL script is not ran very often and usually never ran at the
begining of the year. So I changed the script to always end date the
programs two years 2 years out.