### PR TITLE
US10238 - Jumbotron on Live

### DIFF
--- a/crossroads.net/styles/base/typography.scss
+++ b/crossroads.net/styles/base/typography.scss
@@ -14,7 +14,6 @@
     font-weight: 300;
     font-size: 1em; /* equivalent to 14px */
     line-height: $line-height-base; /* equivalent to 22.75px */
-    -webkit-font-smoothing: antialiased;
   }
 
   body, caption, th, td, input, textarea, select, option, legend, fieldset, h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
Remove antialias smoothing on typography. This was causing a discrepancy between fonts within Angular/Maestro and all other properties.