### PR TITLE
feature/us12539 - TD/RL better error handling

### DIFF
--- a/CI/TestSQL/00.PowershellScripts/DeleteTestData.ps1
+++ b/CI/TestSQL/00.PowershellScripts/DeleteTestData.ps1
@@ -7,14 +7,25 @@ param (
 #Call scripts in subfolders relative to current script
 $root_path = (Split-Path (Split-Path ($MyInvocation.MyCommand.Definition)))
 
-
+$errors = 0
 #Delete from UserData folder
 . "$($root_path)\01.TestUsers\DeleteTestUsers.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
 
 #Delete from TestData folder
 . "$($root_path)\02.TestData\01.Batch+Deposit\DeleteDepositsAndBatches.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
 . "$($root_path)\02.TestData\02.Program\DeletePrograms.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
 . "$($root_path)\02.TestData\03.Group+Attribute\DeleteGroupsAndAttributes.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
 . "$($root_path)\02.TestData\04.Event+EventType\DeleteEventsAndEventTypes.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
 . "$($root_path)\02.TestData\05.Opportunity+Response\DeleteOpportunities.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
 . "$($root_path)\02.TestData\06.PledgeCampaign+Pledge\DeletePledgeCampaigns.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
+
+if($errors -ne 0){
+	exit 1
+}

--- a/CI/TestSQL/00.PowershellScripts/DeleteTestData.ps1
+++ b/CI/TestSQL/00.PowershellScripts/DeleteTestData.ps1
@@ -10,21 +10,21 @@ $root_path = (Split-Path (Split-Path ($MyInvocation.MyCommand.Definition)))
 $errors = 0
 #Delete from UserData folder
 . "$($root_path)\01.TestUsers\DeleteTestUsers.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $LASTEXITCODE
 
 #Delete from TestData folder
 . "$($root_path)\02.TestData\01.Batch+Deposit\DeleteDepositsAndBatches.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $LASTEXITCODE
 . "$($root_path)\02.TestData\02.Program\DeletePrograms.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $LASTEXITCODE
 . "$($root_path)\02.TestData\03.Group+Attribute\DeleteGroupsAndAttributes.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $LASTEXITCODE
 . "$($root_path)\02.TestData\04.Event+EventType\DeleteEventsAndEventTypes.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $LASTEXITCODE
 . "$($root_path)\02.TestData\05.Opportunity+Response\DeleteOpportunities.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $LASTEXITCODE
 . "$($root_path)\02.TestData\06.PledgeCampaign+Pledge\DeletePledgeCampaigns.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $LASTEXITCODE
 
 if($errors -ne 0){
 	exit 1

--- a/CI/TestSQL/00.PowershellScripts/LoadTestData.ps1
+++ b/CI/TestSQL/00.PowershellScripts/LoadTestData.ps1
@@ -7,21 +7,38 @@ param (
 #Call scripts in subfolders relative to current script
 $root_path = (Split-Path (Split-Path ($MyInvocation.MyCommand.Definition)))
 
-
+$errors = 0
 #Load UserData folder
 . "$($root_path)\01.TestUsers\01.Contact+Relationship\CreateContactsAndRelationships.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
 . "$($root_path)\01.TestUsers\02.Donor\CreateDonors.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
 . "$($root_path)\01.TestUsers\03.Participant\CreateParticipants.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
 . "$($root_path)\01.TestUsers\04.Household+Address\CreateHouseholdsAndAddresses.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
 
 
 #Load TestData folder
 . "$($root_path)\02.TestData\01.Batch+Deposit\CreateDepositsAndBatches.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
 . "$($root_path)\02.TestData\02.Program\CreatePrograms.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
 . "$($root_path)\02.TestData\03.Group+Attribute\CreateGroupsAndAttributes.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
 . "$($root_path)\02.TestData\04.Event+EventType\CreateEventsAndEventTypes.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
 . "$($root_path)\02.TestData\05.Opportunity+Response\CreateOpportunitiesAndResponses.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
 . "$($root_path)\02.TestData\06.PledgeCampaign+Pledge\CreatePledgeCampaignsAndPledges.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
 . "$($root_path)\02.TestData\07.Donation+Distribution\CreateDonations.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
 . "$($root_path)\02.TestData\08.Invoice+Payment\CreateInvoicesAndPayments.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
 . "$($root_path)\02.TestData\09.EventParticipants+GroupParticipants\CreateEventAndGroupParticipants.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
+$errors += $LASTERRORCODE
+
+if($errors -ne 0){
+	exit 1
+}

--- a/CI/TestSQL/00.PowershellScripts/LoadTestData.ps1
+++ b/CI/TestSQL/00.PowershellScripts/LoadTestData.ps1
@@ -10,34 +10,34 @@ $root_path = (Split-Path (Split-Path ($MyInvocation.MyCommand.Definition)))
 $errors = 0
 #Load UserData folder
 . "$($root_path)\01.TestUsers\01.Contact+Relationship\CreateContactsAndRelationships.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $$LASTEXITCODE
 . "$($root_path)\01.TestUsers\02.Donor\CreateDonors.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $LASTEXITCODE
 . "$($root_path)\01.TestUsers\03.Participant\CreateParticipants.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $LASTEXITCODE
 . "$($root_path)\01.TestUsers\04.Household+Address\CreateHouseholdsAndAddresses.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $LASTEXITCODE
 
 
 #Load TestData folder
 . "$($root_path)\02.TestData\01.Batch+Deposit\CreateDepositsAndBatches.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $LASTEXITCODE
 . "$($root_path)\02.TestData\02.Program\CreatePrograms.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $LASTEXITCODE
 . "$($root_path)\02.TestData\03.Group+Attribute\CreateGroupsAndAttributes.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $LASTEXITCODE
 . "$($root_path)\02.TestData\04.Event+EventType\CreateEventsAndEventTypes.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $LASTEXITCODE
 . "$($root_path)\02.TestData\05.Opportunity+Response\CreateOpportunitiesAndResponses.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $LASTEXITCODE
 . "$($root_path)\02.TestData\06.PledgeCampaign+Pledge\CreatePledgeCampaignsAndPledges.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $LASTEXITCODE
 . "$($root_path)\02.TestData\07.Donation+Distribution\CreateDonations.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $LASTEXITCODE
 . "$($root_path)\02.TestData\08.Invoice+Payment\CreateInvoicesAndPayments.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $LASTEXITCODE
 . "$($root_path)\02.TestData\09.EventParticipants+GroupParticipants\CreateEventAndGroupParticipants.ps1" -DBServer $DBServer -DBUser $DBUser -DBPassword $DBPassword
-$errors += $LASTERRORCODE
+$errors += $LASTEXITCODE
 
 if($errors -ne 0){
 	exit 1

--- a/CI/TestSQL/01.TestUsers/01.Contact+Relationship/CreateContactsAndRelationships.ps1
+++ b/CI/TestSQL/01.TestUsers/01.Contact+Relationship/CreateContactsAndRelationships.ps1
@@ -19,7 +19,7 @@ function OpenConnection{
 #Update all contacts in list
 function UpdateContacts($DBConnection){
 	$contactDataList = import-csv $contactDataCSV
-	
+	$error_count = 0
 	foreach($userRow in $contactDataList)
 	{
 		if(![string]::IsNullOrEmpty($userRow.R_Contact_Email))
@@ -46,16 +46,17 @@ function UpdateContacts($DBConnection){
 			$contact_created = LogResult $command "@contact_id" "Contact updated"
 			
 			if(!$contact_created){
-				throw
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Create contact relationships
 function CreateContactRelationships($DBConnection){
 	$contactRelationshipsDataList = import-csv $contactRelationshipsDataCSV
-
+	$error_count = 0
 	foreach($userRow in $contactRelationshipsDataList)
 	{
 		if(![string]::IsNullOrEmpty($userRow.R_Contact_Email))
@@ -77,20 +78,25 @@ function CreateContactRelationships($DBConnection){
 			$relationship_created = LogResult $command "@contact_relationship_id" "Contact Relationship"
 			
 			if(!$relationship_created){
-				throw
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Execute all the update functions
 try{
 	$DBConnection = OpenConnection
-	UpdateContacts $DBConnection
-	CreateContactRelationships $DBConnection
+	$errors = 0
+	$errors += UpdateContacts $DBConnection
+	$errors += CreateContactRelationships $DBConnection
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1
 } finally {
 	$DBConnection.Close();
+	if($errors -ne 0){
+		exit 1
+	}
 }

--- a/CI/TestSQL/01.TestUsers/02.Donor/CreateDonors.ps1
+++ b/CI/TestSQL/01.TestUsers/02.Donor/CreateDonors.ps1
@@ -18,7 +18,7 @@ function OpenConnection{
 #Create all donors in list
 function CreateDonors($DBConnection){
 	$donorDataList = import-csv $donorDataCSV
-	
+	$error_count = 0
 	foreach($userRow in $donorDataList)
 	{
 		if(![string]::IsNullOrEmpty($userRow.R_Donor_Email))
@@ -48,16 +48,17 @@ function CreateDonors($DBConnection){
 			$donor_created = LogResult $command "@donor_id" "Donor created"
 			
 			if(!$donor_created){
-				throw
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Create all guest givers in list
 function CreateGuestGivers($DBConnection){
 	$guestGiverDataList = import-csv $guestGiverDataCSV
-	
+	$error_count = 0
 	foreach($userRow in $guestGiverDataList)
 	{
 		if(![string]::IsNullOrEmpty($userRow.R_Donor_Email))
@@ -84,20 +85,25 @@ function CreateGuestGivers($DBConnection){
 			$donor_created = LogResult $command "@donor_id" "Guest Giver created"
 			
 			if(!$donor_created){
-				throw
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Execute all the update functions
 try{
 	$DBConnection = OpenConnection
-	CreateDonors $DBConnection
-	CreateGuestGivers $DBConnection
+	$errors = 0
+	$errors += CreateDonors $DBConnection
+	$errors += CreateGuestGivers $DBConnection
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1
 } finally {
 	$DBConnection.Close();
+	if($errors -ne 0){
+		exit 1
+	}
 }

--- a/CI/TestSQL/01.TestUsers/03.Participant/CreateParticipants.ps1
+++ b/CI/TestSQL/01.TestUsers/03.Participant/CreateParticipants.ps1
@@ -17,7 +17,7 @@ function OpenConnection{
 #Create all participants in list
 function CreateParticipants($DBConnection){
 	$participantDataList = import-csv $particpantDataCSV
-	
+	$error_count = 0
 	foreach($userRow in $participantDataList)
 	{
 		if(![string]::IsNullOrEmpty($userRow.R_Participant_Email))
@@ -40,19 +40,24 @@ function CreateParticipants($DBConnection){
 			$participant_created = LogResult $command "@participant_id" "Participant created"
 			
 			if(!$participant_created){
-				throw
+				$error_count += 1
 			}			
 		}
 	}
+	return $error_count
 }
 
 #Execute all the update functions
 try{
 	$DBConnection = OpenConnection
-	CreateParticipants $DBConnection
+	$errors = 0
+	$errors += CreateParticipants $DBConnection
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1
 } finally {
 	$DBConnection.Close();
+	if($errors -ne 0){
+		exit 1
+	}
 }

--- a/CI/TestSQL/01.TestUsers/04.Household+Address/CreateHouseholdsAndAddresses.ps1
+++ b/CI/TestSQL/01.TestUsers/04.Household+Address/CreateHouseholdsAndAddresses.ps1
@@ -19,7 +19,7 @@ function OpenConnection{
 #Create all households in list
 function CreateHouseholds($DBConnection){
 	$householdDataList = import-csv $householdDataCSV
-
+	$error_count = 0
 	foreach($userRow in $householdDataList)
 	{
 		if(![string]::IsNullOrEmpty($userRow.R_Household_Member_Email))
@@ -40,16 +40,17 @@ function CreateHouseholds($DBConnection){
 			$household_created = LogResult $command "@household_id" "Household created"
 			
 			if(!$household_created){
-				throw
+				$error_count += 1
 			}	
 		}
 	}
+	return $error_count
 }
 
 #Create all household addresses in list
 function CreateHouseholdAddresses($DBConnection){
 	$addressDataList = import-csv $householdAddressDataCSV
-
+	$error_count = 0
 	foreach($userRow in $addressDataList)
 	{
 		if(![string]::IsNullOrEmpty($userRow.R_Household_Member_Email))
@@ -78,16 +79,17 @@ function CreateHouseholdAddresses($DBConnection){
 			$address_created = LogResult $command "@address_id" "Address created"
 			
 			if(!$address_created){
-				throw
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Add contacts to households
 function AddHouseholdMember($DBConnection){
 	$contactHouseholdsDataList = import-csv $contactsInHouseholdDataCSV
-
+	$error_count = 0
 	foreach($userRow in $contactHouseholdsDataList)
 	{
 		if(![string]::IsNullOrEmpty($userRow.R_Household_Member_Email))
@@ -107,21 +109,26 @@ function AddHouseholdMember($DBConnection){
 			$household_created = LogResult $command "@household_id" "$($userRow.R_New_Member_Email) added to household"
 			
 			if(!$household_created){
-				throw
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Execute all the Create functions
 try{
 	$DBConnection = OpenConnection
-	CreateHouseholds $DBConnection
-	CreateHouseholdAddresses $DBConnection
-	AddHouseholdMember $DBConnection
+	$errors = 0
+	$errors += CreateHouseholds $DBConnection
+	$errors += CreateHouseholdAddresses $DBConnection
+	$errors += AddHouseholdMember $DBConnection
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1
 } finally {
 	$DBConnection.Close();
+	if($errors -ne 0){
+		exit 1
+	}
 }

--- a/CI/TestSQL/01.TestUsers/DeleteTestUsers.ps1
+++ b/CI/TestSQL/01.TestUsers/DeleteTestUsers.ps1
@@ -17,7 +17,7 @@ function OpenConnection{
 #Deletes all contacts and their user account in the list
 function DeleteContacts($DBConnection){
 	$userList = import-csv $userDataCSV
-	
+	$error_count = 0
 	foreach($user in $userList)
 	{
 		if(![string]::IsNullOrEmpty($user.email))
@@ -38,18 +38,24 @@ function DeleteContacts($DBConnection){
 			} catch {
 				write-host "There was an error deleting data related to user "$user.email
 				write-host "Error: " $Error
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Execute
 try{
 	$DBConnection = OpenConnection
-	DeleteContacts $DBConnection
+	$errors = 0
+	$errors += DeleteContacts $DBConnection
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1
 } finally {
 	$DBConnection.Close();
+	if($errors -ne 0){
+		exit 1
+	}
 }

--- a/CI/TestSQL/02.TestData/01.Batch+Deposit/CreateDepositsAndBatches.ps1
+++ b/CI/TestSQL/02.TestData/01.Batch+Deposit/CreateDepositsAndBatches.ps1
@@ -19,7 +19,7 @@ function OpenConnection{
 #Create empty deposit
 function CreateDeposits($DBConnection){
 	$depositDataList = import-csv $depositDataCSV
-
+	$error_count = 0
 	foreach($depositRow in $depositDataList)
 	{
 		if(![string]::IsNullOrEmpty($depositRow.R_Deposit_Name))
@@ -40,16 +40,17 @@ function CreateDeposits($DBConnection){
 			$deposit_created = LogResult $command "@deposit_id" "Empty Deposit created"
 			
 			if(!$deposit_created){
-				throw
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Create empty batch
 function CreateBatches($DBConnection){
 	$batchDataList = import-csv $batchDataCSV
-
+	$error_count = 0
 	foreach($batchRow in $batchDataList)
 	{
 		if(![string]::IsNullOrEmpty($batchRow.R_Batch_Name))
@@ -74,16 +75,17 @@ function CreateBatches($DBConnection){
 			$batch_created = LogResult $command "@batch_id" "Empty Batch created"
 			
 			if(!$batch_created){
-				throw
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Add batch to deposit
 function AddBatchToDeposit($DBConnection){
 	$depositBatchLinkDataList = import-csv $depositBatchLinkDataCSV
-
+	$error_count = 0
 	foreach($depositRow in $depositBatchLinkDataList)
 	{
 		if(![string]::IsNullOrEmpty($depositRow.R_Deposit_Name))
@@ -105,21 +107,26 @@ function AddBatchToDeposit($DBConnection){
 			$deposit_found = LogResult $command "@deposit_id" "        added to Deposit"
 			
 			if(!$batch_found -or !$deposit_found){
-				throw
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Execute all the update functions
 try{
 	$DBConnection = OpenConnection
-	CreateDeposits $DBConnection
-	CreateBatches $DBConnection
-	AddBatchToDeposit $DBConnection
+	$errors = 0
+	$errors += CreateDeposits $DBConnection
+	$errors += CreateBatches $DBConnection
+	$errors += AddBatchToDeposit $DBConnection
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1
 } finally {
 	$DBConnection.Close();
+	if($errors -ne 0){
+		exit 1
+	}
 }

--- a/CI/TestSQL/02.TestData/01.Batch+Deposit/DeleteDepositsAndBatches.ps1
+++ b/CI/TestSQL/02.TestData/01.Batch+Deposit/DeleteDepositsAndBatches.ps1
@@ -18,7 +18,7 @@ function OpenConnection{
 #Deletes all batches in the list
 function DeleteBatches($DBConnection){
 	$batchList = import-csv $batchListCSV
-	
+	$error_count = 0
 	foreach($batch in $batchList)
 	{
 		if(![string]::IsNullOrEmpty($batch.R_Batch_Name))
@@ -39,15 +39,17 @@ function DeleteBatches($DBConnection){
 			} catch {
 				write-host "There was an error deleting data related to batch "$batch.R_Batch_Name
 				write-host "Error: " $Error
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Deletes all deposits in the list
 function DeleteDeposites($DBConnection){
 	$depositList = import-csv $depositListCSV
-	
+	$error_count = 0
 	foreach($deposit in $depositList)
 	{
 		if(![string]::IsNullOrEmpty($deposit.R_Deposit_Name))
@@ -68,19 +70,25 @@ function DeleteDeposites($DBConnection){
 			} catch {
 				write-host "There was an error deleting data related to deposit "$deposit.R_Deposit_Name
 				write-host "Error: " $Error
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Execute
 try{
 	$DBConnection = OpenConnection
-	DeleteBatches $DBConnection
-	DeleteDeposites $DBConnection
+	$errors = 0
+	$errors += DeleteBatches $DBConnection
+	$errors += DeleteDeposites $DBConnection
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1
 } finally {
 	$DBConnection.Close();
+	if($errors -ne 0){
+		exit 1
+	}
 }

--- a/CI/TestSQL/02.TestData/02.Program/CreatePrograms.ps1
+++ b/CI/TestSQL/02.TestData/02.Program/CreatePrograms.ps1
@@ -17,7 +17,7 @@ function OpenConnection{
 #Create all programs in list
 function CreatePrograms($DBConnection){
 	$programDataList = import-csv $programDataCSV
-	
+	$error_count = 0
 	foreach($programRow in $programDataList)
 	{
 		if(![string]::IsNullOrEmpty($programRow.R_Program_Name))
@@ -46,19 +46,24 @@ function CreatePrograms($DBConnection){
 			$program_created = LogResult $command "@program_id" "Program created"
 			
 			if(!$program_created){
-				throw
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Execute all the update functions
 try{
 	$DBConnection = OpenConnection
-	CreatePrograms $DBConnection
+	$errors = 0
+	$errors += CreatePrograms $DBConnection
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1
 } finally {
 	$DBConnection.Close();
+	if($errors -ne 0){
+		exit 1
+	}
 }

--- a/CI/TestSQL/02.TestData/02.Program/DeletePrograms.ps1
+++ b/CI/TestSQL/02.TestData/02.Program/DeletePrograms.ps1
@@ -17,7 +17,7 @@ function OpenConnection{
 #Deletes all programs in the list
 function DeletePrograms($DBConnection){
 	$programList = import-csv $programListCSV
-	
+	$error_count = 0
 	foreach($program in $programList)
 	{
 		if(![string]::IsNullOrEmpty($program.R_Program_Name))
@@ -38,18 +38,24 @@ function DeletePrograms($DBConnection){
 			} catch {
 				write-host "There was an error deleting data related to program "$program.R_Program_Name
 				write-host "Error: " $Error
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Execute
 try{
 	$DBConnection = OpenConnection
-	DeletePrograms $DBConnection
+	$errors = 0
+	$errors += DeletePrograms $DBConnection
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1
 } finally {
 	$DBConnection.Close();
+	if($errors -ne 0){
+		exit 1
+	}
 }

--- a/CI/TestSQL/02.TestData/03.Group+Attribute/CreateAttributes.csv
+++ b/CI/TestSQL/02.TestData/03.Group+Attribute/CreateAttributes.csv
@@ -1,3 +1,2 @@
 R_Attribute_Name,Attribute_Type,Attribute_Category
 (t) Automation testing,90,20
-(t) (men and women together),90,19

--- a/CI/TestSQL/02.TestData/03.Group+Attribute/CreateGroupAttributes.csv
+++ b/CI/TestSQL/02.TestData/03.Group+Attribute/CreateGroupAttributes.csv
@@ -2,3 +2,4 @@ R_Attribute_Name,R_Group_Name,R_Start_Date
 (t) Automation testing,(t+auto) The Next Generation,11/1/2015
 Anyone welcome,(t+auto) The Next Generation,11/1/2015
 College Students,(t+auto) The Next Generation,11/1/2015
+verybaddata,notagroup! Fail!,11/01/15

--- a/CI/TestSQL/02.TestData/03.Group+Attribute/CreateGroupAttributes.csv
+++ b/CI/TestSQL/02.TestData/03.Group+Attribute/CreateGroupAttributes.csv
@@ -2,4 +2,3 @@ R_Attribute_Name,R_Group_Name,R_Start_Date
 (t) Automation testing,(t+auto) The Next Generation,11/1/2015
 Anyone welcome,(t+auto) The Next Generation,11/1/2015
 College Students,(t+auto) The Next Generation,11/1/2015
-verybaddata,notagroup! Fail!,11/01/15

--- a/CI/TestSQL/02.TestData/03.Group+Attribute/CreateGroupAttributes.csv
+++ b/CI/TestSQL/02.TestData/03.Group+Attribute/CreateGroupAttributes.csv
@@ -1,4 +1,4 @@
 R_Attribute_Name,R_Group_Name,R_Start_Date
 (t) Automation testing,(t+auto) The Next Generation,11/1/2015
-(t) (men and women together),(t+auto) The Next Generation,11/1/2015
+Anyone welcome,(t+auto) The Next Generation,11/1/2015
 College Students,(t+auto) The Next Generation,11/1/2015

--- a/CI/TestSQL/02.TestData/03.Group+Attribute/CreateGroupsAndAttributes.ps1
+++ b/CI/TestSQL/02.TestData/03.Group+Attribute/CreateGroupsAndAttributes.ps1
@@ -3,9 +3,9 @@ param (
     [string]$addChildGroupDataCSV = ((Split-Path $MyInvocation.MyCommand.Definition)+"\AddChildGroup.csv"),
     [string]$attributeDataCSV = ((Split-Path $MyInvocation.MyCommand.Definition)+"\CreateAttributes.csv"),
     [string]$groupAttributeDataCSV = ((Split-Path $MyInvocation.MyCommand.Definition)+"\CreateGroupAttributes.csv"),
-    [string]$DBServer = "mp-int-db.centralus.cloudapp.azure.com",
-    [string]$DBUser = $(Get-ChildItem Env:MP_SOURCE_DB_USER).Value, # Default to environment variable
-    [string]$DBPassword = $(Get-ChildItem Env:MP_SOURCE_DB_PASSWORD).Value # Default to environment variable
+    [string]$DBServer = "mp-demo-db.centralus.cloudapp.azure.com",
+    [string]$DBUser = 'MigrateUser', #$(Get-ChildItem Env:MP_SOURCE_DB_USER).Value, # Default to environment variable
+    [string]$DBPassword = 'Aw@!ted2014' #$(Get-ChildItem Env:MP_SOURCE_DB_PASSWORD).Value # Default to environment variable
  )
 
 . ((Split-Path $MyInvocation.MyCommand.Definition)+"\..\..\00.PowershellScripts\DBCommand.ps1") #should avoid dot-source errors
@@ -148,12 +148,13 @@ function CreateGroupAttributes($DBConnection){
 			$result = $command.ExecuteNonQuery()
 			$error_found = LogResult $command "@error_message" "ERROR"
 			$attribute_created = LogResult $command "@group_attribute_id" "Group Attribute created"
-			
+			write-host "attribute created = $attribute_created"
 			if(!$attribute_created){
 				$error_count += 1
 			}
 		}
 	}
+	write-host $error_count
 	return $error_count
 }
 
@@ -161,10 +162,11 @@ function CreateGroupAttributes($DBConnection){
 try{
 	$DBConnection = OpenConnection
 	$errors = 0
-	$errors += CreateGroups $DBConnection
-	$errors += AddChildGroup $DBConnection
-	$errors += CreateAttributes $DBConnection
+	#$errors += CreateGroups $DBConnection
+	#$errors += AddChildGroup $DBConnection
+	#$errors += CreateAttributes $DBConnection
 	$errors += CreateGroupAttributes $DBConnection
+	write-host $errors
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1

--- a/CI/TestSQL/02.TestData/03.Group+Attribute/CreateGroupsAndAttributes.ps1
+++ b/CI/TestSQL/02.TestData/03.Group+Attribute/CreateGroupsAndAttributes.ps1
@@ -20,7 +20,7 @@ function OpenConnection{
 #Create all groups in list
 function CreateGroups($DBConnection){
 	$groupDataList = import-csv $groupDataCSV
-
+	$error_count = 0
 	foreach($groupRow in $groupDataList)
 	{
 		if(![string]::IsNullOrEmpty($groupRow.R_Group_Name))
@@ -56,16 +56,17 @@ function CreateGroups($DBConnection){
 			$group_created = LogResult $command "@group_id" "Group created"
 			
 			if(!$group_created){
-				throw
+				$error_count += 1
 			}	
 		}
 	}
+	return $error_count
 }
 
 #Add child group to parent group
 function AddChildGroup($DBConnection){
 	$addChildGroupDataList = import-csv $addChildGroupDataCSV
-
+	$error_count = 0
 	foreach($groupRow in $addChildGroupDataList)
 	{
 		if(![string]::IsNullOrEmpty($groupRow.R_Parent_Group_Name))
@@ -87,16 +88,17 @@ function AddChildGroup($DBConnection){
 			$parent_found = LogResult $command "@parent_group_id" "        to parent Group"
 			
 			if(!$child_found -or !$parent_found){
-				throw
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Creates all attributes in list
 function CreateAttributes($DBConnection){
 	$attributeDataList = import-csv $attributeDataCSV
-
+	$error_count = 0
 	foreach($attributeRow in $attributeDataList)
 	{
 		if(![string]::IsNullOrEmpty($attributeRow.R_Attribute_Name))
@@ -117,16 +119,17 @@ function CreateAttributes($DBConnection){
 			$attribute_created = LogResult $command "@attribute_id" "Attribute created"
 			
 			if(!$attribute_created){
-				throw
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Creates group attributes
 function CreateGroupAttributes($DBConnection){
 	$groupAttributeDataList = import-csv $groupAttributeDataCSV
-
+	$error_count = 0
 	foreach($attributeRow in $groupAttributeDataList)
 	{
 		if(![string]::IsNullOrEmpty($attributeRow.R_Attribute_Name))
@@ -147,22 +150,27 @@ function CreateGroupAttributes($DBConnection){
 			$attribute_created = LogResult $command "@group_attribute_id" "Group Attribute created"
 			
 			if(!$attribute_created){
-				throw
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Execute all the Create functions
 try{
 	$DBConnection = OpenConnection
-	CreateGroups $DBConnection
-	AddChildGroup $DBConnection
-	CreateAttributes $DBConnection
-	CreateGroupAttributes $DBConnection
+	$errors = 0
+	$errors += CreateGroups $DBConnection
+	$errors += AddChildGroup $DBConnection
+	$errors += CreateAttributes $DBConnection
+	$errors += CreateGroupAttributes $DBConnection
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1
 } finally {
 	$DBConnection.Close();
+	if($errors -ne 0){
+		exit 1
+	}
 }

--- a/CI/TestSQL/02.TestData/03.Group+Attribute/CreateGroupsAndAttributes.ps1
+++ b/CI/TestSQL/02.TestData/03.Group+Attribute/CreateGroupsAndAttributes.ps1
@@ -3,9 +3,9 @@ param (
     [string]$addChildGroupDataCSV = ((Split-Path $MyInvocation.MyCommand.Definition)+"\AddChildGroup.csv"),
     [string]$attributeDataCSV = ((Split-Path $MyInvocation.MyCommand.Definition)+"\CreateAttributes.csv"),
     [string]$groupAttributeDataCSV = ((Split-Path $MyInvocation.MyCommand.Definition)+"\CreateGroupAttributes.csv"),
-    [string]$DBServer = "mp-demo-db.centralus.cloudapp.azure.com",
-    [string]$DBUser = 'MigrateUser', #$(Get-ChildItem Env:MP_SOURCE_DB_USER).Value, # Default to environment variable
-    [string]$DBPassword = 'Aw@!ted2014' #$(Get-ChildItem Env:MP_SOURCE_DB_PASSWORD).Value # Default to environment variable
+    [string]$DBServer = "mp-int-db.centralus.cloudapp.azure.com",
+    [string]$DBUser = $(Get-ChildItem Env:MP_SOURCE_DB_USER).Value, # Default to environment variable
+    [string]$DBPassword = $(Get-ChildItem Env:MP_SOURCE_DB_PASSWORD).Value # Default to environment variable
  )
 
 . ((Split-Path $MyInvocation.MyCommand.Definition)+"\..\..\00.PowershellScripts\DBCommand.ps1") #should avoid dot-source errors
@@ -148,13 +148,12 @@ function CreateGroupAttributes($DBConnection){
 			$result = $command.ExecuteNonQuery()
 			$error_found = LogResult $command "@error_message" "ERROR"
 			$attribute_created = LogResult $command "@group_attribute_id" "Group Attribute created"
-			write-host "attribute created = $attribute_created"
+			
 			if(!$attribute_created){
 				$error_count += 1
 			}
 		}
 	}
-	write-host $error_count
 	return $error_count
 }
 
@@ -162,11 +161,11 @@ function CreateGroupAttributes($DBConnection){
 try{
 	$DBConnection = OpenConnection
 	$errors = 0
-	#$errors += CreateGroups $DBConnection
-	#$errors += AddChildGroup $DBConnection
-	#$errors += CreateAttributes $DBConnection
+	$errors += CreateGroups $DBConnection
+	$errors += AddChildGroup $DBConnection
+	$errors += CreateAttributes $DBConnection
 	$errors += CreateGroupAttributes $DBConnection
-	write-host $errors
+	
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1

--- a/CI/TestSQL/02.TestData/03.Group+Attribute/DeleteGroupsAndAttributes.ps1
+++ b/CI/TestSQL/02.TestData/03.Group+Attribute/DeleteGroupsAndAttributes.ps1
@@ -18,7 +18,7 @@ function OpenConnection{
 #Deletes all groups in the list
 function DeleteGroups($DBConnection){
 	$groupList = import-csv $groupListCSV
-	
+	$error_count = 0
 	foreach($group in $groupList)
 	{
 		if(![string]::IsNullOrEmpty($group.R_Group_Name))
@@ -39,15 +39,17 @@ function DeleteGroups($DBConnection){
 			} catch {
 				write-host "There was an error deleting data related to group "$group.R_Group_Name
 				write-host "Error: " $Error
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Deletes all attributes in the list
 function DeleteAttributes($DBConnection){
 	$attributeList = import-csv $attributeDataCSV
-	
+	$error_count = 0
 	foreach($attribute in $attributeList)
 	{
 		if(![string]::IsNullOrEmpty($attribute.R_Attribute_Name))
@@ -68,19 +70,25 @@ function DeleteAttributes($DBConnection){
 			} catch {
 				write-host "There was an error deleting data related to attribute "$attribute.R_Attribute_Name
 				write-host "Error: " $Error
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Execute
 try{
 	$DBConnection = OpenConnection
-	DeleteGroups $DBConnection
-	DeleteAttributes $DBConnection
+	$errors = 0
+	$errors += DeleteGroups $DBConnection
+	$errors += DeleteAttributes $DBConnection
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1
 } finally {
 	$DBConnection.Close();
+	if($errors -ne 0){
+		exit 1
+	}
 }

--- a/CI/TestSQL/02.TestData/04.Event+EventType/CreateEventsAndEventTypes.ps1
+++ b/CI/TestSQL/02.TestData/04.Event+EventType/CreateEventsAndEventTypes.ps1
@@ -18,7 +18,7 @@ function OpenConnection{
 #Create all event types in list
 function CreateEventTypes($DBConnection){
 	$eventTypeDataList = import-csv $eventTypeDataCSV
-	
+	$error_count = 0
 	foreach($eventTypeRow in $eventTypeDataList)
 	{
 		if(![string]::IsNullOrEmpty($eventTypeRow.R_Event_Type))
@@ -38,16 +38,17 @@ function CreateEventTypes($DBConnection){
 			$event_type_created = LogResult $command "@event_type_id" "Event Type created"
 			
 			if(!$event_type_created){
-				throw
+				$error_count += 1
 			}			
 		}
 	}
+	return $error_count
 }
 
 #Create all event types in list
 function CreateEvents($DBConnection){
 	$eventDataList = import-csv $eventDataCSV
-	
+	$error_count = 0
 	foreach($eventRow in $eventDataList)
 	{
 		if(![string]::IsNullOrEmpty($eventRow.R_Event_Name))
@@ -77,20 +78,25 @@ function CreateEvents($DBConnection){
 			
 			#Event group is not required, so don't error out if not created
 			if(!$event_created){
-				throw
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Execute all the update functions
 try{
 	$DBConnection = OpenConnection
-	CreateEventTypes $DBConnection
-	CreateEvents $DBConnection
+	$errors = 0
+	$errors += CreateEventTypes $DBConnection
+	$errors += CreateEvents $DBConnection
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1
 } finally {
 	$DBConnection.Close();
+	if($errors -ne 0){
+		exit 1
+	}
 }

--- a/CI/TestSQL/02.TestData/04.Event+EventType/DeleteEventsAndEventTypes.ps1
+++ b/CI/TestSQL/02.TestData/04.Event+EventType/DeleteEventsAndEventTypes.ps1
@@ -18,7 +18,7 @@ function OpenConnection{
 #Deletes all event types in the list
 function DeleteEventTypes($DBConnection){
 	$eventTypeDataList = import-csv $eventTypeDataCSV
-	
+	$error_count = 0
 	foreach($eventtype in $eventTypeDataList)
 	{
 		if(![string]::IsNullOrEmpty($eventtype.R_Event_Type))
@@ -39,15 +39,17 @@ function DeleteEventTypes($DBConnection){
 			} catch {
 				write-host "There was an error deleting data related to event type "$eventtype.R_Event_Type
 				write-host "Error: " $Error
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Deletes all events in the list
 function DeleteEvents($DBConnection){
 	$eventDataList = import-csv $eventDataCSV
-	
+	$error_count = 0
 	foreach($event in $eventDataList)
 	{
 		if(![string]::IsNullOrEmpty($event.R_Event_Name))
@@ -69,19 +71,25 @@ function DeleteEvents($DBConnection){
 			} catch {
 				write-host "There was an error deleting data related to event "$event.R_Event_Name
 				write-host "Error: " $Error
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Execute
 try{
 	$DBConnection = OpenConnection
-	DeleteEventTypes $DBConnection
-	DeleteEvents $DBConnection
+	$errors = 0
+	$errors += DeleteEventTypes $DBConnection
+	$errors += DeleteEvents $DBConnection
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1
 } finally {
 	$DBConnection.Close();
+	if($errors -ne 0){
+		exit 1
+	}
 }

--- a/CI/TestSQL/02.TestData/05.Opportunity+Response/CreateOpportunitiesAndResponses.ps1
+++ b/CI/TestSQL/02.TestData/05.Opportunity+Response/CreateOpportunitiesAndResponses.ps1
@@ -18,7 +18,7 @@ function OpenConnection{
 #Create all opportunities in list
 function CreateOpportunities($DBConnection){
 	$opportunityDataList = import-csv $opportunityDataCSV
-	
+	$error_count = 0
 	foreach($opportunityRow in $opportunityDataList)
 	{
 		if(![string]::IsNullOrEmpty($opportunityRow.R_Opportunity_Title))
@@ -50,16 +50,17 @@ function CreateOpportunities($DBConnection){
 			$opportunity_created = LogResult $command "@opportunity_id" "Opportunity created"
 			
 			if(!$opportunity_created){
-				throw
+				$error_count += 1
 			}			
 		}
 	}
+	return $error_count
 }
 
 #Create all responses in list
 function CreateResponses($DBConnection){
 	$responseDataList = import-csv $responseDataCSV
-	
+	$error_count = 0
 	foreach($responseRow in $responseDataList)
 	{
 		if(![string]::IsNullOrEmpty($responseRow.R_User_Email))
@@ -81,20 +82,25 @@ function CreateResponses($DBConnection){
 			$response_created = LogResult $command "@response_id" "Response created"
 			
 			if(!$response_created){
-				throw
+				$error_count += 1
 			}			
 		}
 	}
+	return $error_count
 }
 
 #Execute all the update functions
 try{
 	$DBConnection = OpenConnection
-	CreateOpportunities $DBConnection
-	CreateResponses $DBConnection
+	$errors = 0
+	$errors += CreateOpportunities $DBConnection
+	$errors += CreateResponses $DBConnection
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1
 } finally {
 	$DBConnection.Close();
+	if($errors -ne 0){
+		exit 1
+	}
 }

--- a/CI/TestSQL/02.TestData/05.Opportunity+Response/DeleteOpportunities.ps1
+++ b/CI/TestSQL/02.TestData/05.Opportunity+Response/DeleteOpportunities.ps1
@@ -18,7 +18,7 @@ function OpenConnection{
 #Deletes all opportunities in the list
 function DeleteOpportunities($DBConnection){
 	$opportunityList = import-csv $opportunityDataCSV
-	
+	$error_count = 0
 	foreach($opportunity in $opportunityList)
 	{
 		if(![string]::IsNullOrEmpty($opportunity.R_Opportunity_Title))
@@ -39,18 +39,24 @@ function DeleteOpportunities($DBConnection){
 			} catch {
 				write-host "There was an error deleting data related to opportunity "$opportunity.R_Opportunity_Title
 				write-host "Error: " $Error
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Execute
 try{
 	$DBConnection = OpenConnection
-	DeleteOpportunities $DBConnection
+	$errors = 0
+	$errors += DeleteOpportunities $DBConnection
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1
 } finally {
 	$DBConnection.Close();
+	if($errors -ne 0){
+		exit 1
+	}
 }

--- a/CI/TestSQL/02.TestData/06.PledgeCampaign+Pledge/CreatePledgeCampaignsAndPledges.ps1
+++ b/CI/TestSQL/02.TestData/06.PledgeCampaign+Pledge/CreatePledgeCampaignsAndPledges.ps1
@@ -18,7 +18,7 @@ function OpenConnection{
 #Create all pledge campaigns in list
 function CreatePledgeCampaigns($DBConnection){
 	$pledgeCampaignDataList = import-csv $pledgeCampaignDataCSV
-	
+	$error_count = 0
 	foreach($pledgeCampaignRow in $pledgeCampaignDataList)
 	{
 		if(![string]::IsNullOrEmpty($pledgeCampaignRow.R_Campaign_Name))
@@ -51,16 +51,17 @@ function CreatePledgeCampaigns($DBConnection){
 			$pledge_campaign_created = LogResult $command "@campaign_id" "Pledge Campaign created"
 			
 			if(!$pledge_campaign_created){
-				throw
+				$error_count += 1
 			}			
 		}
 	}
+	return $error_count
 }
 
 #Create all pledges in list
 function CreatePledges($DBConnection){
 	$pledgeDataList = import-csv $pledgeDataCSV
-	
+	$error_count = 0
 	foreach($pledgeRow in $pledgeDataList)
 	{
 		if(![string]::IsNullOrEmpty($pledgeRow.R_Donor_Email))
@@ -83,20 +84,25 @@ function CreatePledges($DBConnection){
 			$pledge_created = LogResult $command "@pledge_id" "Pledge created"
 			
 			if(!$pledge_created){
-				throw
+				$error_count += 1
 			}			
 		}
 	}
+	return $error_count
 }
 
 #Execute all the update functions
 try{
 	$DBConnection = OpenConnection
-	CreatePledgeCampaigns $DBConnection
-	CreatePledges $DBConnection
+	$errors = 0
+	$errors += CreatePledgeCampaigns $DBConnection
+	$errors += CreatePledges $DBConnection
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1
 } finally {
 	$DBConnection.Close();
+	if($errors -ne 0){
+		exit 1
+	}
 }

--- a/CI/TestSQL/02.TestData/06.PledgeCampaign+Pledge/DeletePledgeCampaigns.ps1
+++ b/CI/TestSQL/02.TestData/06.PledgeCampaign+Pledge/DeletePledgeCampaigns.ps1
@@ -18,7 +18,7 @@ function OpenConnection{
 #Deletes all pledge campaigns in the list
 function DeletePledgeCampaigns($DBConnection){
 	$pledgeCampaignList = import-csv $pledgeCampaignDataCSV
-	
+	$error_count = 0
 	foreach($pledgeCampaign in $pledgeCampaignList)
 	{
 		if(![string]::IsNullOrEmpty($pledgeCampaign.R_Campaign_Name))
@@ -39,18 +39,24 @@ function DeletePledgeCampaigns($DBConnection){
 			} catch {
 				write-host "There was an error deleting data related to Pledge Campaign "$pledgeCampaign.R_Campaign_Name
 				write-host "Error: " $Error
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Execute
 try{
 	$DBConnection = OpenConnection
-	DeletePledgeCampaigns $DBConnection
+	$errors = 0
+	$errors += DeletePledgeCampaigns $DBConnection
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1
 } finally {
 	$DBConnection.Close();
+	if($errors -ne 0){
+		exit 1
+	}
 }

--- a/CI/TestSQL/02.TestData/07.Donation+Distribution/CreateDonations.ps1
+++ b/CI/TestSQL/02.TestData/07.Donation+Distribution/CreateDonations.ps1
@@ -19,7 +19,7 @@ function OpenConnection{
 #Create all donations in list
 function CreateDonations($DBConnection){
 	$donationDataList = import-csv $donationDataCSV
-	
+	$error_count = 0
 	foreach($donationRow in $donationDataList)
 	{
 		if(![string]::IsNullOrEmpty($donationRow.R_Donor_Email))
@@ -53,7 +53,8 @@ function CreateDonations($DBConnection){
 			$donation_created = LogResult $d_command "@donation_id" "Donation created"
 			
 			if(!$donation_created){
-				throw
+				$error_count += 1
+				continue
 			}
 			
 			$donation_id = $d_command.Parameters["@donation_id"].Value
@@ -79,16 +80,17 @@ function CreateDonations($DBConnection){
 			$distribution_created = LogResult $dd_command "@distribution_id" "        with Donation Distribution"
 			
 			if(!$distribution_created){
-				throw
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Create all donations in the list
 function CreateDonationNoUserAccount($DBConnection){
 	$donationNoUserDataList = import-csv $donationNoUserDataCSV
-	
+	$error_count = 0
 	foreach($donationRow in $donationNoUserDataList)
 	{
 		if(![string]::IsNullOrEmpty($donationRow.R_Donor_Display_Name))
@@ -105,7 +107,8 @@ function CreateDonationNoUserAccount($DBConnection){
 			$contact_found = LogResult $c_command "@contact_id" "Contact making donation"
 			
 			if(!$contact_found){
-				throw
+				$error_count += 1
+				continue
 			}
 			
 			$contact_id = $c_command.Parameters["@contact_id"].Value
@@ -140,7 +143,8 @@ function CreateDonationNoUserAccount($DBConnection){
 			$donation_created = LogResult $d_command "@donation_id" "Donation created"
 			
 			if(!$donation_created){
-				throw
+				$error_count += 1
+				continue
 			}
 			
 			$donation_id = $d_command.Parameters["@donation_id"].Value
@@ -166,17 +170,18 @@ function CreateDonationNoUserAccount($DBConnection){
 			$distribution_created = LogResult $dd_command "@distribution_id" "        with Donation Distribution"
 			
 			if(!$distribution_created){
-				throw
+				$error_count += 1
 			}			
 		}
 	}
+	return $error_count
 }
 
 
 #Create all donations in list
 function CreateDonationsWithTwoDistributions($DBConnection){
 	$donationTwoDistributionsDataList = import-csv $donationTwoDistributionsDataCSV
-	
+	$error_count = 0
 	foreach($donationRow in $donationTwoDistributionsDataList)
 	{
 		if(![string]::IsNullOrEmpty($donationRow.R_Donor_Email))
@@ -210,7 +215,8 @@ function CreateDonationsWithTwoDistributions($DBConnection){
 			$donation_created = LogResult $d_command "@donation_id" "Donation created"
 			
 			if(!$donation_created){
-				throw
+				$error_count += 1
+				continue
 			}
 			
 			$donation_id = $d_command.Parameters["@donation_id"].Value
@@ -236,7 +242,8 @@ function CreateDonationsWithTwoDistributions($DBConnection){
 			$distribution_created = LogResult $dd1_command "@distribution_id" "        with first Distribution"
 			
 			if(!$distribution_created){
-				throw
+				$error_count += 1
+				continue
 			}
 			
 			
@@ -260,24 +267,27 @@ function CreateDonationsWithTwoDistributions($DBConnection){
 			$distribution_created = LogResult $dd2_command "@distribution_id" "        and second Distribution"
 			
 			if(!$distribution_created){
-				throw
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
-
-
 
 
 #Execute all the update functions
 try{
 	$DBConnection = OpenConnection
-	CreateDonations $DBConnection
-	CreateDonationNoUserAccount $DBConnection
-	CreateDonationsWithTwoDistributions $DBConnection
+	$errors = 0
+	$errors += CreateDonations $DBConnection
+	$errors += CreateDonationNoUserAccount $DBConnection
+	$errors += CreateDonationsWithTwoDistributions $DBConnection
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1
 } finally {
 	$DBConnection.Close();
+	if($errors -ne 0){
+		exit 1
+	}
 }

--- a/CI/TestSQL/02.TestData/09.EventParticipants+GroupParticipants/CreateEventAndGroupParticipants.ps1
+++ b/CI/TestSQL/02.TestData/09.EventParticipants+GroupParticipants/CreateEventAndGroupParticipants.ps1
@@ -18,7 +18,7 @@ function OpenConnection{
 #Create all event participants in list
 function CreateEventParticipants($DBConnection){
 	$eventParticipantDataList = import-csv $eventParticipantDataCSV
-	
+	$error_count = 0
 	foreach($participantRow in $eventParticipantDataList)
 	{
 		if(![string]::IsNullOrEmpty($participantRow.R_Event_Name))
@@ -43,16 +43,17 @@ function CreateEventParticipants($DBConnection){
 			$event_participant_created = LogResult $command "@event_participant_id" "Event Participant created"
 			
 			if(!$event_participant_created){
-				throw
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Create all group participants in list
 function CreateGroupParticipants($DBConnection){
 	$groupParticipantDataList = import-csv $groupParticipantDataCSV
-	
+	$error_count = 0
 	foreach($participantRow in $groupParticipantDataList)
 	{
 		if(![string]::IsNullOrEmpty($participantRow.R_Group_Name))
@@ -74,20 +75,25 @@ function CreateGroupParticipants($DBConnection){
 			$group_participant_created = LogResult $command "@group_participant_id" "Group Participant created"
 			
 			if(!$group_participant_created){
-				throw
+				$error_count += 1
 			}
 		}
 	}
+	return $error_count
 }
 
 #Execute all the update functions
 try{
 	$DBConnection = OpenConnection
-	CreateEventParticipants $DBConnection
-	CreateGroupParticipants $DBConnection
+	$errors = 0
+	$errors += CreateEventParticipants $DBConnection
+	$errors += CreateGroupParticipants $DBConnection
 } catch {
 	write-host "Error encountered in $($MyInvocation.MyCommand.Name): "$_
 	exit 1
 } finally {
 	$DBConnection.Close();
+	if($errors -ne 0){
+		exit 1
+	}
 }


### PR DESCRIPTION
- Previously, if an entry could not be created in MP, the remaining entries in the same file would be skipped. With this update, the script will attempt to create all data in the file and report a failing exit code at the end if anything could not be created.
- The master file called by TC will now report a failing exit code if any entry could not be created so TC can be configured to stop the build.

[TeamCity run ](http://mp-ci.centralus.cloudapp.azure.com/viewLog.html?buildId=44740&buildTypeId=Qa_Release_TeardownAndReloadTestData&tab=buildLog#_state=64)where failed teardown stops further steps.

Bonus:
- Fixed a group attribute configuration

Todo:
- The failure is an actual bug that needs to be fixed, but it does demo the exit codes added in this PR work. Bug will be fixed in a future PR.