### PR TITLE
Defect/dewxyz - Loosen event type search

### DIFF
--- a/CI/TestSQL/02.TestData/04.Event+EventType/CreateEvents.csv
+++ b/CI/TestSQL/02.TestData/04.Event+EventType/CreateEvents.csv
@@ -25,5 +25,5 @@ R_Event_Name,R_Start_Date,R_End_Date,R_Event_Type,R_Program_Name,R_Contact_Email
 (t) Kids Club Oakley 1:00,1/12/2018 13:00,1/12/2018 15:00,(t) KC Nursery Oakley weekly 1:00,Kids Club,jkerstanoff@callibrity.com,1,3,(t) KidsClub Oakley Group,,,,,
 (t) Kids Club Oakley 1:00,1/19/2018 13:00,1/19/2018 15:00,(t) KC Nursery Oakley weekly 1:00,Kids Club,jkerstanoff@callibrity.com,1,3,(t) KidsClub Oakley Group,,,,,
 (t) Kids Club Oakley 1:00,1/26/2018 13:00,1/26/2018 15:00,(t) KC Nursery Oakley weekly 1:00,Kids Club,jkerstanoff@callibrity.com,1,3,(t) KidsClub Oakley Group,,,,,
-(t) 1Time Mason with ChildCare,1/5/2018 13:00,1/8/2018 13:00,*Onsite Groups,Kids Club,matt.silbernagel@ingagepartners.com,6,5,(t) 1Time Mason Group with ChildCare,,,,,
+(t) 1Time Mason with ChildCare,1/5/2018 13:00,1/8/2018 13:00,Onsite Groups,Kids Club,matt.silbernagel@ingagepartners.com,6,5,(t) 1Time Mason Group with ChildCare,,,,,
 (t) 1Time Mason with ChildCare - Childcare,1/5/2018 13:00,1/8/2018 13:00,Childcare,Kids Club,matt.silbernagel@ingagepartners.com,6,5,(t) 1Time Mason Group with ChildCare,,,,"Trigger will create this event automatically, this will update it",

--- a/CI/TestSQL/02.TestData/04.Event+EventType/Special Cases.txt
+++ b/CI/TestSQL/02.TestData/04.Event+EventType/Special Cases.txt
@@ -1,0 +1,1 @@
+-When creating an event in CreateEvents.csv, please omit the "*" prefix from any Event Type unless the Event Type is also scripted test data. Int and Demo have some naming differences, and ommitting the * prefix (or other prefix that's in one environment but not the other) will allow test data to be created accurately in both environments.

--- a/CI/TestSQL/02.TestData/04.Event+EventType/Stored Procs/03.CreateData_CreateEvent_StoredProc.sql
+++ b/CI/TestSQL/02.TestData/04.Event+EventType/Stored Procs/03.CreateData_CreateEvent_StoredProc.sql
@@ -77,6 +77,11 @@ BEGIN
 
 	DECLARE @event_type_id int;
 	SET @event_type_id = (SELECT TOP 1 Event_Type_ID FROM [dbo].Event_Types WHERE Event_Type = @event_type_name ORDER BY Event_Type_ID ASC);
+	--Some event types in int are prefixed with *. Loosen the search up to make more compatible.
+	IF @event_type_id is null
+	BEGIN
+		SET @event_type_id = (SELECT TOP 1 Event_Type_ID FROM [dbo].Event_Types WHERE Event_Type LIKE '%'+@event_type_name ORDER BY Event_Type_ID ASC);
+	END;
 	IF @event_type_id is null
 	BEGIN
 		SET @error_message = 'Could not find event type with name '+@event_type_name+CHAR(13);


### PR DESCRIPTION
- Noticed that some event types in Int are prefixed with a * where Demo and Prod are not. This PR allows create event to search for event types with different prefixes if exact match not found.

[TeamCity run](http://mp-ci.centralus.cloudapp.azure.com/viewQueued.html?itemId=44984&buildTypeId=Qa_Release_TeardownAndReloadTestData&tab=buildLog) from this branch.