### PR TITLE
US12479: Email Subscription Messaging

### DIFF
--- a/crossroads.net/app/profile/communications/profileCommunications.html
+++ b/crossroads.net/app/profile/communications/profileCommunications.html
@@ -4,15 +4,8 @@
       <span dynamic-content="$root.MESSAGES.profileCommunicationsHeader.content | html"></span>
       <div class="row">
         <legend class="col-sm-12">Email Communications</legend>
-        <div ng-repeat="subscription in profileCommunications.subscriptions" class="form-group clearfix toggle-input-group">
-          <div class="col-xs-6">
-            <label class="block">{{subscription.Title}}
-              <br /><small class="text-muted">{{subscription.Description}}</small>
-            </label>
-          </div>
-          <div class="col-xs-6">
-            <toggle-switch ng-click="profileCommunications.saveSubscription(subscription)" ng-model="subscription.Subscribed"></toggle-switch>
-          </div>
+        <div class="col-md-6">
+          <div dynamic-content="$root.MESSAGES.profileEmailCommunications.content | html"></div>
         </div>
       </div><!--/row-->
 <!-- Mock, NOT YET IMPLEMENTED

--- a/crossroads.net/app/profile/communications/profileCommunications.html
+++ b/crossroads.net/app/profile/communications/profileCommunications.html
@@ -4,7 +4,7 @@
       <span dynamic-content="$root.MESSAGES.profileCommunicationsHeader.content | html"></span>
       <div class="row">
         <legend class="col-sm-12">Email Communications</legend>
-        <div class="col-md-6">
+        <div class="col-md-8">
           <div dynamic-content="$root.MESSAGES.profileEmailCommunications.content | html"></div>
         </div>
       </div><!--/row-->


### PR DESCRIPTION
Due to some serious hoops we'd have to jump through, crds is opting to notify the user about their email preferences through Hubspot's custom generated prefs page found in an email instead of using an embedded toggle solution.

There is a content block called `profileEmailCommunications` that angular draws from to get this content.