### PR TITLE
US12063 - Use MP REST API and filter layouts based on null Room_ID

### DIFF
--- a/Gateway/MinistryPlatform.Translation/Repositories/RoomRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/RoomRepository.cs
@@ -150,8 +150,14 @@ namespace MinistryPlatform.Translation.Repositories
 
         public List<RoomLayout> GetRoomLayouts()
         {
-            var t = ApiLogin();
-            var records = _ministryPlatformService.GetPageViewRecords("RoomLayoutsById", t);
+            var filter = "Room_ID IS NULL";
+            var columns = "Room_Layout_ID,Layout_Name";
+            var orderBy = "Room_Layout_ID";
+
+            var token = ApiLogin();
+            var records = _ministryPlatformRestRepository
+                .UsingAuthenticationToken(token)
+                .SearchTable<Dictionary<string, object>>("Room_Layouts", filter, columns, orderBy);
 
             return records.Select(record => new RoomLayout
             {


### PR DESCRIPTION
The legacy Create/Edit tool should only show layouts where Room_ID is null.  This will allow us to populate the Room_Layouts table with additional room-specific layouts for the new Create/Edit tool that resides in the crds-mp-tools repo without impacting the legacy Create/Edit tool.