### PR TITLE
Defect/de5285 profile cookie mystery

### DIFF
--- a/crossroads.net/app/constants.js
+++ b/crossroads.net/app/constants.js
@@ -168,7 +168,9 @@
     COOKIES: {
       SESSION_ID: `${__CRDS_ENV__}sessionId`,
       REFRESH_TOKEN: `${__CRDS_ENV__}refreshToken`,
-      IMPERSONATION_ID: `${__CRDS_ENV__}impersonateUserId`
+      IMPERSONATION_ID: `${__CRDS_ENV__}impersonateUserId`,
+      USER_ID: 'userId',
+      USERNAME: 'username'
     },
     EVENTS: {
       ROOM_AVAILABLE: null,

--- a/crossroads.net/core/services/session_service.js
+++ b/crossroads.net/core/services/session_service.js
@@ -55,7 +55,7 @@
       $cookies.put(cookieNames.SESSION_ID, sessionId, { expires: expDate });
       $cookies.put(cookieNames.REFRESH_TOKEN, refreshToken, { expires: expDate });
       $cookies.put(cookieNames.USER_ID, userId, { expires: expDate });
-      $cookies.put(cookieNames:USERNAME, username, { expires: expDate });
+      $cookies.put(cookieNames.USERNAME, username, { expires: expDate });
       $http.defaults.headers.common.Authorization = sessionId;
       $http.defaults.headers.common.RefreshToken = refreshToken;
     };

--- a/crossroads.net/core/services/session_service.js
+++ b/crossroads.net/core/services/session_service.js
@@ -52,14 +52,10 @@
       $log.debug('creating cookies!');
       const expDate = new Date();
       expDate.setTime(expDate.getTime() + (userTokenExp * 1000));
-      $cookies.put(cookieNames.SESSION_ID, sessionId, {
-        expires: expDate
-      });
-      $cookies.put('userId', userId);
-      $cookies.put('username', username);
-      $cookies.put(cookieNames.REFRESH_TOKEN, refreshToken, {
-        expires: expDate
-      });
+      $cookies.put(cookieNames.SESSION_ID, sessionId, { expires: expDate });
+      $cookies.put(cookieNames.REFRESH_TOKEN, refreshToken, { expires: expDate });
+      $cookies.put(cookieNames.USER_ID, userId, { expires: expDate });
+      $cookies.put(cookieNames:USERNAME, username, { expires: expDate });
       $http.defaults.headers.common.Authorization = sessionId;
       $http.defaults.headers.common.RefreshToken = refreshToken;
     };

--- a/crossroads.net/spec-core/services/session.service.spec.js
+++ b/crossroads.net/spec-core/services/session.service.spec.js
@@ -33,6 +33,36 @@ describe('Session Service', function () {
     Backend.verifyNoOutstandingRequest();
   });
 
+  describe('function create(refreshToken, sessionId, userTokenExp, userId, username', function () {
+    it('should set session cookies when called', function () {
+      var refreshToken = 'abcdefg123456789';
+      var sessionId = 'afoobarsessionid0987';
+      var userTokenExp = 1800;
+      var userId = '123456789';
+      var username = 'Foobar User';
+      Session.create(refreshToken, sessionId, userTokenExp, userId, username);
+      expect($cookies.get('refreshToken')).toBe(refreshToken);
+      expect($cookies.get('sessionId')).toBe(sessionId);
+      expect($cookies.get('userId')).toBe(userId);
+      expect($cookies.get('username')).toBe(username);
+    });
+
+    it('should set session cookie expirations when called', function () {
+      var baseTime = new Date(2018, 01, 01);
+      jasmine.clock().mockDate(baseTime);
+      var refreshToken = 'abcdefg123456789';
+      var sessionId = 'afoobarsessionid0987';
+      var userTokenExp = 1800;
+      var userId = '123456789';
+      var username = 'Foobar User';
+      var expiration_time = "Thu Feb 01 2018 00:30:00 GMT-0500 (EST)"
+      spyOn($cookies, 'put');
+      Session.create(refreshToken, sessionId, userTokenExp, userId, username);
+      expect($cookies.put).toHaveBeenCalledWith('userId', '123456789', Object({ expires: Date(expiration_time) }) )
+      expect($cookies.put).toHaveBeenCalledWith('username', 'Foobar User', Object({ expires: Date(expiration_time) }) )
+    });
+  });
+
   it('should save an array of family members', function () {
     Session.addFamilyMembers(family);
     expect($cookies.get('family')).toBe(family.join(','));

--- a/crossroads.net/spec-core/services/session.service.spec.js
+++ b/crossroads.net/spec-core/services/session.service.spec.js
@@ -33,35 +33,6 @@ describe('Session Service', function () {
     Backend.verifyNoOutstandingRequest();
   });
 
-  describe('function create(refreshToken, sessionId, userTokenExp, userId, username', function () {
-    it('should set session cookies when called', function () {
-      var refreshToken = 'abcdefg123456789';
-      var sessionId = 'afoobarsessionid0987';
-      var userTokenExp = 1800;
-      var userId = '123456789';
-      var username = 'Foobar User';
-      Session.create(refreshToken, sessionId, userTokenExp, userId, username);
-      expect($cookies.get('refreshToken')).toBe(refreshToken);
-      expect($cookies.get('sessionId')).toBe(sessionId);
-      expect($cookies.get('userId')).toBe(userId);
-      expect($cookies.get('username')).toBe(username);
-    });
-
-    it('should set session cookie expirations when called', function () {
-      var baseTime = new Date(2018, 01, 01);
-      jasmine.clock().mockDate(baseTime);
-      var refreshToken = 'abcdefg123456789';
-      var sessionId = 'afoobarsessionid0987';
-      var userTokenExp = 1800;
-      var userId = '123456789';
-      var username = 'Foobar User';
-      var expiration_time = "Thu Feb 01 2018 00:30:00 GMT-0500 (EST)"
-      spyOn($cookies, 'put');
-      Session.create(refreshToken, sessionId, userTokenExp, userId, username);
-      expect($cookies.put).toHaveBeenCalledWith('userId', '123456789', Object({ expires: Date(expiration_time) }) )
-      expect($cookies.put).toHaveBeenCalledWith('username', 'Foobar User', Object({ expires: Date(expiration_time) }) )
-    });
-  });
 
   it('should save an array of family members', function () {
     Session.addFamilyMembers(family);
@@ -308,5 +279,35 @@ describe('Session Service', function () {
     });
 
   })
+
+  describe('function create(refreshToken, sessionId, userTokenExp, userId, username', function () {
+    it('should set session cookies when called', function () {
+      var refreshToken = 'abcdefg123456789';
+      var sessionId = 'afoobarsessionid0987';
+      var userTokenExp = 1800;
+      var userId = '123456789';
+      var username = 'Foobar User';
+      Session.create(refreshToken, sessionId, userTokenExp, userId, username);
+      expect($cookies.get('refreshToken')).toBe(refreshToken);
+      expect($cookies.get('sessionId')).toBe(sessionId);
+      expect($cookies.get('userId')).toBe(userId);
+      expect($cookies.get('username')).toBe(username);
+    });
+
+    it('should set session cookie expirations when called', function () {
+      var baseTime = new Date(2018, 01, 01);
+      jasmine.clock().mockDate(baseTime);
+      var refreshToken = 'abcdefg123456789';
+      var sessionId = 'afoobarsessionid0987';
+      var userTokenExp = 1800;
+      var userId = '123456789';
+      var username = 'Foobar User';
+      var expiration_time = "Thu Feb 01 2018 00:30:00 GMT-0500 (EST)"
+      spyOn($cookies, 'put');
+      Session.create(refreshToken, sessionId, userTokenExp, userId, username);
+      expect($cookies.put).toHaveBeenCalledWith('userId', '123456789', Object({ expires: Date(expiration_time) }) )
+      expect($cookies.put).toHaveBeenCalledWith('username', 'Foobar User', Object({ expires: Date(expiration_time) }) )
+    });
+  });
 
 });

--- a/crossroads.net/spec-core/services/session.service.spec.js
+++ b/crossroads.net/spec-core/services/session.service.spec.js
@@ -33,7 +33,6 @@ describe('Session Service', function () {
     Backend.verifyNoOutstandingRequest();
   });
 
-
   it('should save an array of family members', function () {
     Session.addFamilyMembers(family);
     expect($cookies.get('family')).toBe(family.join(','));


### PR DESCRIPTION
The original problem: A user who visits the site crossroads.net logs in, closes the browser, and opens it back up sees that they are still logged in, but their personal information stored in the username and userId cookies is gone, preventing them from seeing information on their /profile page, etc.

The solution: Explicitly set the expiration datetime for the username and userId cookies to mirror that of the sessionId cookie.

Unit test coverage: Unit tests were added to confirm that when a user logs in and expiration datetime is set for the username and userId cookies.

Impacts to other parts of the system: At the present time, I can't think of other ways in which the system is impacted. Logging out still works by removing the various cookies from the browser.

Other considerations: We are going to need to refactor / change this functionality when we implement the keep me logged in feature on crossroads.net as the current behavior to expire those cookies is hard coded in crds-angular.