### PR TITLE
US13212 - Use UTC instead of local for end date because some donations are UTC

### DIFF
--- a/CI/SQL/20180716_090000_US13212-assign-pledges-nightly.sql
+++ b/CI/SQL/20180716_090000_US13212-assign-pledges-nightly.sql
@@ -73,7 +73,7 @@ BEGIN
 		) SP
 	WHERE
 		DD.Pledge_ID IS NULL
-		AND D.Donation_Date BETWEEN @FromDate AND GETDATE()
+		AND D.Donation_Date BETWEEN @FromDate AND GETUTCDATE()
 		AND D.Donor_ID NOT IN (@DefaultDonorID, @UnassignedDonorID)
 		AND (D.Donation_Status_ID = 2 OR D.Donation_Status_ID = 4)
 		AND Prog.Pledge_Campaign_ID IS NOT NULL


### PR DESCRIPTION
This fixes automation tests that create donations and then immediately run the stored proc.  The UTC vs. local discrepancy isn't an issue outside of automation because any donations that fall outside the date range will get processed on the next day.