### PR TITLE
US14573 - Password Confirmation should work without Contact email address

### DIFF
--- a/Gateway/crds-angular.test/Services/LoginServiceTest.cs
+++ b/Gateway/crds-angular.test/Services/LoginServiceTest.cs
@@ -1,11 +1,10 @@
 ﻿
 using crds_angular.Services;
 using crds_angular.Services.Interfaces;
-using Crossroads.Utilities.Interfaces;
 using log4net;
-using Crossroads.Web.Common;
 using Crossroads.Web.Common.Configuration;
 using Crossroads.Web.Common.Security;
+using MinistryPlatform.Translation.Models;
 using MPInterfaces = MinistryPlatform.Translation.Repositories.Interfaces;
 using Moq;
 using NUnit.Framework;
@@ -19,27 +18,24 @@ namespace crds_angular.test.Services
 
         private Mock<ILog> _logger;
 
-        private Mock<IAuthenticationRepository> _authenticationService;
+        private Mock<IAuthenticationRepository> _authenticationRepository;
         private Mock<IConfigurationWrapper> _configurationWrapper;
         private Mock<MPInterfaces.IContactRepository> _contactService;
         private Mock<IEmailCommunication> _emailCommunication;
-        private Mock<MPInterfaces.IUserRepository> _userService;
+        private Mock<MPInterfaces.IUserRepository> _userRepository;
         
 
         [SetUp]
         public void SetUp()
         {
             _logger = new Mock<ILog>();
-            _authenticationService = new Mock<IAuthenticationRepository>();
+            _authenticationRepository = new Mock<IAuthenticationRepository>();
             _configurationWrapper = new Mock<IConfigurationWrapper>();
             _contactService = new Mock<MPInterfaces.IContactRepository>();
             _emailCommunication = new Mock<IEmailCommunication>();
-            _userService = new Mock<MPInterfaces.IUserRepository>();
+            _userRepository = new Mock<MPInterfaces.IUserRepository>();
             
-            _loginService = new LoginService(_authenticationService.Object, _configurationWrapper.Object, _contactService.Object, _emailCommunication.Object, _userService.Object);
-
-            _contactService.Setup(m => m.GetContactIdByEmail(It.IsAny<string>())).Returns(123456);
-            _userService.Setup(m => m.GetUserIdByUsername(It.IsAny<string>())).Returns(123456);
+            _loginService = new LoginService(_authenticationRepository.Object, _configurationWrapper.Object, _contactService.Object, _emailCommunication.Object, _userRepository.Object);
         }
 
         [Test]
@@ -47,7 +43,31 @@ namespace crds_angular.test.Services
         {
             string email = "someone@someone.com";
 
+            _contactService.Setup(m => m.GetContactIdByEmail(It.IsAny<string>())).Returns(123456);
+            _userRepository.Setup(m => m.GetUserIdByUsername(It.IsAny<string>())).Returns(123456);
+
             var result = _loginService.PasswordResetRequest(email, false);
+            Assert.AreEqual(true, result);
+        }
+
+        [Test]
+        public void TestIsValidPassword()
+        {
+            string token = "token_for_loggedin_user";
+            string password = "secret";
+            MpUser user = new MpUser()
+            {
+                UserId = "test@test.com"
+            };
+            AuthToken authData = new AuthToken()
+            {
+                AccessToken = "newtoken"
+            };
+
+            _userRepository.Setup(m => m.GetByAuthenticationToken(token)).Returns(user);
+            _authenticationRepository.Setup(m => m.AuthenticateUser(user.UserId, password, false)).Returns(authData);
+
+            var result = _loginService.IsValidPassword(token, password);
             Assert.AreEqual(true, result);
         }
     }

--- a/Gateway/crds-angular/Controllers/API/LoginController.cs
+++ b/Gateway/crds-angular/Controllers/API/LoginController.cs
@@ -224,6 +224,36 @@ namespace crds_angular.Controllers.API
             });
         }
 
+        /// <summary>
+        /// Validates the password provided matches the user identified by the token.  This function
+        /// can be used in place of VerifyCredentials() to validate the password for the current user
+        /// without requiring an email address.
+        /// </summary>
+        /// <param name="password"></param>
+        /// <returns>Ok (200) if the password is valid, or Unauthorized (401) if the password is not
+        /// valid or an error occurs</returns>
+        [VersionedRoute(template: "verify-password", minimumVersion: "1.0.0")]
+        [Route("verifypassword")]
+        [HttpPost]
+        public IHttpActionResult VerifyPassword([FromBody] string password)
+        {
+            return Authorized(token =>
+            {
+                try
+                {
+                    if (!_loginService.IsValidPassword(token, password))
+                        return this.Unauthorized();
+
+                    return this.Ok();
+                }
+                catch (Exception e)
+                {
+                    var apiError = new ApiErrorDto("Verify Password Failed", e);
+                    throw new HttpResponseException(apiError.HttpResponseMessage);
+                }
+            });
+        }
+
     }
 
     public class LoginReturn

--- a/Gateway/crds-angular/Services/Interfaces/ILoginService.cs
+++ b/Gateway/crds-angular/Services/Interfaces/ILoginService.cs
@@ -8,5 +8,6 @@ namespace crds_angular.Services.Interfaces
         bool ClearResetToken(string email);
         bool ClearResetToken(int userId); 
         bool VerifyResetToken(string token);
+        bool IsValidPassword(string token, string password);
     }
 }

--- a/crossroads.net/app/common/profile/personal/confirmPassword.controller.js
+++ b/crossroads.net/app/common/profile/personal/confirmPassword.controller.js
@@ -7,7 +7,6 @@
       '$rootScope',
       '$modalInstance',
       'modalTypeItem',
-      'email',
       'PasswordService'
   ];
 
@@ -15,7 +14,6 @@
       $rootScope,
       $modalInstance,
       modalTypeItem,
-      email,
       PasswordService) {
 
     var vm = this;
@@ -23,17 +21,17 @@
     vm.cancel = cancel;
     vm.passwd = '';
     vm.modalTypeItem = modalTypeItem;
-    vm.email = email;
     vm.saving = false;
 
     function ok() {
 
       vm.saving = true;
-      var credentials = { username: vm.email, password: vm.passwd };
+      var currentPassword = vm.passwd;
+      var encodedPassword = JSON.stringify(currentPassword);
 
-      PasswordService.VerifyCredentials.save(credentials).$promise.then(function(response) {
+      PasswordService.VerifyPassword.save(encodedPassword).$promise.then(function(response) {
         vm.passwd = '';
-        $modalInstance.close(credentials.password);
+        $modalInstance.close(currentPassword);
       }, function(error) {
 
         $rootScope.$emit('notify', $rootScope.MESSAGES.passwordNotVerified);

--- a/crossroads.net/app/common/profile/personal/profilePersonal.controller.js
+++ b/crossroads.net/app/common/profile/personal/profilePersonal.controller.js
@@ -435,10 +435,6 @@
         resolve: {
           modalTypeItem: function() {
             return modalType;
-          },
-
-          email: function() {
-            return vm.oldEmail;
           }
         }
       });

--- a/crossroads.net/core/services/password_service.js
+++ b/crossroads.net/core/services/password_service.js
@@ -11,7 +11,7 @@
       VerifyResetToken: $resource(__GATEWAY_CLIENT_ENDPOINT__ + 'api/verifyresettoken/:token/'),
       EmailExists: $resource(__GATEWAY_CLIENT_ENDPOINT__ + 'api/lookup/0/find/'),
       ResetPassword: $resource(__GATEWAY_CLIENT_ENDPOINT__ + 'api/resetpassword'),
-      VerifyCredentials: $resource(__GATEWAY_CLIENT_ENDPOINT__ + 'api/verifycredentials')
+      VerifyPassword: $resource(__GATEWAY_CLIENT_ENDPOINT__ + 'api/verifypassword')
     };
   }
 


### PR DESCRIPTION
* Add a new endpoint that verifies the combination of token + old password instead of email address + old password
* Update front-end code to use the new endpoint.