### PR TITLE
DExxxx - Hotfix for System.Net.Http version mismatch

### DIFF
--- a/Gateway/Crossroads.ScheduledDataUpdate/App.config
+++ b/Gateway/Crossroads.ScheduledDataUpdate/App.config
@@ -144,7 +144,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.1" newVersion="4.1.1.1" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Interactive.Async" publicKeyToken="94bc3704cddfc263" culture="neutral" />

--- a/Gateway/MinistryPlatform.Translation/app.config
+++ b/Gateway/MinistryPlatform.Translation/app.config
@@ -28,7 +28,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.1" newVersion="4.1.1.1" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Interactive.Async" publicKeyToken="94bc3704cddfc263" culture="neutral" />


### PR DESCRIPTION
* ScheduledDataUpdate fails to run due to a missing dependency (System.Net.Http version 4.2)