### PR TITLE
US14767 - Update crds-client-api-keys to v2.0.7

### DIFF
--- a/Gateway/crds-angular.test/crds-angular.test.csproj
+++ b/Gateway/crds-angular.test/crds-angular.test.csproj
@@ -95,7 +95,7 @@
       <HintPath>..\packages\Crossroads.ApiVersioning.1.0.4\lib\net45\Crossroads.ApiVersioning.dll</HintPath>
     </Reference>
     <Reference Include="Crossroads.ClientApiKeys, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Crossroads.ClientApiKeys.2.0.6\lib\net461\Crossroads.ClientApiKeys.dll</HintPath>
+      <HintPath>..\packages\Crossroads.ClientApiKeys.2.0.7\lib\net461\Crossroads.ClientApiKeys.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Crossroads.Web.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -491,11 +491,11 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('..\packages\Crossroads.ClientApiKeys.2.0.6\build\Crossroads.ClientApiKeys.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Crossroads.ClientApiKeys.2.0.6\build\Crossroads.ClientApiKeys.targets'))" />
+    <Error Condition="!Exists('..\packages\Crossroads.ClientApiKeys.2.0.7\build\Crossroads.ClientApiKeys.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Crossroads.ClientApiKeys.2.0.7\build\Crossroads.ClientApiKeys.targets'))" />
   </Target>
   <Import Project="$(SlowCheetahTargets)" Condition="Exists('$(SlowCheetahTargets)')" Label="SlowCheetah" />
   <Import Project="..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets" Condition="Exists('..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets')" />
-  <Import Project="..\packages\Crossroads.ClientApiKeys.2.0.6\build\Crossroads.ClientApiKeys.targets" Condition="Exists('..\packages\Crossroads.ClientApiKeys.2.0.6\build\Crossroads.ClientApiKeys.targets')" />
+  <Import Project="..\packages\Crossroads.ClientApiKeys.2.0.7\build\Crossroads.ClientApiKeys.targets" Condition="Exists('..\packages\Crossroads.ClientApiKeys.2.0.7\build\Crossroads.ClientApiKeys.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Gateway/crds-angular.test/packages.config
+++ b/Gateway/crds-angular.test/packages.config
@@ -7,7 +7,7 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
-  <package id="Crossroads.ClientApiKeys" version="2.0.6" targetFramework="net461" />
+  <package id="Crossroads.ClientApiKeys" version="2.0.7" targetFramework="net461" />
   <package id="Crossroads.Web.Common" version="2.0.6" targetFramework="net461" />
   <package id="EntityFramework" version="6.1.2" targetFramework="net45" />
   <package id="FactoryGirl.NET" version="1.0.0.0" targetFramework="net45" />

--- a/Gateway/crds-angular/crds-angular.csproj
+++ b/Gateway/crds-angular/crds-angular.csproj
@@ -87,7 +87,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Crossroads.ClientApiKeys, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Crossroads.ClientApiKeys.2.0.6\lib\net461\Crossroads.ClientApiKeys.dll</HintPath>
+      <HintPath>..\packages\Crossroads.ClientApiKeys.2.0.7\lib\net461\Crossroads.ClientApiKeys.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Crossroads.Web.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -963,15 +963,15 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('..\packages\Crossroads.ClientApiKeys.2.0.6\build\Crossroads.ClientApiKeys.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Crossroads.ClientApiKeys.2.0.6\build\Crossroads.ClientApiKeys.targets'))" />
     <Error Condition="!Exists('..\packages\Grpc.Core.1.13.1\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grpc.Core.1.13.1\build\net45\Grpc.Core.targets'))" />
     <Error Condition="!Exists('..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets'))" />
+    <Error Condition="!Exists('..\packages\Crossroads.ClientApiKeys.2.0.7\build\Crossroads.ClientApiKeys.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Crossroads.ClientApiKeys.2.0.7\build\Crossroads.ClientApiKeys.targets'))" />
   </Target>
   <Import Project="$(SlowCheetahTargets)" Condition="Exists('$(SlowCheetahTargets)')" Label="SlowCheetah" />
   <Import Project="..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets" Condition="Exists('..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets')" />
-  <Import Project="..\packages\Crossroads.ClientApiKeys.2.0.6\build\Crossroads.ClientApiKeys.targets" Condition="Exists('..\packages\Crossroads.ClientApiKeys.2.0.6\build\Crossroads.ClientApiKeys.targets')" />
   <Import Project="..\packages\Grpc.Core.1.13.1\build\net45\Grpc.Core.targets" Condition="Exists('..\packages\Grpc.Core.1.13.1\build\net45\Grpc.Core.targets')" />
   <Import Project="..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets" Condition="Exists('..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets')" />
+  <Import Project="..\packages\Crossroads.ClientApiKeys.2.0.7\build\Crossroads.ClientApiKeys.targets" Condition="Exists('..\packages\Crossroads.ClientApiKeys.2.0.7\build\Crossroads.ClientApiKeys.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Gateway/crds-angular/packages.config
+++ b/Gateway/crds-angular/packages.config
@@ -10,7 +10,7 @@
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
   <package id="Crossroads.ApiVersioning" version="1.0.4" targetFramework="net45" />
-  <package id="Crossroads.ClientApiKeys" version="2.0.6" targetFramework="net461" />
+  <package id="Crossroads.ClientApiKeys" version="2.0.7" targetFramework="net461" />
   <package id="Crossroads.Web.Common" version="2.0.6" targetFramework="net461" />
   <package id="EntityFramework" version="6.1.2" targetFramework="net45" />
   <package id="Flurl" version="2.4.0" targetFramework="net461" />


### PR DESCRIPTION
Adds logic to automatically retry loading client api keys if the first attempt fails.