### PR TITLE
DE5915 Redirect User Away From Login if Already Signed In

### DIFF
--- a/crossroads.net/core/crds_utilities.js
+++ b/crossroads.net/core/crds_utilities.js
@@ -77,6 +77,7 @@ var checkLoggedin = function ($q, $timeout, $http, $location, $rootScope, $cooki
       $location.url('/');
     }
   }).error(function (e) {
+    $timeout(deferred.reject, 0);
     console.log(e);
     console.log('ERROR: trying to authenticate');
   });
@@ -84,8 +85,8 @@ var checkLoggedin = function ($q, $timeout, $http, $location, $rootScope, $cooki
 };
 
 /**
- * This is a specialty function that just checks if the cookie exists and is 
- * not expired. This helps when we are in a flow that requires logging in and 
+ * This is a specialty function that just checks if the cookie exists and is
+ * not expired. This helps when we are in a flow that requires logging in and
  * quickly transitioning between states
  */
 var optimisticallyCheckLoggedin = function ($q, $timeout, $http, $location, $rootScope, $cookies, Session) {

--- a/crossroads.net/core/login/login_controller.js
+++ b/crossroads.net/core/login/login_controller.js
@@ -47,7 +47,7 @@
     vm.defaultImage = ImageService.DefaultProfileImage;
     vm.navigateToHome = navigateToHome;
 
-    $scope.alreadyLoggedInCheckProcessing = true;
+    $scope.isUserAlreadyLoggedInCheckRunning = true;
     redirectUserToDestinationOrHomepageIfAlreadyLoggedIn();
 
     $scope.loginShow = false;
@@ -95,7 +95,7 @@
       crds_utilities.checkLoggedin($q, $timeout, $http, $location, $rootScope, $cookies, Session, Impersonate)
         .then(
           () => { redirectToSpecifiedPageOrToHomepage(Session, $timeout); },
-          () => { $scope.alreadyLoggedInCheckProcessing = false; }
+          () => { $scope.isUserAlreadyLoggedInCheckRunning = false; }
         );
     }
 

--- a/crossroads.net/core/login/login_controller.js
+++ b/crossroads.net/core/login/login_controller.js
@@ -94,12 +94,8 @@
     function redirectUserToDestinationOrHomepageIfAlreadyLoggedIn() {
       crds_utilities.checkLoggedin($q, $timeout, $http, $location, $rootScope, $cookies, Session, Impersonate)
         .then(
-          () => {
-            redirectToSpecifiedPageOrToHomepage(Session, $timeout);
-          },
-          () => {
-            $scope.alreadyLoggedInCheckProcessing = false;
-          }
+          () => { redirectToSpecifiedPageOrToHomepage(Session, $timeout); },
+          () => { $scope.alreadyLoggedInCheckProcessing = false; }
         );
     }
 

--- a/crossroads.net/core/login/login_controller.js
+++ b/crossroads.net/core/login/login_controller.js
@@ -4,6 +4,10 @@
   module.exports = LoginController;
 
   LoginController.$inject = [
+    '$q',
+    '$http',
+    '$location',
+    '$cookies',
     '$scope',
     '$rootScope',
     'AUTH_EVENTS',
@@ -15,10 +19,15 @@
     '$timeout',
     'User',
     'ImageService',
+    'Impersonate',
     'AnalyticsService'
   ];
 
   function LoginController(
+    $q,
+    $http,
+    $location,
+    $cookies,
     $scope,
     $rootScope,
     AUTH_EVENTS,
@@ -30,7 +39,16 @@
     $timeout,
     User,
     ImageService,
+    Impersonate,
     AnalyticsService) {
+
+    // Check if the user is logged in, if they are, redirect them to home or whatever page
+    console.log('signin controller hit');
+    crds_utilities.checkLoggedin($q, $timeout, $http, $location, $rootScope, $cookies, Session, Impersonate)
+      .then(
+        () => { console.log('User is authenticated'); },
+        () => { console.log('User is NOT authenticated'); }
+      );
 
     var vm = this;
     vm.path = ImageService.ProfileImageBaseURL + vm.contactId;

--- a/crossroads.net/core/login/login_controller.js
+++ b/crossroads.net/core/login/login_controller.js
@@ -102,10 +102,8 @@
     function redirectToSpecifiedPageOrToHomepage(Session, $timeout) {
       $timeout(function () {
         if (Session.hasRedirectionInfo()) {
-          console.log('HAS redirect info');
           Session.redirectIfNeeded();
         } else {
-          console.log('Has NO redirect info');
           navigateToHome();
         }
       }, 500);

--- a/crossroads.net/core/login/login_controller.js
+++ b/crossroads.net/core/login/login_controller.js
@@ -92,11 +92,13 @@
     }
 
     function redirectUserToDestinationOrHomepageIfAlreadyLoggedIn() {
-      crds_utilities.checkLoggedin($q, $timeout, $http, $location, $rootScope, $cookies, Session, Impersonate)
-        .then(
-          () => { redirectToSpecifiedPageOrToHomepage(Session, $timeout); },
-          () => { $scope.isUserAlreadyLoggedInCheckRunning = false; }
-        );
+      let isUserLoggedInPromise =
+        crds_utilities.checkLoggedin($q, $timeout, $http, $location, $rootScope, $cookies, Session, Impersonate);
+
+      isUserLoggedInPromise.then(
+        () => { redirectToSpecifiedPageOrToHomepage(Session, $timeout); },
+        () => { $scope.isUserAlreadyLoggedInCheckRunning = false; }
+      );
     }
 
     function redirectToSpecifiedPageOrToHomepage(Session, $timeout) {

--- a/crossroads.net/core/login/login_form.html
+++ b/crossroads.net/core/login/login_form.html
@@ -1,7 +1,7 @@
 <div dynamic-content="$root.MESSAGES.loginFormTop.content | html"></div>
 
 <form id="navlogin" name="navlogin" ng-submit="login()"
-      role="form" ng-hide="processing || alreadyLoggedInCheckProcessing" novalidate>
+      role="form" ng-hide="processing || isUserAlreadyLoggedInCheckRunning" novalidate>
   <div class="form-group">
     <div ng-show="!modal" class="" ng-class="{'has-error': checkEmail() }">
       <label class="sr-only" for="{{passwordPrefix}}-email">Email address</label>

--- a/crossroads.net/core/login/login_form.html
+++ b/crossroads.net/core/login/login_form.html
@@ -1,6 +1,7 @@
 <div dynamic-content="$root.MESSAGES.loginFormTop.content | html"></div>
 
-<form id="navlogin" name="navlogin" ng-submit="login()" role="form" ng-hide="processing" novalidate>
+<form id="navlogin" name="navlogin" ng-submit="login()"
+      role="form" ng-hide="processing || alreadyLoggedInCheckProcessing" novalidate>
   <div class="form-group">
     <div ng-show="!modal" class="" ng-class="{'has-error': checkEmail() }">
       <label class="sr-only" for="{{passwordPrefix}}-email">Email address</label>


### PR DESCRIPTION
Currently, if the user is logged in, and goes to the `/signin` page, they stay on the page infinitely - there is no logic to redirect them to where they need to go. 

Solution: Check if the user is properly logged in (can't do a quick check here because any error would keep the user from able to access the login page). If they are logged in and their session is valid, redirect them to their destination or the homepage.
