### PR TITLE
Update to Test Date to Change the Dates

### DIFF
--- a/CI/TestSQL/StandardScripts/02.TestData/02.Program+Product/CreatePrograms.csv
+++ b/CI/TestSQL/StandardScripts/02.TestData/02.Program+Product/CreatePrograms.csv
@@ -1,11 +1,11 @@
 R_Program_Name,R_Contact_Email,R_Congregation_ID,R_Ministry_ID,R_Allow_Recurring_Giving,R_Start_Date,End_Date,Program_Type_ID,Communication_ID,Available_Online
-(t) Test Pledge Program1,mpcrds+chell@aperture.com,5,8,0,1/1/2018,12/31/2018,1,11402,1
-(t) Test Pledge Program2,mpcrds+chell@aperture.com,5,8,1,1/1/2018,12/31/2018,1,11402,1
-(t) Test Pledge Program+Auto1,mpcrds+chell@aperture.com,5,8,1,1/1/2018,12/31/2018,1,11402,1
-(t) Test Pledge Program+Auto2,mpcrds+chell@aperture.com,5,8,1,1/1/2018,12/31/2018,1,11402,1
-(t) GO Midgar 2018,mpcrds+chell@aperture.com,5,20,0,1/1/2018,12/31/2018,3,121611,
-(t+auto) GO Bedrock 2018,mpcrds+chell@aperture.com,5,20,0,1/1/2018,12/31/2018,3,121611,
-(t+auto) NOLA Trip,mpcrds+aliciakeys@gmail.com,5,20,0,1/1/2018,12/31/2018,3,121611,
-(t+auto) SA Trip,mpcrds+aliciakeys@gmail.com,5,20,0,1/1/2018,12/31/2018,3,121611,
-(t+auto) Camp Crystal Lake Program,mpcrds+aliciakeys@gmail.com,5,34,0,1/1/2018,12/31/2018,5,2022,
-(t+auto) Camp Anawanna Program,mpcrds+aliciakeys@gmail.com,5,34,0,1/1/2018,12/31/2018,5,2022,
+(t) Test Pledge Program1,mpcrds+chell@aperture.com,5,8,0,1/1/2019,12/31/2019,1,11402,1
+(t) Test Pledge Program2,mpcrds+chell@aperture.com,5,8,1,1/1/2019,12/31/2019,1,11402,1
+(t) Test Pledge Program+Auto1,mpcrds+chell@aperture.com,5,8,1,1/1/2019,12/31/2019,1,11402,1
+(t) Test Pledge Program+Auto2,mpcrds+chell@aperture.com,5,8,1,1/1/2019,12/31/2019,1,11402,1
+(t) GO Midgar 2018,mpcrds+chell@aperture.com,5,20,0,1/1/2019,12/31/2019,3,121611,
+(t+auto) GO Bedrock 2018,mpcrds+chell@aperture.com,5,20,0,1/1/2019,12/31/2019,3,121611,
+(t+auto) NOLA Trip,mpcrds+aliciakeys@gmail.com,5,20,0,1/1/2019,12/31/2019,3,121611,
+(t+auto) SA Trip,mpcrds+aliciakeys@gmail.com,5,20,0,1/1/2019,12/31/2019,3,121611,
+(t+auto) Camp Crystal Lake Program,mpcrds+aliciakeys@gmail.com,5,34,0,1/1/2019,12/31/2019,5,2022,
+(t+auto) Camp Anawanna Program,mpcrds+aliciakeys@gmail.com,5,34,0,1/1/2019,12/31/2019,5,2022,

--- a/CI/TestSQL/StandardScripts/02.TestData/04.Event+EventType/CreateEvents.csv
+++ b/CI/TestSQL/StandardScripts/02.TestData/04.Event+EventType/CreateEvents.csv
@@ -1,6 +1,6 @@
 R_Event_Name,R_Start_Date,R_End_Date,R_Event_Type,R_Program_Name,R_Contact_Email,R_Congregation_ID,Location_ID,Group_Name,Registration_Start_Date,Registration_End_Date,Online_Registration_Product_Name,,
-(t+auto) GO Bedrock 2018,1/1/2018,12/25/2018,GO Trips,(t+auto) GO Bedrock 2018,mpcrds+chell@aperture.com,5,,(t+auto) GO Bedrock 2018 (Trip Participants),,,,,
-(t) GO Midgar 2018,12/25/2018,12/31/2018,GO Trips,(t) GO Midgar 2018,mpcrds+chell@aperture.com,5,,(t) GO Midgar 2018 (Trip Participants),,,,,Creates an Event and adds it to a Group if specified
+(t+auto) GO Bedrock 2018,1/1/2019,12/25/2019,GO Trips,(t+auto) GO Bedrock 2018,mpcrds+chell@aperture.com,5,,(t+auto) GO Bedrock 2018 (Trip Participants),,,,,
+(t) GO Midgar 2018,12/25/2019,12/31/2019,GO Trips,(t) GO Midgar 2018,mpcrds+chell@aperture.com,5,,(t) GO Midgar 2018 (Trip Participants),,,,,Creates an Event and adds it to a Group if specified
 (t) Superbowl Oakley 10:00,12/22/2017 10:00,12/22/2017 11:00,(t) Superbowl Oakley daily 10:00,Kids Club,mpcrds+chell@aperture.com,1,3,(t) Superbowl Oakley Group,,,,,All fields are required except Location_ID and Group_Name
 (t) Superbowl Oakley 10:00,12/23/2017 10:00,12/23/2017 11:00,(t) Superbowl Oakley daily 10:00,Kids Club,mpcrds+chell@aperture.com,1,3,(t) Superbowl Oakley Group,,,,,
 (t) Superbowl Oakley 10:00,12/24/2017 10:00,12/24/2017 11:00,(t) Superbowl Oakley daily 10:00,Kids Club,mpcrds+chell@aperture.com,1,3,(t) Superbowl Oakley Group,,,,,Dependencies:
@@ -27,8 +27,8 @@ R_Event_Name,R_Start_Date,R_End_Date,R_Event_Type,R_Program_Name,R_Contact_Email
 (t) Kids Club Oakley 1:00,1/26/2018 13:00,1/26/2018 15:00,(t) KC Nursery Oakley weekly 1:00,Kids Club,mpcrds+chell@aperture.com,1,3,(t) KidsClub Oakley Group,,,,,
 (t) 1Time Mason with ChildCare,1/5/2018 13:00,1/8/2018 13:00,Onsite Groups,Kids Club,mpcrds+chell@aperture.com,6,5,(t) 1Time Mason Group with ChildCare,,,,,
 (t) 1Time Mason with ChildCare - Childcare,1/5/2018 13:00,1/8/2018 13:00,Childcare,Kids Club,mpcrds+chell@aperture.com,6,5,(t) 1Time Mason Group with ChildCare,,,,"Trigger will create this event automatically, this will update it",
-(t+auto) NOLA Trip,1/1/2019,12/31/2019,GO Trips,(t+auto) NOLA Trip,mpcrds+aliciakeys@gmail.com,5,,(t+auto) NOLA Trip,,,,,
-(t+auto) SA Trip,1/1/2019,12/31/2019,GO Trips,(t+auto) SA Trip,mpcrds+aliciakeys@gmail.com,5,,(t+auto) SA Trip,,,,,
-(t+auto) Camp Crystal Lake,1/1/2019,12/31/2019,Camp,(t+auto) Camp Crystal Lake Program,mpcrds+aliciakeys@gmail.com,5,,High School Grade 10,1/1/2018,12/31/2018,(t+auto) Camp Crystal Lake Product,,
-(t+auto) Camp Anawanna,1/1/2019,12/31/2019,Camp,(t+auto) Camp Anawanna Program,mpcrds+aliciakeys@gmail.com,5,,High School Grade 10,1/1/2018,12/31/2018,(t+auto) Camp Anawanna Product,,
-(t+auto) automation test form event,1/1/2019,12/31/2019,Outside Events,Reachout,mpcrds+aliciakeys@gmail.com,15,,,1/1/2018,12/31/2018,,,
+(t+auto) NOLA Trip,1/1/2020,12/31/2020,GO Trips,(t+auto) NOLA Trip,mpcrds+aliciakeys@gmail.com,5,,(t+auto) NOLA Trip,,,,,
+(t+auto) SA Trip,1/1/2020,12/31/2020,GO Trips,(t+auto) SA Trip,mpcrds+aliciakeys@gmail.com,5,,(t+auto) SA Trip,,,,,
+(t+auto) Camp Crystal Lake,1/1/2020,12/31/2020,Camp,(t+auto) Camp Crystal Lake Program,mpcrds+aliciakeys@gmail.com,5,,High School Grade 10,1/1/2019,12/31/2019,(t+auto) Camp Crystal Lake Product,,
+(t+auto) Camp Anawanna,1/1/2020,12/31/2020,Camp,(t+auto) Camp Anawanna Program,mpcrds+aliciakeys@gmail.com,5,,High School Grade 10,1/1/2019,12/31/2019,(t+auto) Camp Anawanna Product,,
+(t+auto) automation test form event,1/1/2020,12/31/2020,Outside Events,Reachout,mpcrds+aliciakeys@gmail.com,15,,,1/1/2019,12/31/2019,,,

--- a/CI/TestSQL/StandardScripts/02.TestData/06.PledgeCampaign+Pledge/CreatePledgeCampaigns.csv
+++ b/CI/TestSQL/StandardScripts/02.TestData/06.PledgeCampaign+Pledge/CreatePledgeCampaigns.csv
@@ -1,9 +1,9 @@
 R_Campaign_Name,R_Campaign_Goal,R_Pledge_Campaign_Type,R_Start_Date,End_Date,Program_Name,Event_Name,Description,Registration_Start_Date,Registration_End_Date,Registration_Deposit,Registration_Form_ID,Fundraising_Goal,Destination_ID,Maximum_Registrants,Youngest_Age_Allowed,Campaign_Nickname
-(t) Test Pledge Campaign1,10000000,1,1/1/2018,,(t) Test Pledge Program1,,Test Pledge Campaign1,,,,,,,,,
-(t) Test Pledge Campaign2,1000,1,1/1/2018,,(t) Test Pledge Program2,,,,,,,,,,,
-(t) Test Pledge Campaign+Auto1,10000000,1,1/1/2018,,(t) Test Pledge Program+Auto1,,Test Pledge Campaign+Auto1,,,,,,,,,
-(t) Test Pledge Campaign+Auto2,10000000,1,1/1/2018,,(t) Test Pledge Program+Auto2,,,,,,,,,,,
-(t) GO Midgar 2018,5000,2,1/1/2018,12/25/2018,(t) GO Midgar 2018,(t) GO Midgar 2018,Church Mobilization - Midgar,1/1/2018,12/25/2018,100,20,1000,2,,17,
-(t+auto) GO Bedrock 2018,5000,2,1/1/2018,12/25/2018,(t+auto) GO Bedrock 2018,(t+auto) GO Bedrock 2018,Church Mobilization - Bedrock,1/1/2018,12/25/2018,100,20,1000,,,17,
-(t+auto) NOLA Trip,150000,2,1/1/2019,12/31/2019,(t+auto) NOLA Trip,(t+auto) NOLA Trip,,1/1/2018,12/31/2018,200,20,1000,1,9999999,13,NOLA
-(t+auto) SA Trip,150000,2,1/1/2019,12/31/2019,(t+auto) SA Trip,(t+auto) SA Trip,,1/1/2018,12/31/2018,200,20,1000,2,9999999,13,South Africa
+(t) Test Pledge Campaign1,10000000,1,1/1/2019,,(t) Test Pledge Program1,,Test Pledge Campaign1,,,,,,,,,
+(t) Test Pledge Campaign2,1000,1,1/1/2019,,(t) Test Pledge Program2,,,,,,,,,,,
+(t) Test Pledge Campaign+Auto1,10000000,1,1/1/2019,,(t) Test Pledge Program+Auto1,,Test Pledge Campaign+Auto1,,,,,,,,,
+(t) Test Pledge Campaign+Auto2,10000000,1,1/1/2019,,(t) Test Pledge Program+Auto2,,,,,,,,,,,
+(t) GO Midgar 2018,5000,2,1/1/2019,12/25/2020,(t) GO Midgar 2018,(t) GO Midgar 2018,Church Mobilization - Midgar,1/1/2019,12/25/2019,100,20,1000,2,,17,
+(t+auto) GO Bedrock 2018,5000,2,1/1/2019,12/25/2020,(t+auto) GO Bedrock 2018,(t+auto) GO Bedrock 2018,Church Mobilization - Bedrock,1/1/2019,12/25/2019,100,20,1000,,,17,
+(t+auto) NOLA Trip,150000,2,1/1/2019,12/31/2020,(t+auto) NOLA Trip,(t+auto) NOLA Trip,,1/1/2019,12/31/2019,200,20,1000,1,9999999,13,NOLA
+(t+auto) SA Trip,150000,2,1/1/2019,12/31/2020,(t+auto) SA Trip,(t+auto) SA Trip,,1/1/2019,12/31/2019,200,20,1000,2,9999999,13,South Africa

--- a/CI/TestSQL/StandardScripts/02.TestData/06.PledgeCampaign+Pledge/CreatePledges.csv
+++ b/CI/TestSQL/StandardScripts/02.TestData/06.PledgeCampaign+Pledge/CreatePledges.csv
@@ -1,7 +1,7 @@
 R_Donor_Email,R_Pledge_Campaign,R_Total_Pledge,R_First_Installment_Date,R_Installments_Planned
-mpcrds+tremplay.richard@gmail.com,(t) Test Pledge Campaign1,1000,1/26/2018,10
-mpcrds+tremplay.mary@gmail.com,(t) Test Pledge Campaign2,1000,1/26/2018,10
-mpcrds+auto+1@gmail.com,(t) Test Pledge Campaign+Auto1,50000,1/26/2018,0
-mpcrds+auto+2@gmail.com,(t) Test Pledge Campaign+Auto2,50000,1/26/2018,0
-mpcrds+cloudstrife@gmail.com,(t) GO Midgar 2018,1000,1/1/2018,0
-mpcrds+auto+fredflintstone@gmail.com,(t+auto) GO Bedrock 2018,1000,1/1/2018,0
+mpcrds+tremplay.richard@gmail.com,(t) Test Pledge Campaign1,1000,1/26/2019,10
+mpcrds+tremplay.mary@gmail.com,(t) Test Pledge Campaign2,1000,1/26/2019,10
+mpcrds+auto+1@gmail.com,(t) Test Pledge Campaign+Auto1,50000,1/26/2019,0
+mpcrds+auto+2@gmail.com,(t) Test Pledge Campaign+Auto2,50000,1/26/2019,0
+mpcrds+cloudstrife@gmail.com,(t) GO Midgar 2018,1000,1/1/2019,0
+mpcrds+auto+fredflintstone@gmail.com,(t+auto) GO Bedrock 2018,1000,1/1/2019,0

--- a/CI/TestSQL/StandardScripts/02.TestData/09.EventParticipants+GroupParticipants/CreateEventParticipants.csv
+++ b/CI/TestSQL/StandardScripts/02.TestData/09.EventParticipants+GroupParticipants/CreateEventParticipants.csv
@@ -1,6 +1,6 @@
 R_Event_Name,R_Participant_Email,R_Event_Start_Date,R_Participation_Status_ID,Time_In,Time_Confirmed,Setup_Date
-(t) GO Midgar 2018,mpcrds+cloudstrife@gmail.com,12/25/2018,2,1/1/2018,1/1/2018,9/9/2017
-(t+auto) GO Bedrock 2018,mpcrds+auto+fredflintstone@gmail.com,1/1/2018,2,1/1/2018,1/1/2018,9/9/2017
+(t) GO Midgar 2018,mpcrds+cloudstrife@gmail.com,12/25/2019,2,1/1/2019,1/1/2019,9/9/2017
+(t+auto) GO Bedrock 2018,mpcrds+auto+fredflintstone@gmail.com,1/1/2019,2,1/1/2019,1/1/2019,9/9/2017
 ,,,,,,
 ,,,,,,
 ,,,,,,

--- a/CI/TestSQL/StandardScripts/02.TestData/09.EventParticipants+GroupParticipants/CreateGroupParticipants.csv
+++ b/CI/TestSQL/StandardScripts/02.TestData/09.EventParticipants+GroupParticipants/CreateGroupParticipants.csv
@@ -1,6 +1,6 @@
 R_Group_Name,R_Participant_Email,R_Group_Role_ID,R_Start_Date,Preferred_Serving_Event_Type_ID
-(t) GO Midgar 2018 (Trip Participants),mpcrds+cloudstrife@gmail.com,16,1/1/2018,
-(t+auto) GO Bedrock 2018 (Trip Participants),mpcrds+auto+fredflintstone@gmail.com,16,1/1/2018,
+(t) GO Midgar 2018 (Trip Participants),mpcrds+cloudstrife@gmail.com,16,1/1/2019,
+(t+auto) GO Bedrock 2018 (Trip Participants),mpcrds+auto+fredflintstone@gmail.com,16,1/1/2019,
 (t+auto) Band of the Red Hand,mpcrds+auto+matcauthon@gmail.com,22,11/1/2015,
 (t+auto) Band of the Red Hand,mpcrds+auto+talmanesdelovinde@gmail.com,16,11/1/2015,
 (t+auto) Band of the Red Hand,mpcrds+auto+naleseanaldiaya@gmail.com,16,11/1/2015,
@@ -51,4 +51,4 @@ Isaac N,mpcrds+newton@gmail.com,22,11/1/2015,
 (t+auto) Avalanche,mpcrds+auto+deceased@gmail.com,16,5/1/2015,
 (t+auto) Avalanche,mpcrds+auto+memberofavalanche@gmail.com,16,5/1/2015,95
 (t+auto) Serve Shinra Electric Power Company,mpcrds+auto+memberofavalanche@gmail.com,16,5/1/2015,
-(t+auto) Parents Who Need Childcare,mpcrds+auto+childcareparent@gmail.com,16,1/1/2018,
+(t+auto) Parents Who Need Childcare,mpcrds+auto+childcareparent@gmail.com,16,1/1/2019,


### PR DESCRIPTION
I had to change the dates on some of the trips, events and participants because they were dated 2018 and I needed them to be 2019 to reflect the new year. 