### PR TITLE
Hotfix/us15967 error on payment confirmation

### DIFF
--- a/crossroads.net/app/invoices/invoice.controller.js
+++ b/crossroads.net/app/invoices/invoice.controller.js
@@ -41,7 +41,7 @@ class InvoiceController {
         this.returnUrl = `https://demo.crossroads.net/invoices/${this.invoiceId}/email`;
         break;
       default:
-        this.returnUrl = `https://crossroads.net/invoices/${this.invoiceId}/email`;
+        this.returnUrl = `https://www.crossroads.net/invoices/${this.invoiceId}/email`;
         break;
     }
   }

--- a/crossroads.net/spec-es6/invoices/invoice.component.spec.js
+++ b/crossroads.net/spec-es6/invoices/invoice.component.spec.js
@@ -40,7 +40,7 @@ describe('Invoice Component', () => {
     });
 
     it('should set urls, set the view as ready', () => {
-      expect(fixture.returnUrl).toBe(`https://crossroads.net/invoices/${invoiceId}/email`);
+      expect(fixture.returnUrl).toBe(`https://www.crossroads.net/invoices/${invoiceId}/email`);
       expect(fixture.viewReady).toBeTruthy();
     });
 


### PR DESCRIPTION
Users are intermittently getting errors when trying to get the payment confirmation page. This seems to be caused by our code not using the www prefix on the link and netlify not adding it. Adding www. to the code for this specific link to help with the issue until a general fix can be found. 