### PR TITLE
Make GetDonorStatments return without an exception if user does not have a donor record

### DIFF
--- a/Gateway/MinistryPlatform.Translation/Models/MpContactDonor.cs
+++ b/Gateway/MinistryPlatform.Translation/Models/MpContactDonor.cs
@@ -22,7 +22,7 @@ namespace MinistryPlatform.Translation.Models
         public string StatementType { get; set; }
         public int StatementTypeId { get; set; }
         public string StatementMethod { get; set; }
-        public int StatementMethodId { get; set; }
+        public int? StatementMethodId { get; set; }
         public DateTime SetupDate { get; set; }
         public string ProcessorId { get; set; }
         public string Email { get; set; }

--- a/Gateway/MinistryPlatform.Translation/Repositories/DonorRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/DonorRepository.cs
@@ -1098,7 +1098,7 @@ namespace MinistryPlatform.Translation.Repositories
         {
             var records = GetContactDonor(contactId);
 
-            if (records == null)
+            if (records == null || records.DonorId == 0)
             {
                 return null;
             }


### PR DESCRIPTION
- Make Statement a nullable int so stored proc does not blow up
- Have GetDonorStatment return null if a donor id does not exists