### PR TITLE
Logic in the new base controller to allow refreshing expired tokens

### DIFF
--- a/Gateway/crds-angular/Security/ImpersonateAuthBaseController.cs
+++ b/Gateway/crds-angular/Security/ImpersonateAuthBaseController.cs
@@ -56,7 +56,24 @@ namespace crds_angular.Security
             string accessToken;
             IEnumerable<string> accessTokens;
             Request.Headers.TryGetValues("Authorization", out accessTokens);
-            accessToken = accessTokens == null? string.Empty: accessTokens.FirstOrDefault();
+            accessToken = accessTokens == null ? string.Empty : accessTokens.FirstOrDefault();
+            bool authTokenCloseToExpiry = _authTokenExpiryService.IsAuthtokenCloseToExpiry(Request.Headers);
+
+            IEnumerable<string> refreshTokens;
+            Request.Headers.TryGetValues("RefreshToken", out refreshTokens);
+            string refreshToken = refreshTokens == null ? null : refreshTokens.FirstOrDefault();
+
+            bool shouldGetNewAccessToken = authTokenCloseToExpiry && refreshToken != null;
+
+            if (shouldGetNewAccessToken) // Check if request is an mp token with an mp refresh token, if so we may need to refresh
+            {
+                var authData = AuthenticationRepository.RefreshToken(refreshToken);
+                if (authData != null)
+                {
+                    accessToken = authData.AccessToken;
+                    refreshToken = authData.RefreshToken;
+                }
+            }
 
             AuthDTO auth;
             try
@@ -79,81 +96,48 @@ namespace crds_angular.Security
                 return actionWhenNotAuthorized();
             }
 
+            IEnumerable<string> impersonateUserIds;
+            bool impersonate = false;
+            if (Request.Headers.TryGetValues("ImpersonateUserId", out impersonateUserIds) && impersonateUserIds.Any())
+            {
+                impersonate = true;
+            }
+
             //If its an mp token we need to perform the token refresh logic:
             if (auth.Authentication.Provider == "mp")
             {
-                return RefreshTokensAndHandleImpersonate(actionWhenAuthorized, actionWhenNotAuthorized, auth);
+                IHttpActionResult result = null;
+                if (impersonate)
+                {
+                    if (shouldGetNewAccessToken)
+                    {
+                        result =
+                        new HttpAuthResult(
+                            _userImpersonationService.WithImpersonation(auth, impersonateUserIds.FirstOrDefault(), () => actionWhenAuthorized(auth)),
+                            accessToken,
+                            refreshToken);
+                    }
+                    else
+                    {
+                        result = _userImpersonationService.WithImpersonation(auth, impersonateUserIds.FirstOrDefault(), () => actionWhenAuthorized(auth));
+                    }
+                }
+                else
+                {
+                    if (shouldGetNewAccessToken)
+                    {
+                        result = new HttpAuthResult(actionWhenAuthorized(auth), accessToken, refreshToken);
+                    }
+                    else
+                    {
+                        result = actionWhenAuthorized(auth);
+                    }
+                }
+                return result;
             }
             else // Okta for now but could be another provider in the future
             {
                 return actionWhenAuthorized(auth);
-            }
-
-            
-        }
-
-        private IHttpActionResult RefreshTokensAndHandleImpersonate(Func<AuthDTO, IHttpActionResult> actionWhenAuthorized, 
-            Func<IHttpActionResult> actionWhenNotAuthorized,
-            AuthDTO authDTO)
-        {
-            try
-            {
-                IEnumerable<string> refreshTokens;
-                IEnumerable<string> impersonateUserIds;
-                bool impersonate = false;
-                var accessToken = "";
-
-                if (Request.Headers.TryGetValues("ImpersonateUserId", out impersonateUserIds) && impersonateUserIds.Any())
-                {
-                    impersonate = true;
-                }
-
-                bool authTokenCloseToExpiry = _authTokenExpiryService.IsAuthtokenCloseToExpiry(Request.Headers);
-                bool isRefreshTokenPresent =
-                    Request.Headers.TryGetValues("RefreshToken", out refreshTokens) && refreshTokens.Any();
-
-                HttpRequestHeaders headers = Request.Headers;
-
-                if (authTokenCloseToExpiry && isRefreshTokenPresent)
-                {
-                    var authData = AuthenticationRepository.RefreshToken(refreshTokens.FirstOrDefault());
-                    if (authData != null)
-                    {
-                        accessToken = authData.AccessToken;
-                        var refreshToken = authData.RefreshToken;
-                        IHttpActionResult result = null;
-                        if (impersonate)
-                        {
-                            result =
-                                new HttpAuthResult(
-                                    _userImpersonationService.WithImpersonation(authDTO, impersonateUserIds.FirstOrDefault(), () => actionWhenAuthorized(authDTO)),
-                                    accessToken,
-                                    refreshToken);
-                        }
-                        else
-                        {
-                            result = new HttpAuthResult(actionWhenAuthorized(authDTO), accessToken, refreshToken);
-                        }
-                        return result;
-                    }
-                }
-                accessToken = Request.Headers.GetValues("Authorization").FirstOrDefault();
-                if (accessToken != null && (accessToken != "null" || accessToken != ""))
-                {
-                    if (impersonate)
-                    {
-                        return _userImpersonationService.WithImpersonation(authDTO, impersonateUserIds.FirstOrDefault(), () => actionWhenAuthorized(authDTO));
-                    }
-                    else
-                    {
-                        return actionWhenAuthorized(authDTO);
-                    }
-                }
-                return actionWhenNotAuthorized();
-            }
-            catch (System.InvalidOperationException e)
-            {
-                return actionWhenNotAuthorized();
             }
         }
     }

--- a/Gateway/crds-angular/Security/ImpersonateAuthBaseController.cs
+++ b/Gateway/crds-angular/Security/ImpersonateAuthBaseController.cs
@@ -63,7 +63,7 @@ namespace crds_angular.Security
             Request.Headers.TryGetValues("RefreshToken", out refreshTokens);
             string refreshToken = refreshTokens == null ? null : refreshTokens.FirstOrDefault();
 
-            bool shouldGetNewAccessToken = authTokenCloseToExpiry && refreshToken != null;
+            bool shouldGetNewAccessToken = authTokenCloseToExpiry && (refreshToken != null);
 
             if (shouldGetNewAccessToken) // Check if request is an mp token with an mp refresh token, if so we may need to refresh
             {
@@ -97,11 +97,8 @@ namespace crds_angular.Security
             }
 
             IEnumerable<string> impersonateUserIds;
-            bool impersonate = false;
-            if (Request.Headers.TryGetValues("ImpersonateUserId", out impersonateUserIds) && impersonateUserIds.Any())
-            {
-                impersonate = true;
-            }
+            Request.Headers.TryGetValues("ImpersonateUserId", out impersonateUserIds);
+            bool impersonate = (impersonateUserIds != null) && impersonateUserIds.Any();
 
             //If its an mp token we need to perform the token refresh logic:
             if (auth.Authentication.Provider == "mp")


### PR DESCRIPTION
Moving logic to refresh expired tokens from after the request to the auth service to before the request to the auth service.